### PR TITLE
feat(slack): add real-time channel watching

### DIFF
--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -137,7 +137,7 @@ Stop watching a channel or thread. Deletes the webhook and removes the watch sta
 
 ### slack watches
 
-List all active Slack watches with their targets, scoops, and delivery stats.
+List all active Slack watches with their targets and scoops.
 
 ### slack reinject
 

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: slack
 description: Interact with Slack via its Web API — read messages, post to channels,
-  search channels, read threads, and look up users. Use when the user wants to check
-  Slack messages, post a Slack message, search Slack channels, read Slack threads,
-  get Slack user info, or automate any Slack task. Triggers on mentions of Slack,
-  channels, DMs, threads, messages, or Slackbot.
+  search channels, read threads, look up users, and watch channels for new messages
+  in real time. Use when the user wants to check Slack messages, post a Slack message,
+  search Slack channels, read Slack threads, get Slack user info, watch a channel for
+  updates, or automate any Slack task. Triggers on mentions of Slack, channels, DMs,
+  threads, messages, Slackbot, or watching/monitoring.
 allowed-tools: bash
 ---
 
@@ -20,7 +21,6 @@ context (same-origin) with the user's `xoxc-*` token from `localStorage`.
 slack history C087NCG774J
 
 # Post a message to Slackbot (safe — never messages real people)
-# Use "slack slackbot" to find your DM channel ID first
 slack post <slackbot_dm_id> "Hello from SLICC!"
 
 # Search for channels
@@ -31,6 +31,18 @@ slack thread C087NCG774J 1774539502.747989
 
 # Look up a user
 slack user W5BPKRLUA
+
+# Watch a channel for new messages (real-time!)
+slack watch C087NCG774J --scoop=my-monitor
+
+# Watch a specific thread
+slack watch C087NCG774J --scoop=my-monitor --thread=1774539502.747989
+
+# List active watches
+slack watches
+
+# Stop watching
+slack unwatch C087NCG774J
 ```
 
 ## Authentication
@@ -79,12 +91,98 @@ Get channel metadata (name, purpose, topic, member count).
 
 Opens/finds the Slackbot DM channel and prints its ID.
 
+### slack watch \<channel_id\> --scoop=\<name\> [--thread=\<ts\>] [--force]
+
+Watch a channel or thread for new messages **in real time**. Each new message is
+delivered as a lick event to the specified scoop within seconds.
+
+**Options:**
+- `--scoop=<name>` — **(required)** the scoop that receives lick events
+- `--thread=<thread_ts>` — watch a specific thread instead of the whole channel
+- `--force` — replace an existing watch on the same target
+
+**How it works:**
+1. Creates a SLICC webhook routed to the target scoop
+2. Injects a WebSocket interceptor into the Slack browser tab
+3. Slack's existing `wss://wss-primary.slack.com/` connections carry all real-time
+   events (messages, typing indicators, etc.)
+4. The interceptor filters for `type: "message"` events matching the watched
+   channel (and thread if specified)
+5. Matching events are POSTed to the webhook → delivered as licks to the scoop
+
+**Lick payload:**
+```json
+{
+  "type": "slack-watch",
+  "watchId": "C087NCG774J",
+  "channel": "C087NCG774J",
+  "thread_ts": null,
+  "ts": "1776097845.451319",
+  "user": "W5BPKRLUA",
+  "text": "Hello world!",
+  "subtype": null,
+  "event": { /* full Slack WebSocket message event */ }
+}
+```
+
+**Duplicate prevention:** The watch ID is deterministic from channel + thread.
+You cannot create two watches on the same target without `--force`.
+
+**Durability:** The interceptor lives in the Slack tab's page context. If the
+page reloads, use `slack reinject` to re-attach the interceptor.
+
+### slack unwatch \<channel_id\> [--thread=\<thread_ts\>]
+
+Stop watching a channel or thread. Deletes the webhook and removes the watch state.
+
+### slack watches
+
+List all active Slack watches with their targets, scoops, and delivery stats.
+
+### slack reinject
+
+Re-inject the WebSocket interceptor into the Slack tab. Use after a page reload
+or if watches stop firing. This reads all active watch state files and re-installs
+the interceptor with the full watch list.
+
+## Watch architecture
+
+The watch system taps directly into Slack's real-time WebSocket infrastructure:
+
+```
+Slack servers → wss://wss-primary.slack.com/ → Browser WebSocket
+    ↓
+Injected interceptor (filters for watched channels)
+    ↓
+fetch() POST to SLICC webhook URL
+    ↓
+SLICC delivers lick event to target scoop
+```
+
+**Key components:**
+- **WebSocket interceptor** — patches `WebSocket.prototype.send` to discover
+  existing connections, then wraps `onmessage` on each to filter events
+- **SLICC webhook** — one per watch, routes events to the target scoop
+- **State files** — at `/workspace/skills/slack/.watch-<id>.json`, track webhook
+  IDs and watch configuration
+
+**Why WebSocket interception?** Slack maintains persistent WebSocket connections
+to `wss://wss-primary.slack.com/` (one per workspace/team). All real-time events
+flow through these connections. By intercepting at the WebSocket level, we get
+sub-second latency with zero additional API calls or polling.
+
+**Connection discovery:** The interceptor patches `WebSocket.prototype.send`.
+Since Slack sends `{"type":"ping"}` keepalives every ~10 seconds, existing
+connections are discovered within one ping cycle.
+
 ## Enterprise grid notes
 
-Adobe's Slack is an Enterprise Grid. Some standard Web API methods like
-`conversations.list` and `users.conversations` return `enterprise_is_restricted`.
-The skill uses `search.modules` (module=channels) for channel discovery and
-`conversations.open` for DM channel lookup instead.
+Adobe's Slack is an Enterprise Grid (enterprise ID `E23RE8G4F`). The gateway
+WebSocket for the enterprise org is on `gateway_server=T23RE8G4F-*`. Some
+standard Web API methods like `conversations.list` and `users.conversations`
+return `enterprise_is_restricted`. The skill uses `search.modules`
+(module=channels) for channel discovery and `conversations.open` for DM
+channel lookup instead.
 
 ## Endpoints reference
 

--- a/skills/slack/scripts/slack.jsh
+++ b/skills/slack/scripts/slack.jsh
@@ -435,8 +435,17 @@ const commands = {
     };
     await fs.writeFile(stateFile, JSON.stringify(state, null, 2));
 
-    // Inject WebSocket interceptor into Slack tab
-    await injectWsInterceptor([state]);
+    // Inject interceptor with the full watch set so all watches stay active
+    const allStates = await loadAllWatchStates();
+    try {
+      await injectWsInterceptor(allStates);
+    } catch (e) {
+      // Roll back: remove state file and delete webhook on injection failure
+      await fs.rm(stateFile).catch(() => {});
+      await exec(`slicc webhook delete ${webhook.id}`).catch(() => {});
+      console.error('Failed to inject interceptor — watch rolled back:', e.message || e);
+      process.exit(1);
+    }
 
     console.log(`Watching ${watchId} → scoop "${scoop}"`);
     console.log(`  Webhook: ${webhook.id}`);
@@ -471,6 +480,15 @@ const commands = {
 
     // Remove state file
     await fs.rm(stateFile).catch(() => {});
+
+    // Reinject with remaining watches so the in-page interceptor is updated
+    const remainingStates = await loadAllWatchStates();
+    if (remainingStates.length > 0) {
+      await injectWsInterceptor(remainingStates).catch(() => {});
+    } else {
+      // No watches left — clear the in-page watch list
+      await injectWsInterceptor([]).catch(() => {});
+    }
 
     console.log(`Stopped watching ${watchId} (was → scoop "${state.scoop}").`);
   },
@@ -521,7 +539,24 @@ const commands = {
   },
 };
 
+// --- Watch state helpers ---
+
+async function loadAllWatchStates() {
+  const globResult = await exec('ls /workspace/skills/slack/.watch-*.json 2>/dev/null');
+  if (globResult.exitCode !== 0 || !globResult.stdout.trim()) return [];
+  const files = globResult.stdout.trim().split('\n');
+  const states = [];
+  for (const file of files) {
+    try {
+      states.push(JSON.parse(await fs.readFile(file.trim(), 'utf8')));
+    } catch (_) {}
+  }
+  return states;
+}
+
 // --- WebSocket interceptor injection ---
+// Uses window.__slackWatchWatches as a mutable list so the watch set can be
+// updated without re-wrapping already-intercepted WebSocket connections.
 
 async function injectWsInterceptor(watchStates) {
   const tabId = await findSlackTab();
@@ -537,9 +572,13 @@ async function injectWsInterceptor(watchStates) {
 
   const interceptorCode = `
 (async () => {
-  const WATCHES = ${JSON.stringify(watchConfig)};
+  // Update the mutable watch list on window — existing wrapped connections
+  // read from this list on every message, so changes take effect immediately.
+  window.__slackWatchWatches = ${JSON.stringify(watchConfig)};
 
-  // Wrap an existing WebSocket connection's onmessage to filter and forward events
+  // Only install the WebSocket interceptor once
+  if (window.__slackWatchInstalled) return 'watches_updated';
+
   function wrapConnection(ws) {
     if (ws.__slackWatchWrapped) return;
     ws.__slackWatchWrapped = true;
@@ -552,7 +591,9 @@ async function injectWsInterceptor(watchStates) {
         const data = JSON.parse(event.data);
         if (data.type !== 'message') return;
 
-        for (const w of WATCHES) {
+        // Read the current watch list from window at dispatch time
+        const watches = window.__slackWatchWatches || [];
+        for (const w of watches) {
           if (data.channel !== w.channel) continue;
           if (w.thread_ts && data.thread_ts !== w.thread_ts) continue;
 
@@ -585,8 +626,10 @@ async function injectWsInterceptor(watchStates) {
     return origSend.call(this, data);
   };
 
-  // Also scan any already-opened WebSocket connections that we can find
-  // (Slack's ping keepalives will trigger send within ~10s)
+  window.__slackWatchInstalled = true;
+
+  // Slack sends ping keepalives every ~10s, so existing connections
+  // are discovered within one ping cycle.
 
   return 'interceptor_installed';
 })()
@@ -600,8 +643,7 @@ async function injectWsInterceptor(watchStates) {
   });
 
   if (result.exitCode !== 0) {
-    console.error('Failed to inject interceptor:', result.stderr);
-    process.exit(1);
+    throw new Error(result.stderr || 'eval failed');
   }
 }
 

--- a/skills/slack/scripts/slack.jsh
+++ b/skills/slack/scripts/slack.jsh
@@ -378,7 +378,232 @@ const commands = {
     console.log(`Slackbot DM channel: ${ch.id}`);
     if (data.already_open) console.log('  (already open)');
   },
+
+  async watch(args) {
+    const { flags, positional } = parseArgs(args);
+    const channel = positional[0];
+    const scoop = flags.scoop;
+    const threadTs = flags.thread || null;
+
+    if (!channel || !scoop) {
+      console.error('Usage: slack watch <channel_id> --scoop=<name> [--thread=<ts>] [--force]');
+      process.exit(1);
+    }
+
+    const watchId = threadTs ? `${channel}-${threadTs}` : channel;
+    const stateFile = `/workspace/skills/slack/.watch-${watchId}.json`;
+
+    // Check for existing watch
+    try {
+      const existing = JSON.parse(await fs.readFile(stateFile, 'utf8'));
+      if (!flags.force) {
+        console.error(`Already watching ${watchId} (scoop: ${existing.scoop}).`);
+        console.error('Use --force to replace.');
+        process.exit(1);
+      }
+      // Clean up old webhook
+      if (existing.webhookId) {
+        await exec(`slicc webhook delete ${existing.webhookId}`).catch(() => {});
+      }
+    } catch (_) {
+      // No existing watch — proceed
+    }
+
+    // Create SLICC webhook routed to target scoop
+    const whResult = await exec(`slicc webhook create --scoop=${scoop} --format=json`);
+    if (whResult.exitCode !== 0) {
+      console.error('Failed to create webhook:', whResult.stderr);
+      process.exit(1);
+    }
+    let webhook;
+    try {
+      webhook = JSON.parse(whResult.stdout.trim());
+    } catch (e) {
+      console.error('Failed to parse webhook response:', whResult.stdout.substring(0, 200));
+      process.exit(1);
+    }
+
+    // Save watch state
+    const state = {
+      watchId,
+      channel,
+      thread_ts: threadTs,
+      scoop,
+      webhookId: webhook.id,
+      webhookUrl: webhook.url,
+      createdAt: new Date().toISOString(),
+    };
+    await fs.writeFile(stateFile, JSON.stringify(state, null, 2));
+
+    // Inject WebSocket interceptor into Slack tab
+    await injectWsInterceptor([state]);
+
+    console.log(`Watching ${watchId} → scoop "${scoop}"`);
+    console.log(`  Webhook: ${webhook.id}`);
+    if (threadTs) console.log(`  Thread: ${threadTs}`);
+  },
+
+  async unwatch(args) {
+    const { flags, positional } = parseArgs(args);
+    const channel = positional[0];
+    const threadTs = flags.thread || null;
+
+    if (!channel) {
+      console.error('Usage: slack unwatch <channel_id> [--thread=<ts>]');
+      process.exit(1);
+    }
+
+    const watchId = threadTs ? `${channel}-${threadTs}` : channel;
+    const stateFile = `/workspace/skills/slack/.watch-${watchId}.json`;
+
+    let state;
+    try {
+      state = JSON.parse(await fs.readFile(stateFile, 'utf8'));
+    } catch (_) {
+      console.error(`No active watch for ${watchId}.`);
+      process.exit(1);
+    }
+
+    // Delete webhook
+    if (state.webhookId) {
+      await exec(`slicc webhook delete ${state.webhookId}`).catch(() => {});
+    }
+
+    // Remove state file
+    await fs.rm(stateFile).catch(() => {});
+
+    console.log(`Stopped watching ${watchId} (was → scoop "${state.scoop}").`);
+  },
+
+  async watches() {
+    const globResult = await exec('ls /workspace/skills/slack/.watch-*.json 2>/dev/null');
+    if (globResult.exitCode !== 0 || !globResult.stdout.trim()) {
+      console.log('No active watches.');
+      return;
+    }
+
+    const files = globResult.stdout.trim().split('\n');
+    console.log(`Active watches (${files.length}):\n`);
+    for (const file of files) {
+      try {
+        const state = JSON.parse(await fs.readFile(file.trim(), 'utf8'));
+        const thread = state.thread_ts ? ` thread=${state.thread_ts}` : '';
+        console.log(`  ${state.watchId}${thread} → scoop "${state.scoop}" (webhook: ${state.webhookId})`);
+        console.log(`    Created: ${state.createdAt}`);
+      } catch (_) {
+        console.log(`  (corrupt state file: ${file})`);
+      }
+    }
+  },
+
+  async reinject() {
+    const globResult = await exec('ls /workspace/skills/slack/.watch-*.json 2>/dev/null');
+    if (globResult.exitCode !== 0 || !globResult.stdout.trim()) {
+      console.log('No active watches to reinject.');
+      return;
+    }
+
+    const files = globResult.stdout.trim().split('\n');
+    const states = [];
+    for (const file of files) {
+      try {
+        states.push(JSON.parse(await fs.readFile(file.trim(), 'utf8')));
+      } catch (_) {}
+    }
+
+    if (states.length === 0) {
+      console.log('No valid watch states found.');
+      return;
+    }
+
+    await injectWsInterceptor(states);
+    console.log(`Re-injected interceptor with ${states.length} watch(es).`);
+  },
 };
+
+// --- WebSocket interceptor injection ---
+
+async function injectWsInterceptor(watchStates) {
+  const tabId = await findSlackTab();
+
+  // Build watch config as JSON for injection
+  const watchConfig = watchStates.map(s => ({
+    watchId: s.watchId,
+    channel: s.channel,
+    thread_ts: s.thread_ts,
+    webhookUrl: s.webhookUrl,
+    scoop: s.scoop,
+  }));
+
+  const interceptorCode = `
+(async () => {
+  const WATCHES = ${JSON.stringify(watchConfig)};
+
+  // Wrap an existing WebSocket connection's onmessage to filter and forward events
+  function wrapConnection(ws) {
+    if (ws.__slackWatchWrapped) return;
+    ws.__slackWatchWrapped = true;
+
+    const origOnMessage = ws.onmessage;
+    ws.onmessage = function(event) {
+      if (origOnMessage) origOnMessage.call(ws, event);
+
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type !== 'message') return;
+
+        for (const w of WATCHES) {
+          if (data.channel !== w.channel) continue;
+          if (w.thread_ts && data.thread_ts !== w.thread_ts) continue;
+
+          const payload = {
+            type: 'slack-watch',
+            watchId: w.watchId,
+            channel: data.channel,
+            thread_ts: w.thread_ts,
+            ts: data.ts,
+            user: data.user,
+            text: data.text,
+            subtype: data.subtype || null,
+            event: data,
+          };
+
+          fetch(w.webhookUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          }).catch(() => {});
+        }
+      } catch (_) {}
+    };
+  }
+
+  // Patch WebSocket.prototype.send to discover existing connections
+  const origSend = WebSocket.prototype.send;
+  WebSocket.prototype.send = function(data) {
+    wrapConnection(this);
+    return origSend.call(this, data);
+  };
+
+  // Also scan any already-opened WebSocket connections that we can find
+  // (Slack's ping keepalives will trigger send within ~10s)
+
+  return 'interceptor_installed';
+})()
+  `.trim().replace(/\n/g, ' ');
+
+  const tmpFile = '/shared/.slack_ws_intercept_' + Date.now() + '.js';
+  await fs.writeFile(tmpFile, interceptorCode);
+  const result = await exec(`playwright-cli eval-file ${tmpFile} --tab=${tabId}`);
+  await fs.rm(tmpFile).catch(async () => {
+    await fs.writeFile(tmpFile, '').catch(() => {});
+  });
+
+  if (result.exitCode !== 0) {
+    console.error('Failed to inject interceptor:', result.stderr);
+    process.exit(1);
+  }
+}
 
 // --- Main ---
 
@@ -395,6 +620,10 @@ if (!cmd || cmd === 'help' || cmd === '--help') {
   console.log('  user <user_id>                            Look up user info');
   console.log('  info <channel_id>                         Get channel info');
   console.log('  slackbot                                  Find Slackbot DM channel');
+  console.log('  watch <channel_id> --scoop=<name>         Watch channel for new messages');
+  console.log('  unwatch <channel_id> [--thread=<ts>]      Stop watching a channel');
+  console.log('  watches                                   List active watches');
+  console.log('  reinject                                  Re-inject WebSocket interceptor');
   console.log(`\nUse "slack slackbot" to find your Slackbot DM channel ID.`);
   process.exit(0);
 }


### PR DESCRIPTION
## Summary
- Add `watch`, `unwatch`, `watches`, and `reinject` commands for real-time Slack monitoring
- WebSocket interception taps into Slack's existing `wss://` connections for sub-second message delivery
- New messages are forwarded as lick events to SLICC scoops via webhooks
- Updated SKILL.md with watch architecture documentation

## Test plan
- [ ] Verify `slack watch` creates webhook and injects WebSocket interceptor
- [ ] Verify new messages in watched channels are delivered as lick events
- [ ] Verify `slack unwatch` cleans up webhook and state file
- [ ] Verify `slack watches` lists active watches
- [ ] Verify `slack reinject` restores interceptor after page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)