### PR TITLE
fix(llm-wiki): remove unnecessary cp from sprinkle setup

### DIFF
--- a/skills/llm-wiki/SKILL.md
+++ b/skills/llm-wiki/SKILL.md
@@ -27,7 +27,6 @@ Ask the user where their knowledge base lives (e.g. `/mnt/kb`). If they have an 
 
 ### 2. Install the sprinkle
 ```
-cp /workspace/skills/llm-wiki/llm-wiki.shtml /shared/sprinkles/llm-wiki/llm-wiki.shtml
 sprinkle open llm-wiki
 ```
 


### PR DESCRIPTION
## Summary

- Removes the unnecessary `cp` command from the sprinkle install step in SKILL.md — `sprinkle open llm-wiki` handles it

## Test plan

- [ ] Verify `sprinkle open llm-wiki` works without the preceding `cp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)