### PR TITLE
feat(slack): add activity feed command

### DIFF
--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: slack
 description: Interact with Slack via its Web API — read messages, post to channels,
-  search channels, read threads, look up users, and watch channels for new messages
-  in real time. Supports multiple workspaces with auto-detection from the active tab.
-  Use when the user wants to check Slack messages, post a Slack message,
-  search Slack channels, read Slack threads, get Slack user info, watch a channel for
-  updates, or automate any Slack task. Triggers on mentions of Slack, channels, DMs,
-  threads, messages, Slackbot, or watching/monitoring.
+  search channels, read threads, look up users, view activity/notifications, and watch
+  channels for new messages in real time. Supports multiple workspaces with auto-detection
+  from the active tab. Use when the user wants to check Slack messages, post a Slack
+  message, search Slack channels, read Slack threads, get Slack user info, view Slack
+  notifications or activity feed, watch a channel for updates, or automate any Slack task.
+  Triggers on mentions of Slack, channels, DMs, threads, messages, Slackbot,
+  notifications, activity, or watching/monitoring.
 allowed-tools: bash
 ---
 
@@ -22,6 +23,18 @@ or can be specified explicitly with `--workspace`.
 ```bash
 # List available workspaces
 slack workspaces
+
+# View activity feed (notifications)
+slack activity
+
+# Admin notifications only (channel archiving, etc.)
+slack --ws=E06V3987PMY activity --type=admin
+
+# Unread mentions
+slack activity --type=mentions --unread
+
+# App DMs (invite requests, Google Drive, etc.)
+slack activity --type=apps
 
 # Read recent messages from a channel (uses active workspace)
 slack history C087NCG774J
@@ -92,6 +105,35 @@ slack history C087NCG774J --workspace=E23RE8G4F
 
 List all workspaces the user is signed into. Shows the workspace ID, name, and
 domain. The currently active workspace (from the tab URL) is marked with `*`.
+
+### slack activity [--type=TYPE] [--unread] [--limit=N] [--cursor=CURSOR]
+
+View the activity feed (notifications). Resolves user and channel names inline.
+For app DM bundles (invite requests, Google Drive, etc.), fetches the latest
+messages from the DM channel to show actual content.
+
+**Type filters:**
+- `all` (default) — everything
+- `admin` — system alerts (channel archived, workspace changes)
+- `mentions` — @user, @usergroup, @channel, @everyone, unjoined channel mentions
+- `threads` — thread replies
+- `reactions` — emoji reactions on your messages
+- `invites` — channel invitations (internal and Slack Connect)
+- `apps` — bot/app DM bundles (invite requests, Google Drive, etc.)
+
+**Flags:**
+- `--unread` — show only unread items
+- `--limit=N` — number of items (default 20)
+- `--cursor=CURSOR` — pagination cursor for next page
+
+**Output format:**
+```
+[2026-04-15 16:19:41 UTC] ADMIN: Amol Anand archived the channel #aem-volvo-redesign *
+[2026-04-15 15:54:02 UTC] App DM (5 unread): slackbot: Request to join a Slack Connect channel... *
+[2026-04-13 16:24:47 UTC] @mention by Stefan Guggisberg in #mpdm-roman-...
+```
+
+Items marked with `*` are unread.
 
 ### slack history \<channel_id\> [--limit=N]
 

--- a/skills/slack/references/endpoints.md
+++ b/skills/slack/references/endpoints.md
@@ -236,6 +236,76 @@ Use these alternatives:
 - DM channel lookup: `conversations.open` with target user IDs
 - Channel info: `conversations.info` with a known channel ID
 
+### POST /api/activity.feed
+
+Get the activity feed (notifications). This is an undocumented internal API used
+by Slack's Activity tab.
+
+**Parameters:**
+| Param | Required | Description |
+|-------|----------|-------------|
+| token | yes | xoxc token |
+| types | yes | Comma-separated activity types (see below) |
+| mode | yes | `chrono_reads_and_unreads` or `priority_reads_and_unreads_v1` |
+| limit | no | Number of items (default 20) |
+| unread_only | no | `true` or `false` (default `false`) |
+| archive_only | no | `true` or `false` (default `false`) |
+| priority_only | no | `true` or `false` (default `false`) |
+| cursor | no | Pagination cursor from `response_metadata.next_cursor` |
+
+**Activity types:**
+- `generic_system_alert` — admin events (channel archived, workspace changes)
+- `bot_dm_bundle` — grouped bot/app DMs (invite requests, Google Drive, etc.)
+- `at_user` — direct @mention
+- `at_user_group` — @usergroup mention
+- `at_channel` — @channel mention
+- `at_everyone` — @everyone mention
+- `unjoined_channel_mention` — @mention in a channel you haven't joined
+- `thread_v2` — thread reply
+- `message_reaction` — emoji reaction on your message
+- `internal_channel_invite` — invited to a channel
+- `external_channel_invite` — Slack Connect invite
+- `list_record_edited`, `list_record_assigned`, `list_user_mentioned` — list items
+- `list_todo_notification`, `list_approval_request`, `list_approval_reviewed` — list workflows
+
+**Response:**
+```json
+{
+  "ok": true,
+  "items": [
+    {
+      "is_unread": true,
+      "feed_ts": "1776269981.932928",
+      "key": "generic_system_alert.1776269981932928",
+      "item": {
+        "type": "generic_system_alert",
+        "generic_system_alert_payload": {
+          "category": "CHANNEL",
+          "blocks": [{ "type": "rich_text", "elements": [...] }],
+          "click_target_id": "C05JRAM3A1H"
+        }
+      }
+    }
+  ],
+  "response_metadata": {
+    "next_cursor": "YWN0aXZpdHk6..."
+  }
+}
+```
+
+**Item type shapes:**
+- `generic_system_alert` → `.item.generic_system_alert_payload.{category, blocks[], reason, click_target_id}`
+- `bot_dm_bundle` → `.item.bundle_info.{unread_count, payload.message.{ts, channel}}`
+- `at_user` → `.item.message.{ts, channel, author_user_id, is_broadcast}`
+- `internal_channel_invite` → `.item.invite_info.{channel_id, inviter_user_id}`
+
+**Notes:**
+- This endpoint works cross-workspace: use the target workspace's token even if the
+  active Slack tab is on a different workspace.
+- The `mode` parameter determines sort order. `chrono_reads_and_unreads` returns items
+  in reverse chronological order. `priority_reads_and_unreads_v1` uses Slack's priority
+  ranking (used by the "All" tab).
+
 ## Error Handling
 
 All responses include `"ok": true|false`. On error:

--- a/skills/slack/scripts/slack.jsh
+++ b/skills/slack/scripts/slack.jsh
@@ -673,6 +673,186 @@ const commands = {
     await injectWsInterceptor(states);
     console.log(`Re-injected interceptor with ${states.length} watch(es).`);
   },
+
+  async activity(args, globalFlags) {
+    const { flags } = parseArgs(args);
+    const wsId = await resolveWorkspace(globalFlags);
+    const limit = flags.limit || '20';
+    const unreadOnly = flags.unread === true || flags.unread === 'true';
+    const cursor = flags.cursor || null;
+
+    // Map --type filter to activity.feed types
+    const typeMap = {
+      all: 'generic_system_alert,bot_dm_bundle,at_user,at_user_group,at_channel,at_everyone,unjoined_channel_mention,thread_v2,message_reaction,internal_channel_invite,external_channel_invite',
+      admin: 'generic_system_alert',
+      mentions: 'at_user,at_user_group,at_channel,at_everyone,unjoined_channel_mention',
+      threads: 'thread_v2',
+      reactions: 'message_reaction',
+      invites: 'internal_channel_invite,external_channel_invite',
+      apps: 'bot_dm_bundle',
+    };
+    const typeFilter = flags.type || 'all';
+    const types = typeMap[typeFilter];
+    if (!types) {
+      console.error(`Unknown --type "${typeFilter}". Valid types: ${Object.keys(typeMap).join(', ')}`);
+      process.exit(1);
+    }
+
+    const params = {
+      limit,
+      types,
+      mode: 'chrono_reads_and_unreads',
+      archive_only: 'false',
+      unread_only: String(unreadOnly),
+      priority_only: 'false',
+    };
+    if (cursor) params.cursor = cursor;
+
+    const data = await slackApi('activity.feed', params, wsId);
+    if (!data.ok) {
+      console.error('Error:', data.error);
+      process.exit(1);
+    }
+
+    if (!data.items || data.items.length === 0) {
+      console.log('No activity items found.');
+      return;
+    }
+
+    // Collect user and channel IDs to resolve in batch
+    const userIds = new Set();
+    const channelIds = new Set();
+    for (const item of data.items) {
+      const i = item.item;
+      if (i.type === 'generic_system_alert') {
+        for (const b of (i.generic_system_alert_payload?.blocks || [])) {
+          for (const el of (b.elements || [])) {
+            for (const sub of (el.elements || [])) {
+              if (sub.type === 'user') userIds.add(sub.user_id);
+              if (sub.type === 'channel') channelIds.add(sub.channel_id);
+            }
+          }
+        }
+      }
+      if (i.message?.author_user_id) userIds.add(i.message.author_user_id);
+      if (i.message?.channel) channelIds.add(i.message.channel);
+      if (i.invite_info?.channel_id) channelIds.add(i.invite_info.channel_id);
+      if (i.invite_info?.inviter_user_id) userIds.add(i.invite_info.inviter_user_id);
+    }
+
+    // Resolve names (best-effort, don't fail on individual lookups)
+    const userNames = {};
+    for (const uid of userIds) {
+      try {
+        const u = await slackApi('users.info', { user: uid }, wsId);
+        if (u.ok) userNames[uid] = u.user.real_name || u.user.name || uid;
+      } catch (_) {}
+    }
+    const channelNames = {};
+    for (const cid of channelIds) {
+      try {
+        const c = await slackApi('conversations.info', { channel: cid }, wsId);
+        if (c.ok) channelNames[cid] = '#' + (c.channel.name || cid);
+      } catch (_) {}
+    }
+
+    function resolveName(uid) { return userNames[uid] || uid; }
+    function resolveChannel(cid) { return channelNames[cid] || cid; }
+
+    // For bot_dm_bundle items, fetch the latest message from the DM channel
+    const botDmMessages = {};
+    for (const item of data.items) {
+      const i = item.item;
+      if (i.type === 'bot_dm_bundle') {
+        const ch = i.bundle_info?.payload?.message?.channel;
+        if (ch && !botDmMessages[ch]) {
+          try {
+            const hist = await slackApi('conversations.history', { channel: ch, limit: '5' }, wsId);
+            if (hist.ok && hist.messages?.length > 0) {
+              // Get latest messages, most recent first
+              botDmMessages[ch] = hist.messages.slice(0, 3).map(m => {
+                const name = m.bot_profile?.name || m.username || m.user || 'bot';
+                let text = m.text || '';
+                // Compact multi-line text
+                text = text.replace(/\n+/g, ' ').substring(0, 200);
+                return `${name}: ${text}`;
+              });
+            }
+          } catch (_) {}
+        }
+      }
+    }
+
+    // Format and print
+    for (const item of data.items) {
+      const i = item.item;
+      const ts = formatTimestamp(item.feed_ts);
+      const unread = item.is_unread ? ' *' : '';
+
+      if (i.type === 'generic_system_alert') {
+        const payload = i.generic_system_alert_payload || {};
+        const texts = [];
+        for (const b of (payload.blocks || [])) {
+          for (const el of (b.elements || [])) {
+            for (const sub of (el.elements || [])) {
+              if (sub.type === 'text') texts.push(sub.text);
+              if (sub.type === 'user') texts.push(resolveName(sub.user_id));
+              if (sub.type === 'channel') texts.push(resolveChannel(sub.channel_id));
+              if (sub.type === 'link') texts.push(sub.text || sub.url);
+            }
+          }
+        }
+        console.log(`[${ts}] ADMIN: ${texts.join('')}${unread}`);
+
+      } else if (i.type === 'at_user' || i.type === 'at_user_group') {
+        const author = resolveName(i.message?.author_user_id);
+        const ch = resolveChannel(i.message?.channel);
+        console.log(`[${ts}] @mention by ${author} in ${ch}${unread}`);
+
+      } else if (i.type === 'at_channel' || i.type === 'at_everyone') {
+        const author = resolveName(i.message?.author_user_id);
+        const ch = resolveChannel(i.message?.channel);
+        console.log(`[${ts}] @${i.type === 'at_channel' ? 'channel' : 'everyone'} by ${author} in ${ch}${unread}`);
+
+      } else if (i.type === 'unjoined_channel_mention') {
+        console.log(`[${ts}] Mentioned in unjoined channel${unread}`);
+
+      } else if (i.type === 'internal_channel_invite') {
+        const inviter = resolveName(i.invite_info?.inviter_user_id);
+        const ch = resolveChannel(i.invite_info?.channel_id);
+        console.log(`[${ts}] Invited to ${ch} by ${inviter}${unread}`);
+
+      } else if (i.type === 'external_channel_invite') {
+        console.log(`[${ts}] Slack Connect invite${unread}`);
+
+      } else if (i.type === 'bot_dm_bundle') {
+        const ch = i.bundle_info?.payload?.message?.channel;
+        const count = i.bundle_info?.unread_count || '?';
+        const msgs = botDmMessages[ch];
+        if (msgs && msgs.length > 0) {
+          console.log(`[${ts}] App DM (${count} unread): ${msgs[0].substring(0, 200)}${unread}`);
+          for (const m of msgs.slice(1)) {
+            console.log(`         ${m.substring(0, 200)}`);
+          }
+        } else {
+          console.log(`[${ts}] App DM (${count} unread)${unread}`);
+        }
+
+      } else if (i.type === 'thread_v2') {
+        console.log(`[${ts}] Thread reply${unread}`);
+
+      } else if (i.type === 'message_reaction') {
+        console.log(`[${ts}] Reaction${unread}`);
+
+      } else {
+        console.log(`[${ts}] ${i.type}${unread}`);
+      }
+    }
+
+    if (data.response_metadata?.next_cursor) {
+      console.log(`\n--- More items available. Use --cursor=${data.response_metadata.next_cursor} ---`);
+    }
+  },
 };
 
 // --- Watch state helpers ---
@@ -818,6 +998,9 @@ if (!cmd || cmd === 'help' || cmd === '--help') {
   console.log('                                           Auto-detects from active Slack tab if omitted\n');
   console.log('Commands:');
   console.log('  workspaces                               List all available workspaces');
+  console.log('  activity [--type=TYPE] [--unread] [--limit=N]');
+  console.log('                                           View activity feed (notifications)');
+  console.log('           Types: all, admin, mentions, threads, reactions, invites, apps');
   console.log('  history <channel_id> [--limit=N]          Read channel messages');
   console.log('  post <channel_id> <message> [--force]     Post a message (Slackbot DM only by default)');
   console.log('  channels --search=<term>                  Search for channels');

--- a/skills/slack/scripts/slack.jsh
+++ b/skills/slack/scripts/slack.jsh
@@ -95,7 +95,7 @@ async function resolveWorkspace(globalFlags) {
 // Executes Slack Web API calls via XHR from the Slack page context.
 // This ensures same-origin cookies are included and the xoxc token works.
 
-async function slackApi(method, params, workspaceId) {
+async function slackApi(method, params, workspaceId, { fatal = true } = {}) {
   const tabId = await findSlackTab();
 
   // Build the param entries as a JSON array to pass into eval
@@ -144,6 +144,7 @@ async function slackApi(method, params, workspaceId) {
   });
 
   if (result.exitCode !== 0) {
+    if (!fatal) return { ok: false, error: 'eval_failed' };
     console.error('Eval failed:', result.stderr);
     process.exit(1);
   }
@@ -160,17 +161,20 @@ async function slackApi(method, params, workspaceId) {
       throw new Error('API response was not an object');
     }
   } catch (e) {
+    if (!fatal) return { ok: false, error: 'parse_failed' };
     console.error('Failed to parse API response:', result.stdout.substring(0, 200));
     process.exit(1);
   }
 
   if (!data.ok) {
     if (data.error === 'invalid_auth' || data.error === 'token_not_found') {
+      if (!fatal) return data;
       console.error('Auth failed. Log into Slack at app.slack.com in your browser and try again.');
       if (data.detail) console.error('Detail:', data.detail);
       process.exit(1);
     }
     if (data.error === 'ratelimited') {
+      if (!fatal) return data;
       console.error('Rate limited by Slack. Wait a moment and try again.');
       process.exit(1);
     }
@@ -683,7 +687,7 @@ const commands = {
 
     // Map --type filter to activity.feed types
     const typeMap = {
-      all: 'generic_system_alert,bot_dm_bundle,at_user,at_user_group,at_channel,at_everyone,unjoined_channel_mention,thread_v2,message_reaction,internal_channel_invite,external_channel_invite',
+      all: 'generic_system_alert,bot_dm_bundle,at_user,at_user_group,at_channel,at_everyone,unjoined_channel_mention,thread_v2,message_reaction,internal_channel_invite,external_channel_invite,list_record_edited,list_record_assigned,list_user_mentioned,list_todo_notification,list_approval_request,list_approval_reviewed',
       admin: 'generic_system_alert',
       mentions: 'at_user,at_user_group,at_channel,at_everyone,unjoined_channel_mention',
       threads: 'thread_v2',
@@ -740,20 +744,16 @@ const commands = {
       if (i.invite_info?.inviter_user_id) userIds.add(i.invite_info.inviter_user_id);
     }
 
-    // Resolve names (best-effort, don't fail on individual lookups)
+    // Resolve names (best-effort, non-fatal — rate limits or errors won't kill the command)
     const userNames = {};
     for (const uid of userIds) {
-      try {
-        const u = await slackApi('users.info', { user: uid }, wsId);
-        if (u.ok) userNames[uid] = u.user.real_name || u.user.name || uid;
-      } catch (_) {}
+      const u = await slackApi('users.info', { user: uid }, wsId, { fatal: false });
+      if (u.ok) userNames[uid] = u.user.real_name || u.user.name || uid;
     }
     const channelNames = {};
     for (const cid of channelIds) {
-      try {
-        const c = await slackApi('conversations.info', { channel: cid }, wsId);
-        if (c.ok) channelNames[cid] = '#' + (c.channel.name || cid);
-      } catch (_) {}
+      const c = await slackApi('conversations.info', { channel: cid }, wsId, { fatal: false });
+      if (c.ok) channelNames[cid] = '#' + (c.channel.name || cid);
     }
 
     function resolveName(uid) { return userNames[uid] || uid; }
@@ -766,8 +766,8 @@ const commands = {
       if (i.type === 'bot_dm_bundle') {
         const ch = i.bundle_info?.payload?.message?.channel;
         if (ch && !botDmMessages[ch]) {
-          try {
-            const hist = await slackApi('conversations.history', { channel: ch, limit: '5' }, wsId);
+          {
+            const hist = await slackApi('conversations.history', { channel: ch, limit: '5' }, wsId, { fatal: false });
             if (hist.ok && hist.messages?.length > 0) {
               // Get latest messages, most recent first
               botDmMessages[ch] = hist.messages.slice(0, 3).map(m => {
@@ -778,7 +778,7 @@ const commands = {
                 return `${name}: ${text}`;
               });
             }
-          } catch (_) {}
+          }
         }
       }
     }
@@ -827,7 +827,7 @@ const commands = {
 
       } else if (i.type === 'bot_dm_bundle') {
         const ch = i.bundle_info?.payload?.message?.channel;
-        const count = i.bundle_info?.unread_count || '?';
+        const count = i.bundle_info?.unread_count ?? '?';
         const msgs = botDmMessages[ch];
         if (msgs && msgs.length > 0) {
           console.log(`[${ts}] App DM (${count} unread): ${msgs[0].substring(0, 200)}${unread}`);
@@ -998,7 +998,7 @@ if (!cmd || cmd === 'help' || cmd === '--help') {
   console.log('                                           Auto-detects from active Slack tab if omitted\n');
   console.log('Commands:');
   console.log('  workspaces                               List all available workspaces');
-  console.log('  activity [--type=TYPE] [--unread] [--limit=N]');
+  console.log('  activity [--type=TYPE] [--unread] [--limit=N] [--cursor=CURSOR]');
   console.log('                                           View activity feed (notifications)');
   console.log('           Types: all, admin, mentions, threads, reactions, invites, apps');
   console.log('  history <channel_id> [--limit=N]          Read channel messages');


### PR DESCRIPTION
## Summary
- Add `slack activity` command to view Slack notifications via the internal `activity.feed` API
- Support type filters (`admin`, `mentions`, `threads`, `reactions`, `invites`, `apps`) and `--unread` mode
- Resolve user and channel IDs to readable names; expand bot DM bundles to show actual message content
- Document the undocumented `activity.feed` endpoint in the endpoints reference

## Test plan
- [ ] Run `slack activity` — verify notifications render with timestamps and resolved names
- [ ] Run `slack activity --type=admin` — verify only system alerts appear
- [ ] Run `slack activity --type=mentions --unread` — verify only unread @mentions
- [ ] Run `slack activity --type=apps` — verify bot DM bundles expand with message content
- [ ] Run `slack activity --limit=5` — verify pagination cursor appears when more items exist
- [ ] Run with `--cursor=<value>` to fetch the next page
- [ ] Run with `--ws=<ID>` to verify cross-workspace activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)