### PR TITLE
fix(slack): improve pending command parsing

### DIFF
--- a/skills/slack/scripts/slack.jsh
+++ b/skills/slack/scripts/slack.jsh
@@ -928,7 +928,7 @@ const commands = {
         if (joinOrgMatch) org = joinOrgMatch[1];
 
         for (const att of (msg.attachments || [])) {
-          const at = att.text || '';
+          const at = (att.text || '') + ' ' + (att.fallback || '');
           const emailMatch = at.match(/\*Email\*:\s*<mailto:([^|]+)\|/);
           if (emailMatch) email = emailMatch[1];
           const chMatch = at.match(/\*Channel:\*\s*<#\w+\|([^>]+)>/);
@@ -938,6 +938,9 @@ const commands = {
           const reasonMatch = at.match(/\*Reason for Request\*:\n(.+)/);
           if (reasonMatch) reason = reasonMatch[1].trim();
         }
+
+        // Clean up Slack markup from channel names
+        channelName = channelName.replace(/<#\w+\|([^>]+)>/g, '#$1');
 
         pending.push({
           ts: msg.ts,


### PR DESCRIPTION
## Summary
- Include attachment `fallback` text alongside `text` when extracting email, channel, and reason fields from invite messages
- Strip Slack markup (`<#C123|channel-name>`) from channel names in table output

## Test plan
- [ ] Run `slack pending` — verify channel names render as plain text without Slack markup
- [ ] Verify invite messages with details in fallback (not text) are correctly parsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)