### PR TITLE
feat(slack): allow posting to any channel or user

### DIFF
--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -176,7 +176,7 @@ Fetch recent messages from a channel. Default limit is 20.
 
 ### slack post \<channel_or_user_id\> \<message\>
 
-Post a message to a channel, DM, or user. Accepts channel IDs (`C...`, `D...`) directly,
+Post a message to a channel, DM, or user. Accepts channel IDs (`C...`, `D...`, `G...`) directly,
 or user IDs (`U...`, `W...`) — in which case a DM is opened automatically.
 
 ```bash

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -52,8 +52,11 @@ slack --workspace=T06DUTYDQ channels --search=helix
 # Shorthand
 slack --ws=T06DUTYDQ history C06ABC123
 
-# Post a message to Slackbot (safe — never messages real people)
-slack post <slackbot_dm_id> "Hello from SLICC!"
+# Post a message to a channel
+slack post C087NCG774J "Hello from SLICC!"
+
+# DM a user directly (opens DM automatically)
+slack post W5BPKRLUA "Hey, quick question..."
 
 # Search for channels
 slack channels --search=one-aem
@@ -171,12 +174,21 @@ Deny an interactive message action. Same as `approve` but clicks the Deny button
 
 Fetch recent messages from a channel. Default limit is 20.
 
-### slack post \<channel_id\> \<message\>
+### slack post \<channel_or_user_id\> \<message\>
 
-Post a message to a channel. Use `slack slackbot` to find the Slackbot DM channel ID.
-For safety, posting is restricted to the Slackbot DM only — attempts to post to other
-channels are blocked unless `--force` is passed. The Slackbot DM ID is resolved
-dynamically via the `conversations.open` API.
+Post a message to a channel, DM, or user. Accepts channel IDs (`C...`, `D...`) directly,
+or user IDs (`U...`, `W...`) — in which case a DM is opened automatically.
+
+```bash
+# Post to a channel
+slack post C087NCG774J "Hello channel!"
+
+# DM a user by user ID (opens DM automatically)
+slack post W5BPKRLUA "Hey, quick question..."
+
+# Reply in a thread
+slack post C087NCG774J "Got it" --thread_ts=1774539502.747989
+```
 
 ### slack channels [--search=term]
 

--- a/skills/slack/scripts/slack.jsh
+++ b/skills/slack/scripts/slack.jsh
@@ -338,25 +338,25 @@ const commands = {
     const message = positional.slice(1).join(' ');
 
     if (!channel || !message) {
-      console.error('Usage: slack post <channel_id> <message>');
-      console.error('Use "slack slackbot" to find your Slackbot DM channel ID.');
+      console.error('Usage: slack post <channel_or_user_id> <message> [--thread_ts=TS]');
+      console.error('Accepts a channel ID (C...), DM ID (D...), or user ID (U.../W... — opens a DM automatically).');
       process.exit(1);
     }
 
     const wsId = await resolveWorkspace(globalFlags);
 
-    // Safety: only allow posting to Slackbot DM unless --force
-    if (!flags.force) {
-      const sbData = await slackApi('conversations.open', { users: 'USLACKBOT', return_im: 'true' }, wsId);
-      const slackbotDm = sbData.ok ? sbData.channel.id : null;
-      if (channel !== slackbotDm) {
-        console.error(`Safety: posting is restricted to Slackbot DM (${slackbotDm || 'unknown'}).`);
-        console.error('Use --force to override (use with caution — this messages real people).');
+    // Resolve channel: if it looks like a user ID (U/W prefix), open a DM first
+    let targetChannel = channel;
+    if (/^[UW][A-Z0-9]+$/.test(channel)) {
+      const dmData = await slackApi('conversations.open', { users: channel, return_im: 'true' }, wsId);
+      if (!dmData.ok) {
+        console.error(`Error opening DM with ${channel}:`, dmData.error);
         process.exit(1);
       }
+      targetChannel = dmData.channel.id;
     }
 
-    const params = { channel, text: message };
+    const params = { channel: targetChannel, text: message };
     if (flags.thread_ts) params.thread_ts = flags.thread_ts;
 
     const data = await slackApi('chat.postMessage', params, wsId);
@@ -365,7 +365,10 @@ const commands = {
       process.exit(1);
     }
 
-    console.log(`Message sent to ${channel} at ${formatTimestamp(data.ts)}`);
+    console.log(`Message sent to ${targetChannel} at ${formatTimestamp(data.ts)}`);
+    if (targetChannel !== channel) {
+      console.log(`  (DM opened with user ${channel})`);
+    }
     if (data.message) {
       console.log(`Text: ${data.message.text}`);
     }
@@ -1279,7 +1282,7 @@ if (!cmd || cmd === 'help' || cmd === '--help') {
   console.log('  approve <message_ts> [--channel=<id>]    Approve an interactive action (e.g. invite request)');
   console.log('  deny <message_ts> [--channel=<id>]       Deny an interactive action (e.g. invite request)');
   console.log('  history <channel_id> [--limit=N]          Read channel messages');
-  console.log('  post <channel_id> <message> [--force]     Post a message (Slackbot DM only by default)');
+  console.log('  post <channel_or_user_id> <message>        Post a message to any channel, DM, or user');
   console.log('  channels --search=<term>                  Search for channels');
   console.log('  thread <channel_id> <thread_ts> [--limit] Read thread replies');
   console.log('  user <user_id>                            Look up user info');

--- a/skills/slack/scripts/slack.jsh
+++ b/skills/slack/scripts/slack.jsh
@@ -339,7 +339,7 @@ const commands = {
 
     if (!channel || !message) {
       console.error('Usage: slack post <channel_or_user_id> <message> [--thread_ts=TS]');
-      console.error('Accepts a channel ID (C...), DM ID (D...), or user ID (U.../W... — opens a DM automatically).');
+      console.error('Accepts a conversation ID (C.../G.../D...), or user ID (U.../W... — opens a DM automatically).');
       process.exit(1);
     }
 
@@ -1282,7 +1282,7 @@ if (!cmd || cmd === 'help' || cmd === '--help') {
   console.log('  approve <message_ts> [--channel=<id>]    Approve an interactive action (e.g. invite request)');
   console.log('  deny <message_ts> [--channel=<id>]       Deny an interactive action (e.g. invite request)');
   console.log('  history <channel_id> [--limit=N]          Read channel messages');
-  console.log('  post <channel_or_user_id> <message>        Post a message to any channel, DM, or user');
+  console.log('  post <id> <message> [--thread_ts=TS]      Post a message to any channel, DM, or user');
   console.log('  channels --search=<term>                  Search for channels');
   console.log('  thread <channel_id> <thread_ts> [--limit] Read thread replies');
   console.log('  user <user_id>                            Look up user info');


### PR DESCRIPTION
## Summary
- Remove the Slackbot-only safety restriction from `slack post` — messages can now be sent to any channel or DM
- Auto-open DMs when a user ID (`U...`/`W...`) is passed instead of a channel ID
- Update SKILL.md docs and CLI help text to reflect new behavior

## Test plan
- [ ] `slack post C... "msg"` — post to a channel directly
- [ ] `slack post W... "msg"` — auto-opens DM and posts
- [ ] `slack post U... "msg"` — same auto-DM behavior
- [ ] `slack post C... "reply" --thread_ts=...` — thread reply still works
- [ ] Verify help text shows updated usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)