### PR TITLE
fix(slack): strip shell redirect tokens from post command args

### DIFF
--- a/skills/slack/scripts/slack.jsh
+++ b/skills/slack/scripts/slack.jsh
@@ -335,7 +335,10 @@ const commands = {
   async post(args, globalFlags) {
     const { flags, positional } = parseArgs(args);
     const channel = positional[0];
-    const message = positional.slice(1).join(' ');
+    // Filter out shell redirect tokens (e.g. 2>&1, >&2, 2>/dev/null) that leak
+    // through when scoops call `exec('slack post ... 2>&1')` without proper quoting
+    const shellRedirectRe = /^[012]?>{1,2}&?[012]?$|^[012]?>(?:\/\S+)$/;
+    const message = positional.slice(1).filter(t => !shellRedirectRe.test(t)).join(' ');
 
     if (!channel || !message) {
       console.error('Usage: slack post <channel_or_user_id> <message> [--thread_ts=TS]');


### PR DESCRIPTION
## Summary

When a scoop called `exec('slack post C123 "Hello" 2>&1')`, the `.jsh` runtime passed `2>&1` as a literal positional argument. The `parseArgs()` function had no awareness of shell metacharacters, so `2>&1` was joined into the message text and posted verbatim to Slack.

**Fix:** Added a regex filter in the `post` command that strips shell redirect tokens (`2>&1`, `>&2`, `2>/dev/null`, etc.) from positional args before joining them into the message string.

## Changes

- `skills/slack/scripts/slack.jsh` — `post` command: filter out positional tokens matching shell redirect pattern before building the message string

## Testing

- Verified `2>&1` no longer appears in posted messages when called via `exec('slack post CHANNEL "MSG" 2>&1')`
- Verified normal messages without redirect tokens are unaffected