### PR TITLE
feat(pdf): add PDF skill

### DIFF
--- a/skills/pdf/SKILL.md
+++ b/skills/pdf/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: pdf
+description: Read, create, merge, split, rotate, and extract text from PDF files. Uses SLICC's built-in pdftk and convert commands. No Python required.
+triggers:
+  - "extract text from pdf"
+  - "extract text from this pdf"
+  - "read this pdf"
+  - "merge pdfs"
+  - "merge these pdfs"
+  - "combine pdfs"
+  - "split pdf"
+  - "split this pdf"
+  - "extract pages from pdf"
+  - "rotate pdf"
+  - "rotate pages"
+  - "create a pdf"
+  - "make a pdf"
+  - "generate a pdf"
+  - "pdf page count"
+  - "how many pages in this pdf"
+  - "pdf metadata"
+  - "burst pdf into pages"
+---
+
+# PDF Skill
+
+Work with PDF files using SLICC's built-in `pdftk` (backed by `@cantoo/pdf-lib` + `unpdf`) and `convert` (magick-wasm) commands.
+
+## pdftk Syntax
+
+pdftk uses positional syntax: **input file(s) come before the operation.**
+
+```bash
+pdftk <input.pdf> <operation> [options]
+```
+
+For multi-file operations, assign handle labels first:
+
+```bash
+pdftk A=first.pdf B=second.pdf cat A B output merged.pdf
+```
+
+## Operations
+
+### Extract text
+```js
+var r = await exec('pdftk /mnt/file.pdf dump_data_utf8');
+console.log(r.stdout);
+```
+
+### Extract metadata
+```js
+var r = await exec('pdftk /mnt/file.pdf dump_data');
+console.log(r.stdout);
+// Output: NumberOfPages, InfoKey/InfoValue pairs, etc.
+```
+
+### Merge PDFs
+```js
+// Assign handle labels A, B, C — then cat them in order
+await exec('pdftk A=/mnt/a.pdf B=/mnt/b.pdf C=/mnt/c.pdf cat A B C output /shared/merged.pdf');
+open('/shared/merged.pdf', '--download');
+```
+
+### Split — extract specific pages
+```js
+// Extract pages 2–5
+await exec('pdftk /mnt/file.pdf cat 2-5 output /shared/pages2to5.pdf');
+
+// Extract a single page
+await exec('pdftk /mnt/file.pdf cat 3 output /shared/page3.pdf');
+
+// Extract from page 4 to the end
+await exec('pdftk /mnt/file.pdf cat 4-end output /shared/from4.pdf');
+```
+
+### Split — every page into its own file
+```js
+// Creates /shared/page_01.pdf, /shared/page_02.pdf, etc.
+await exec('pdftk /mnt/file.pdf burst output /shared/page_%02d.pdf');
+```
+
+### Rotate pages
+```js
+// Rotate all pages 90° clockwise
+await exec('pdftk /mnt/file.pdf rotate 1-end right output /shared/rotated.pdf');
+
+// Rotate a single page (page 3 only)
+await exec('pdftk /mnt/file.pdf rotate 3 right output /shared/rotated.pdf');
+
+// Rotate directions: right (90° CW), left (90° CCW), down (180°)
+```
+
+### Create a PDF from scratch
+Say "create a pdf [title]" — SLICC will run `create-pdf.jsh` directly and download the result.
+
+To generate programmatically, run the script via node:
+```js
+await exec('node /workspace/skills/pdf/scripts/create-pdf.jsh "My Report Title"');
+```
+
+The script produces a 2-page US Letter PDF (612×792pt) with:
+- Centered gray header + hairline rule on every page
+- 24pt bold Helvetica titles, 13pt body, 72pt margins
+- "Page N of M" footer centered at the bottom of every page
+
+### Convert PDF page to image
+```js
+// Convert page 1 to PNG (0-indexed — page 1 = [0])
+await exec('convert /mnt/file.pdf[0] /shared/page1.png');
+open('/shared/page1.png', '--view');
+```
+
+## Notes
+
+- All output files should go to `/shared/` or `/mnt/` — not `/tmp/`.
+- `pdftk cat` page ranges are 1-based. `end` means last page: `3-end`.
+- `pdftk burst` zero-pads page numbers — use `%02d` or `%03d` in the output pattern.
+- `convert` (ImageMagick) requires a tray runtime; not available in the browser-only float.
+- OCR and PDF form filling are not available in the current SLICC environment.
+- For PPTX → PDF conversion with font embedding and layout fidelity, use the `pptx2pdf` skill.

--- a/skills/pdf/scripts/create-pdf.jsh
+++ b/skills/pdf/scripts/create-pdf.jsh
@@ -1,0 +1,100 @@
+// create-pdf.jsh — Create a PDF from scratch using pdf-lib
+// Triggered by: "create a pdf", "make a pdf", "generate a pdf"
+// Usage: create-pdf [title] [--output=/shared/out.pdf]
+// If called with no arguments, creates a sample document.
+
+var args    = (process && process.argv) ? process.argv.slice(2) : [];
+var title   = args.filter(function(a) { return !a.startsWith('--'); }).join(' ') || 'My Document';
+var outArg  = args.find(function(a) { return a.startsWith('--output='); });
+var output  = outArg ? outArg.replace('--output=', '') : '/shared/' + title.toLowerCase().replace(/\s+/g, '-') + '.pdf';
+
+var lib      = await import('https://esm.sh/pdf-lib');
+var pdfDoc   = await lib.PDFDocument.create();
+var margin   = 72;
+var bodySize = 13;
+var titSize  = 24;
+var lineGap  = 6;
+var W        = 612;
+var H        = 792;
+var maxW     = W - margin * 2;
+var metaSize = 10;
+var totalPages = 2;
+
+var stdFonts = lib.StandardFonts;
+var bodyFont  = await pdfDoc.embedFont(stdFonts.Helvetica);
+var titleFont = await pdfDoc.embedFont(stdFonts.HelveticaBold);
+var metaFont  = await pdfDoc.embedFont(stdFonts.Helvetica);
+
+var wrapLines = function(text, font, size) {
+  var lines = [];
+  var paragraphs = text.split('\n');
+  for (var pi = 0; pi < paragraphs.length; pi++) {
+    var para = paragraphs[pi];
+    if (!para.trim()) { lines.push(''); continue; }
+    var words = para.split(' ');
+    var line  = '';
+    for (var wi = 0; wi < words.length; wi++) {
+      var word      = words[wi];
+      var candidate = line ? line + ' ' + word : word;
+      if (font.widthOfTextAtSize(candidate, size) <= maxW) {
+        line = candidate;
+      } else {
+        if (line) lines.push(line);
+        line = word;
+      }
+    }
+    if (line) lines.push(line);
+  }
+  return lines;
+};
+
+var drawPage = function(pageIndex, pgTitle, pgBody) {
+  var page = pdfDoc.addPage([W, H]);
+  var curY = H - margin;
+  var grey = { type: 'RGB', red: 0.5, green: 0.5, blue: 0.5 };
+  var rule = { type: 'RGB', red: 0.8, green: 0.8, blue: 0.8 };
+
+  // Header
+  var hW = metaFont.widthOfTextAtSize(title, metaSize);
+  page.drawText(title, { x: (W - hW) / 2, y: H - margin + metaSize + 4, size: metaSize, font: metaFont, color: grey });
+  page.drawLine({ start: { x: margin, y: H - margin + 2 }, end: { x: W - margin, y: H - margin + 2 }, thickness: 0.5, color: rule });
+
+  // Footer
+  var footerStr = 'Page ' + (pageIndex + 1) + ' of ' + totalPages;
+  var fW = metaFont.widthOfTextAtSize(footerStr, metaSize);
+  page.drawLine({ start: { x: margin, y: margin - 4 }, end: { x: W - margin, y: margin - 4 }, thickness: 0.5, color: rule });
+  page.drawText(footerStr, { x: (W - fW) / 2, y: margin - metaSize - 6, size: metaSize, font: metaFont, color: grey });
+
+  // Title
+  var titleLines = wrapLines(pgTitle, titleFont, titSize);
+  for (var tl = 0; tl < titleLines.length; tl++) {
+    curY -= titSize;
+    if (curY < margin) break;
+    page.drawText(titleLines[tl], { x: margin, y: curY, size: titSize, font: titleFont });
+    curY -= lineGap;
+  }
+  curY -= titSize * 0.8;
+
+  // Body
+  var bodyLines = wrapLines(pgBody, bodyFont, bodySize);
+  for (var bl = 0; bl < bodyLines.length; bl++) {
+    if (!bodyLines[bl]) { curY -= bodySize; continue; }
+    curY -= bodySize;
+    if (curY < margin) break;
+    page.drawText(bodyLines[bl], { x: margin, y: curY, size: bodySize, font: bodyFont });
+    curY -= lineGap;
+  }
+};
+
+drawPage(0, title,
+  'This document was created with the SLICC pdf skill.\n\nEdit this script or call createPdf() directly to generate documents with your own content, headers, footers, and multi-page layouts.'
+);
+
+drawPage(1, 'Getting Started',
+  'Use the pdf skill to:\n\n- Create PDFs from scratch with custom text and layout\n- Extract text: pdftk /mnt/file.pdf dump_data_utf8\n- Merge files: pdftk A=a.pdf B=b.pdf cat A B output merged.pdf\n- Split pages: pdftk /mnt/file.pdf cat 2-5 output pages.pdf\n- Rotate pages: pdftk /mnt/file.pdf rotate 1-end right output rotated.pdf'
+);
+
+var pdfBytes = await pdfDoc.save();
+await fs.writeFileBinary(output, pdfBytes);
+open(output, '--download');
+console.log('Created: ' + output);


### PR DESCRIPTION
## Summary
- Adds PDF skill for reading, creating, merging, splitting, rotating, and extracting text from PDFs
- Uses SLICC's built-in `pdftk` and `convert` commands (no Python required)
- Includes `create-pdf.jsh` script for generating PDFs from scratch using pdf-lib

## Test plan
- [ ] Verify SKILL.md loads correctly in SLICC
- [ ] Test `pdftk` operations (merge, split, rotate, extract text)
- [ ] Test `create-pdf.jsh` script generates valid PDF

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)