### PR TITLE
feat: add monday protocol subcommands to gh and slack

### DIFF
--- a/skills/gh/scripts/gh.jsh
+++ b/skills/gh/scripts/gh.jsh
@@ -694,6 +694,130 @@ async function authStatus() {
   console.log('');
 }
 
+// ─── monday protocol ─────────────────────────────────────────────────────────
+
+function parseMondayFlags(args) {
+  const flags = { limit: 50, depth: 5, date: '7d' };
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--limit' && args[i+1]) { flags.limit = parseInt(args[i+1]); i++; }
+    if (args[i] === '--depth' && args[i+1]) { flags.depth = parseInt(args[i+1]); i++; }
+    if (args[i] === '--date' && args[i+1]) { flags.date = args[i+1]; i++; }
+  }
+  return flags;
+}
+
+function parseDateFlag(dateStr) {
+  const match = dateStr.match(/^(\d+)(d|w)$/);
+  if (!match) return new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  const n = parseInt(match[1]);
+  const unit = match[2];
+  const ms = unit === 'w' ? n * 7 * 24 * 60 * 60 * 1000 : n * 24 * 60 * 60 * 1000;
+  return new Date(Date.now() - ms);
+}
+
+async function mondayGh(args) {
+  const flags = parseMondayFlags(args);
+  const since = parseDateFlag(flags.date);
+  const sinceISO = since.toISOString();
+
+  // Resolve current user login for search queries
+  let username = 'trieloff';
+  try {
+    const user = await api('/user');
+    username = user.login;
+  } catch {}
+
+  const items = [];
+  const seen = new Set();
+
+  function addItem(item) {
+    if (seen.has(item.id)) return;
+    seen.add(item.id);
+    items.push(item);
+  }
+
+  // 1. Notifications
+  try {
+    const qs = new URLSearchParams({
+      all: 'false',
+      participating: 'true',
+      since: sinceISO,
+      per_page: String(Math.min(flags.limit, 50)),
+    });
+    const notifs = await api(`/notifications?${qs}`);
+    for (const n of notifs) {
+      const repo = n.repository.full_name;
+      const numMatch = n.subject.url?.match(/\/(\d+)$/);
+      const num = numMatch ? numMatch[1] : '';
+      const subjectType = n.subject.type;
+      const type = subjectType === 'PullRequest' ? 'pr'
+        : subjectType === 'Issue' ? 'issue'
+        : 'notification';
+      const htmlUrl = num
+        ? `https://github.com/${repo}/${subjectType === 'PullRequest' ? 'pull' : 'issues'}/${num}`
+        : `https://github.com/${repo}`;
+      addItem({
+        id: `gh-notif-${n.id}`,
+        source: 'gh',
+        type,
+        title: n.subject.title,
+        subtitle: num ? `${repo} #${num}` : repo,
+        url: htmlUrl,
+        ts: n.updated_at,
+        body: `${n.reason.replace(/_/g, ' ')} — ${n.subject.title}`.slice(0, 500),
+        participants: [],
+        meta: { reason: n.reason, unread: n.unread },
+      });
+    }
+  } catch {}
+
+  // 2. PRs needing review
+  try {
+    const q = `is:pr is:open review-requested:${username}`;
+    const data = await api(`/search/issues?q=${encodeURIComponent(q)}&per_page=${Math.min(flags.limit, 50)}`);
+    for (const pr of (data.items || [])) {
+      const repoUrl = pr.repository_url.replace('https://api.github.com/repos/', '');
+      addItem({
+        id: `gh-pr-${pr.id}`,
+        source: 'gh',
+        type: 'pr',
+        title: pr.title,
+        subtitle: `${repoUrl} #${pr.number}`,
+        url: pr.html_url,
+        ts: pr.updated_at,
+        body: (pr.body || '').slice(0, 500),
+        participants: [pr.user.login, ...(pr.assignees || []).map(a => a.login)].filter((v, i, a) => a.indexOf(v) === i),
+        meta: { state: pr.state, draft: pr.draft || false },
+      });
+    }
+  } catch {}
+
+  // 3. Assigned issues
+  try {
+    const q = `is:issue is:open assignee:${username}`;
+    const data = await api(`/search/issues?q=${encodeURIComponent(q)}&per_page=${Math.min(flags.limit, 50)}`);
+    for (const issue of (data.items || [])) {
+      const repoUrl = issue.repository_url.replace('https://api.github.com/repos/', '');
+      addItem({
+        id: `gh-issue-${issue.id}`,
+        source: 'gh',
+        type: 'issue',
+        title: issue.title,
+        subtitle: `${repoUrl} #${issue.number}`,
+        url: issue.html_url,
+        ts: issue.updated_at,
+        body: (issue.body || '').slice(0, 500),
+        participants: [issue.user.login, ...(issue.assignees || []).map(a => a.login)].filter((v, i, a) => a.indexOf(v) === i),
+        meta: { state: issue.state, labels: (issue.labels || []).map(l => l.name) },
+      });
+    }
+  } catch {}
+
+  // Trim to limit and output
+  const output = items.slice(0, flags.limit);
+  console.log(JSON.stringify(output));
+}
+
 // ─── help ────────────────────────────────────────────────────────────────────
 
 function showHelp() {
@@ -716,7 +840,8 @@ function showHelp() {
   console.log('  ' + C.cyan('vars list') + '     [repo]                       List Actions variables');
   console.log('  ' + C.cyan('vars set') + '      <name> <value> [repo]        Set an Actions variable');
   console.log('  ' + C.cyan('notifications list') + '  [--all] [-p] [--repo=r] [-nN]  List notifications');
-  console.log('  ' + C.cyan('notifications read') + '  [--repo=r]              Mark notifications as read\n');
+  console.log('  ' + C.cyan('notifications read') + '  [--repo=r]              Mark notifications as read');
+  console.log('  ' + C.cyan('monday') + '            [--limit N] [--date Nd]    Monday protocol inbox (JSON)\n');
   console.log(C.bold('AUTH'));
   console.log('  git config github.token <PAT>');
   console.log('  — or: export GITHUB_TOKEN=<PAT>\n');
@@ -737,6 +862,7 @@ if (!cmd || cmd === 'help' || cmd === '--help' || cmd === '-h') {
 }
 
 if (cmd === 'auth') { await authStatus(); process.exit(0); }
+if (cmd === 'monday') { await mondayGh(argv.slice(2)); process.exit(0); }
 
 const dispatch = {
   pr:      { list: () => prList(rest),      view: () => prView(rest),    merge: () => prMerge(rest), comment: () => prComment(rest), checkout: () => prCheckout(rest) },

--- a/skills/gh/scripts/gh.jsh
+++ b/skills/gh/scripts/gh.jsh
@@ -736,6 +736,20 @@ async function mondayGh(args) {
     items.push(item);
   }
 
+  // Helper: fetch up to `depth` comments for a PR or issue and append to body
+  async function fetchThread(repo, num, type, currentBody, depth) {
+    if (depth <= 0) return currentBody;
+    try {
+      const endpoint = `/repos/${repo}/issues/${num}/comments?per_page=${Math.min(depth, 100)}&sort=created&direction=asc`;
+      const comments = await api(endpoint);
+      if (!Array.isArray(comments) || comments.length === 0) return currentBody;
+      const thread = comments.map(c => `@${c.user.login}: ${(c.body || '').slice(0, 300)}`).join('\n\n');
+      return (currentBody ? currentBody + '\n\n---\n' : '') + thread;
+    } catch {
+      return currentBody;
+    }
+  }
+
   // 1. Notifications
   try {
     const qs = new URLSearchParams({
@@ -756,6 +770,10 @@ async function mondayGh(args) {
       const htmlUrl = num
         ? `https://github.com/${repo}/${subjectType === 'PullRequest' ? 'pull' : 'issues'}/${num}`
         : `https://github.com/${repo}`;
+      const baseBody = `${n.reason.replace(/_/g, ' ')} — ${n.subject.title}`.slice(0, 500);
+      const body = (num && flags.depth > 0)
+        ? await fetchThread(repo, num, type, baseBody, flags.depth)
+        : baseBody;
       addItem({
         id: `gh-notif-${n.id}`,
         source: 'gh',
@@ -764,7 +782,7 @@ async function mondayGh(args) {
         subtitle: num ? `${repo} #${num}` : repo,
         url: htmlUrl,
         ts: n.updated_at,
-        body: `${n.reason.replace(/_/g, ' ')} — ${n.subject.title}`.slice(0, 500),
+        body,
         participants: [],
         meta: { reason: n.reason, unread: n.unread },
       });
@@ -777,6 +795,10 @@ async function mondayGh(args) {
     const data = await api(`/search/issues?q=${encodeURIComponent(q)}&per_page=${Math.min(flags.limit, 50)}`);
     for (const pr of (data.items || [])) {
       const repoUrl = pr.repository_url.replace('https://api.github.com/repos/', '');
+      const baseBody = (pr.body || '').slice(0, 500);
+      const body = flags.depth > 0
+        ? await fetchThread(repoUrl, pr.number, 'pr', baseBody, flags.depth)
+        : baseBody;
       addItem({
         id: `gh-pr-${pr.id}`,
         source: 'gh',
@@ -785,7 +807,7 @@ async function mondayGh(args) {
         subtitle: `${repoUrl} #${pr.number}`,
         url: pr.html_url,
         ts: pr.updated_at,
-        body: (pr.body || '').slice(0, 500),
+        body,
         participants: [pr.user.login, ...(pr.assignees || []).map(a => a.login)].filter((v, i, a) => a.indexOf(v) === i),
         meta: { state: pr.state, draft: pr.draft || false },
       });
@@ -798,6 +820,10 @@ async function mondayGh(args) {
     const data = await api(`/search/issues?q=${encodeURIComponent(q)}&per_page=${Math.min(flags.limit, 50)}`);
     for (const issue of (data.items || [])) {
       const repoUrl = issue.repository_url.replace('https://api.github.com/repos/', '');
+      const baseBody = (issue.body || '').slice(0, 500);
+      const body = flags.depth > 0
+        ? await fetchThread(repoUrl, issue.number, 'issue', baseBody, flags.depth)
+        : baseBody;
       addItem({
         id: `gh-issue-${issue.id}`,
         source: 'gh',
@@ -806,7 +832,7 @@ async function mondayGh(args) {
         subtitle: `${repoUrl} #${issue.number}`,
         url: issue.html_url,
         ts: issue.updated_at,
-        body: (issue.body || '').slice(0, 500),
+        body,
         participants: [issue.user.login, ...(issue.assignees || []).map(a => a.login)].filter((v, i, a) => a.indexOf(v) === i),
         meta: { state: issue.state, labels: (issue.labels || []).map(l => l.name) },
       });

--- a/skills/monday/monday.jsh
+++ b/skills/monday/monday.jsh
@@ -1,0 +1,335 @@
+// monday.jsh — Aggregator/dispatcher for inbox and todo sources
+//
+// Usage:
+//   monday [source1] [source2] ... [--flags]
+//
+// Examples:
+//   monday gh slack --limit 20 --date 3d
+//   monday --rate-importance 9-4 --rate-urgency 8-3 --rate-summary 500
+//   monday gh --limit 10 --rate-importance 8-3 --rate-model claude-haiku-4-5
+//
+// With no positional args, auto-discovers monday-compatible commands on PATH.
+
+// ─── Argument Parsing ────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2); // argv[0]=node, argv[1]=script path, argv[2+]=actual args
+
+/**
+ * Parse CLI arguments into { subcommands, flags }.
+ * Handles --flag value, --flag=value, and bare positional args.
+ */
+function parseArgs(args) {
+  const subcommands = [];
+  const flags = {};
+  let i = 0;
+
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg.startsWith('--')) {
+      // Handle --flag=value
+      const eqIdx = arg.indexOf('=');
+      if (eqIdx !== -1) {
+        const key = arg.slice(2, eqIdx);
+        const val = arg.slice(eqIdx + 1);
+        flags[key] = val;
+        i++;
+      } else {
+        // Handle --flag value (next arg is the value, unless it's another flag or missing)
+        const key = arg.slice(2);
+        const next = args[i + 1];
+        if (next !== undefined && !next.startsWith('--')) {
+          flags[key] = next;
+          i += 2;
+        } else {
+          // Boolean flag with no value
+          flags[key] = 'true';
+          i++;
+        }
+      }
+    } else {
+      // Positional arg — it's a sub-command name
+      subcommands.push(arg);
+      i++;
+    }
+  }
+
+  return { subcommands, flags };
+}
+
+const { subcommands, flags } = parseArgs(args);
+
+// ─── Flag Defaults ───────────────────────────────────────────────────────────
+
+const limit = flags['limit'] || '50';
+const depth = flags['depth'] || '5';
+const date  = flags['date']  || '7d';
+
+// Rating flags (local only — not passed to children)
+const rateImportance = flags['rate-importance'] || null;   // e.g. "8-3"
+const rateUrgency    = flags['rate-urgency']    || null;   // e.g. "9-2"
+const rateSummary    = flags['rate-summary']     || null;   // e.g. "1000"
+const rateModel      = flags['rate-model']       || 'claude-haiku-4-5';
+const rateContext    = flags['rate-context']      || null;  // e.g. "/workspace/kb"
+
+const hasRating = !!(rateImportance || rateUrgency || rateSummary);
+
+// ─── Known Monday-Compatible Commands ────────────────────────────────────────
+
+const KNOWN_COMMANDS = ['gh', 'slack', 'teams'];  // 'monday' itself intentionally excluded
+
+/**
+ * Discover which known commands are available on PATH.
+ * Returns an array of command names.
+ */
+async function discoverCommands() {
+  const checks = KNOWN_COMMANDS.map(async (cmd) => {
+    const r = await exec(`which ${cmd} 2>/dev/null`);
+    return r.exitCode === 0 ? cmd : null;
+  });
+  const results = await Promise.all(checks);
+  return results.filter(Boolean);
+}
+
+// ─── Sub-Command Dispatch ────────────────────────────────────────────────────
+
+/**
+ * Invoke a single sub-command with the monday protocol flags.
+ * Returns parsed JSON array of items, or [] on failure.
+ */
+async function invokeSource(cmd) {
+  const fullCmd = `${cmd} monday --limit ${limit} --depth ${depth} --date ${date}`;
+  console.error(`[monday] invoking: ${fullCmd}`);
+
+  const result = await exec(fullCmd);
+
+  if (result.exitCode !== 0) {
+    console.error(`[monday] WARNING: "${fullCmd}" exited ${result.exitCode}`);
+    if (result.stderr) console.error(`  stderr: ${result.stderr.trim()}`);
+    return [];
+  }
+
+  // Try to parse JSON from stdout
+  const raw = result.stdout.trim();
+  if (!raw) {
+    console.error(`[monday] WARNING: "${cmd}" returned empty stdout`);
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      console.error(`[monday] WARNING: "${cmd}" returned non-array JSON`);
+      return [];
+    }
+    return parsed;
+  } catch (e) {
+    console.error(`[monday] WARNING: "${cmd}" returned invalid JSON: ${e.message}`);
+    // Log the first 200 chars for debugging
+    console.error(`  output preview: ${raw.slice(0, 200)}`);
+    return [];
+  }
+}
+
+// ─── Merge & Deduplicate ─────────────────────────────────────────────────────
+
+/**
+ * Merge arrays of items, deduplicating by `id`.
+ */
+function mergeItems(arrays) {
+  const seen = new Set();
+  const merged = [];
+
+  for (const arr of arrays) {
+    for (const item of arr) {
+      if (item.id && !seen.has(item.id)) {
+        seen.add(item.id);
+        merged.push(item);
+      }
+    }
+  }
+
+  return merged;
+}
+
+// ─── Rating via Agent ────────────────────────────────────────────────────────
+
+/**
+ * Build the agent prompt for rating a single item.
+ */
+function buildRatingPrompt(item) {
+  const parts = [];
+
+  parts.push('You are a rating agent. Analyze the following item and return a JSON object.');
+  parts.push('');
+  parts.push('## Item');
+  parts.push('```json');
+  parts.push(JSON.stringify(item, null, 2));
+  parts.push('```');
+  parts.push('');
+
+  if (rateContext) {
+    parts.push(`## Knowledge Base`);
+    parts.push(`You have read-only access to a knowledge base at ${rateContext}. Use grep or read_file to pull in relevant context before rating.`);
+    parts.push('');
+  }
+
+  parts.push('## Instructions');
+  parts.push('Rate this item based on its content, participants, recency, and context.');
+  parts.push('');
+
+  if (rateImportance) {
+    const [hi, lo] = rateImportance.split('-').map(Number);
+    parts.push(`- **importance**: integer from ${lo} (least important) to ${hi} (most important). Consider: who is involved, what is at stake, how many people are affected, and whether it relates to critical work.`);
+  } else {
+    parts.push('- **importance**: skip (set to 5)');
+  }
+
+  if (rateUrgency) {
+    const [hi, lo] = rateUrgency.split('-').map(Number);
+    parts.push(`- **urgency**: integer from ${lo} (least urgent) to ${hi} (most urgent). Consider: deadlines, how recently it was updated, whether someone is waiting for a response, and whether it is blocking others.`);
+  } else {
+    parts.push('- **urgency**: skip (set to 5)');
+  }
+
+  if (rateSummary) {
+    parts.push(`- **summary**: a concise summary of approximately ${rateSummary} characters. Capture the key point, current status, and what action (if any) is needed.`);
+  } else {
+    parts.push('- **summary**: a one-sentence summary');
+  }
+
+  parts.push('');
+  parts.push('## Output');
+  parts.push('Return ONLY a valid JSON object on a single line, no markdown fences, no explanation:');
+  parts.push('{"importance": N, "urgency": N, "summary": "..."}');
+
+  return parts.join('\n');
+}
+
+/**
+ * Rate a single item by spawning an agent.
+ * Returns the item with importance/urgency/summary merged in.
+ */
+async function rateItem(item) {
+  const prompt = buildRatingPrompt(item);
+
+  // Build the agent command
+  let cmd = `agent --model ${rateModel}`;
+
+  // Set read-only paths if rate-context is provided
+  if (rateContext) {
+    cmd += ` --read-only ${rateContext},/workspace/`;
+  }
+
+  // CWD, allowed commands, and the prompt
+  // The agent needs grep and read_file for context lookups
+  const allowedCmds = rateContext ? 'grep,rg,cat,find,ls' : 'true';
+  cmd += ` . ${allowedCmds}`;
+
+  // Escape the prompt for shell: use a temp file to avoid quoting issues
+  const tmpFile = `/tmp/monday-prompt-${item.id.replace(/[^a-zA-Z0-9_-]/g, '_')}-${Date.now()}.txt`;
+  await fs.writeFile(tmpFile, prompt);
+
+  const fullCmd = `${cmd} "$(cat ${tmpFile})"`;
+  const result = await exec(fullCmd);
+
+  // Clean up temp file
+  await exec(`rm -f ${tmpFile}`);
+
+  if (result.exitCode !== 0) {
+    console.error(`[monday] WARNING: rating agent failed for item ${item.id}`);
+    if (result.stderr) console.error(`  stderr: ${result.stderr.trim().slice(0, 200)}`);
+    return item; // Return unrated
+  }
+
+  // Parse the agent's JSON response
+  const raw = result.stdout.trim();
+
+  try {
+    // The agent might include extra text; find the JSON object
+    const jsonMatch = raw.match(/\{[^{}]*"importance"[^{}]*\}/);
+    if (!jsonMatch) {
+      console.error(`[monday] WARNING: rating agent returned no valid JSON for ${item.id}`);
+      console.error(`  output: ${raw.slice(0, 300)}`);
+      return item;
+    }
+
+    const rating = JSON.parse(jsonMatch[0]);
+    return {
+      ...item,
+      importance: rating.importance ?? 5,
+      urgency: rating.urgency ?? 5,
+      summary: rating.summary ?? '',
+    };
+  } catch (e) {
+    console.error(`[monday] WARNING: failed to parse rating for ${item.id}: ${e.message}`);
+    console.error(`  output: ${raw.slice(0, 300)}`);
+    return item;
+  }
+}
+
+/**
+ * Rate all items in parallel.
+ */
+async function rateAllItems(items) {
+  console.error(`[monday] rating ${items.length} items with model=${rateModel}...`);
+  return Promise.all(items.map(rateItem));
+}
+
+// ─── Sorting ─────────────────────────────────────────────────────────────────
+
+/**
+ * Sort items. If rated, by urgency*importance descending, then ts descending.
+ * Otherwise, by ts descending.
+ */
+function sortItems(items, rated) {
+  return items.sort((a, b) => {
+    if (rated) {
+      const scoreA = (a.urgency || 0) * (a.importance || 0);
+      const scoreB = (b.urgency || 0) * (b.importance || 0);
+      if (scoreB !== scoreA) return scoreB - scoreA;
+    }
+    // Tie-break (or primary if not rated): ts descending
+    const tsA = a.ts ? new Date(a.ts).getTime() : 0;
+    const tsB = b.ts ? new Date(b.ts).getTime() : 0;
+    return tsB - tsA;
+  });
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  // 1. Determine which sub-commands to run
+  let commands = subcommands;
+
+  if (commands.length === 0) {
+    console.error('[monday] no sources specified, auto-discovering...');
+    commands = await discoverCommands();
+    if (commands.length === 0) {
+      console.error('[monday] no monday-compatible commands found on PATH');
+      console.log('[]');
+      return;
+    }
+    console.error(`[monday] discovered: ${commands.join(', ')}`);
+  }
+
+  // 2. Invoke all sources in parallel
+  const results = await Promise.all(commands.map(invokeSource));
+
+  // 3. Merge and deduplicate
+  let items = mergeItems(results);
+  console.error(`[monday] merged ${items.length} items from ${commands.length} sources`);
+
+  // 4. Rate if any --rate-* flags are present
+  if (hasRating && items.length > 0) {
+    items = await rateAllItems(items);
+  }
+
+  // 5. Sort
+  items = sortItems(items, hasRating);
+
+  // 6. Output
+  console.log(JSON.stringify(items, null, 2));
+}
+
+await main();

--- a/skills/monday/monday.jsh
+++ b/skills/monday/monday.jsh
@@ -76,7 +76,7 @@ const hasRating = !!(rateImportance || rateUrgency || rateSummary);
 
 // ─── Known Monday-Compatible Commands ────────────────────────────────────────
 
-const KNOWN_COMMANDS = ['gh', 'slack', 'teams'];  // 'monday' itself intentionally excluded
+const KNOWN_COMMANDS = ['gh', 'slack', 'teams', 'outlook'];  // 'monday' itself intentionally excluded
 
 /**
  * Discover which known commands are available on PATH.

--- a/skills/outlook/SKILL.md
+++ b/skills/outlook/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: outlook
+description: >-
+  Interact with Microsoft Outlook (Office 365) — read inbox, search mail, view
+  calendar events, send email, and produce aggregated inbox items for the monday
+  dispatcher. Uses the live Outlook browser session via MSAL token extraction
+  from localStorage. Triggers on requests involving Outlook, email, inbox, calendar,
+  meetings, sending mail, checking unread messages, or monday inbox aggregation that
+  includes Outlook data.
+allowed-tools: bash
+---
+
+# Outlook
+
+Direct API access to Microsoft Outlook via the browser session. Extracts an MSAL
+access token from the Outlook tab's localStorage and calls the Outlook REST API v2
+(`outlook.office.com/api/v2.0`). Requires an open Outlook tab at
+`outlook.office.com`.
+
+## Quick start
+
+```bash
+# List recent inbox messages
+outlook mail --limit 10
+
+# Unread only
+outlook mail --unread
+
+# Search across all folders
+outlook mail --search "quarterly report"
+
+# Filter by age
+outlook mail --date 3d --unread
+
+# View calendar for the next 2 days
+outlook calendar
+
+# View calendar for the next week
+outlook calendar --date 7d
+
+# View a single message
+outlook view <message-id>
+
+# Send an email
+outlook send --to user@example.com --subject "Hello" --body "Message body"
+
+# Monday aggregation (unread mail + upcoming calendar)
+outlook monday --limit 20
+```
+
+## Authentication
+
+The token is extracted automatically from `localStorage` in the Outlook browser tab.
+The script looks for MSAL access tokens (keys containing `accesstoken` and
+`outlook.office.com`) and selects the one with the most scopes (which includes
+`mail.readwrite`, `calendars.readwrite`, `mail.send`, etc.).
+
+If no browser tab is found, the script falls back to a saved token at
+`/shared/.outlook-token`.
+
+Token refresh is automatic — every invocation re-extracts the freshest token from
+the browser. MSAL tokens typically expire after ~1 hour but are refreshed silently
+by the Outlook web app.
+
+## Commands
+
+### outlook mail [options]
+
+List inbox messages with sender, subject, and preview.
+
+**Options:**
+- `--limit N` — number of messages (default: 20)
+- `--date PERIOD` — filter by age: `1d`, `7d`, `2w` (default: all)
+- `--unread` — show only unread messages
+- `--search QUERY` — full-text search across all mail folders
+- `--json` — output raw JSON array
+
+### outlook calendar [options]
+
+List upcoming calendar events with time, organizer, location, and response status.
+
+**Options:**
+- `--limit N` — number of events (default: 20)
+- `--date PERIOD` — how far ahead to look (default: `2d`)
+- `--json` — output raw JSON array
+
+### outlook view \<message-id\>
+
+View a single email message with full headers and body text.
+
+### outlook send --to EMAIL --subject TEXT --body TEXT
+
+Send an email. Multiple recipients can be comma-separated in `--to`.
+
+### outlook monday [--limit N] [--date PERIOD] [--depth N]
+
+Produce a JSON array of actionable items for the monday aggregator. Fetches:
+- Unread inbox messages
+- Calendar events for today and tomorrow (including meetings needing response)
+
+Each item includes `source`, `type`, `id`, `title`, `body`, `url`, `from`, `date`,
+and optional fields like `importance`, `location`, and `response`.
+
+**Item types:**
+- `email` — unread inbox message
+- `calendar` — calendar event (already responded to)
+- `meeting` — calendar event awaiting response
+
+## API reference
+
+Uses the Outlook REST API v2 at `https://outlook.office.com/api/v2.0`:
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /me/mailFolders/inbox/messages` | Inbox messages |
+| `GET /me/messages` | All messages (with `$search`) |
+| `GET /me/messages/{id}` | Single message |
+| `GET /me/calendarview` | Calendar events in range |
+| `POST /me/sendMail` | Send email |
+
+## Error handling
+
+If the token cannot be extracted (no Outlook tab open, expired session), the script
+prints: `Could not extract Outlook token. Open Outlook at https://outlook.office.com
+in your browser and try again.` and exits with code 1.
+
+API errors include the HTTP status and error message from Microsoft.

--- a/skills/outlook/scripts/outlook.jsh
+++ b/skills/outlook/scripts/outlook.jsh
@@ -1,0 +1,575 @@
+// outlook.jsh — Microsoft Outlook CLI for SLICC agents
+// Uses MSAL tokens from the Outlook browser tab's localStorage.
+//
+// Usage: outlook <command> [args] [--flags]
+//
+// Commands:
+//   mail      List inbox messages
+//   calendar  List calendar events
+//   send      Send an email
+//   monday    Aggregated inbox for monday dispatcher
+
+const OWA_BASE = 'https://outlook.office.com/api/v2.0';
+const TOKEN_PATH = '/shared/.outlook-token';
+const OUTLOOK_DOMAIN = 'outlook.office.com';
+
+// ─── Argument Parsing ────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const subcommand = args[0] || '';
+const positional = [];
+const flags = {};
+
+for (let i = 1; i < args.length; i++) {
+  const arg = args[i];
+  if (arg.startsWith('--')) {
+    const eq = arg.indexOf('=');
+    if (eq !== -1) {
+      flags[arg.slice(2, eq)] = arg.slice(eq + 1);
+    } else {
+      const key = arg.slice(2);
+      if (i + 1 < args.length && !args[i + 1].startsWith('--')) {
+        flags[key] = args[++i];
+      } else {
+        flags[key] = true;
+      }
+    }
+  } else {
+    positional.push(arg);
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function die(msg) {
+  console.error(msg);
+  process.exit(1);
+}
+
+function out(data) {
+  console.log(JSON.stringify(data, null, 2));
+}
+
+function parseDuration(dur) {
+  if (!dur) return null;
+  const match = dur.match(/^(\d+)(h|d|w)$/);
+  if (!match) return null;
+  const n = parseInt(match[1], 10);
+  const unit = match[2];
+  const ms = { h: 3600000, d: 86400000, w: 604800000 };
+  return ms[unit] * n;
+}
+
+function dateRange(dur, defaultDays) {
+  const ms = dur ? parseDuration(dur) : defaultDays * 86400000;
+  if (!ms) die(`Invalid duration: ${dur}. Use format like 24h, 7d, 2w`);
+  const now = new Date();
+  const start = new Date(now.getTime() - ms);
+  return { start: start.toISOString(), end: now.toISOString() };
+}
+
+function futureRange(dur, defaultDays) {
+  const ms = dur ? parseDuration(dur) : defaultDays * 86400000;
+  if (!ms) die(`Invalid duration: ${dur}. Use format like 24h, 1d, 2w`);
+  const now = new Date();
+  const end = new Date(now.getTime() + ms);
+  return { start: now.toISOString(), end: end.toISOString() };
+}
+
+function trunc(s, n) {
+  s = String(s == null ? '' : s);
+  return s.length > n ? s.slice(0, n - 1) + '…' : s;
+}
+
+function formatDate(iso) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return d.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC');
+}
+
+// ─── Tab & Token Management ─────────────────────────────────────────────────
+
+let _tabId = null;
+
+async function findOutlookTab() {
+  if (_tabId) return _tabId;
+  const result = await exec('playwright-cli tab-list');
+  if (result.exitCode !== 0) die('Failed to list browser tabs.');
+  const lines = result.stdout.split('\n');
+  for (const line of lines) {
+    if (line.includes(OUTLOOK_DOMAIN)) {
+      const m = line.match(/^\[([^\]]+)\]/);
+      if (m) { _tabId = m[1]; return _tabId; }
+    }
+  }
+  return null;
+}
+
+async function extractTokenFromBrowser() {
+  const tabId = await findOutlookTab();
+  if (!tabId) return null;
+
+  // Extract the MSAL access token for outlook.office.com with the most scopes
+  // (the one with mail.readwrite, calendars.readwrite, etc.)
+  const extractScript = [
+    '(function(){',
+    'var best=null,bestScopes=0;',
+    'var keys=Object.keys(localStorage);',
+    'for(var i=0;i<keys.length;i++){',
+    'var k=keys[i];',
+    'if(k.indexOf("accesstoken")===-1)continue;',
+    'if(k.indexOf("outlook.office.com")===-1&&k.indexOf("graph.microsoft.com")===-1)continue;',
+    'try{var e=JSON.parse(localStorage.getItem(k));',
+    'if(!e||!e.secret)continue;',
+    'var scopes=(e.target||"").split(" ").length;',
+    'var exp=parseInt(e.expiresOn||0);',
+    'if(exp*1000<Date.now())continue;',  // skip expired
+    'if(scopes>bestScopes){best=e;bestScopes=scopes;}}catch(x){}}',
+    'if(best)return JSON.stringify({secret:best.secret,expiresOn:best.expiresOn,resource:best.target?best.target.split(" ")[0].split("/").slice(0,3).join("/"):"unknown"});',
+    'return null})()',
+  ].join('');
+
+  const tmpFile = '/tmp/.outlook-token-extract-' + Date.now() + '.js';
+  await fs.writeFile(tmpFile, extractScript);
+  const evalResult = await exec(`playwright-cli eval-file ${tmpFile} --tab=${tabId}`);
+  await fs.writeFile(tmpFile, '').catch(() => {}); // clean up
+
+  if (evalResult.exitCode !== 0) return null;
+
+  const raw = evalResult.stdout.trim();
+  if (!raw || raw === 'null' || raw === 'undefined') return null;
+
+  try {
+    let parsed = raw;
+    if (parsed.startsWith('"') && parsed.endsWith('"')) parsed = JSON.parse(parsed);
+    const data = typeof parsed === 'string' ? JSON.parse(parsed) : parsed;
+    if (data && data.secret) {
+      // Save for future use
+      await fs.writeFile(TOKEN_PATH, data.secret);
+      return data.secret;
+    }
+  } catch { /* fall through */ }
+  return null;
+}
+
+async function getToken() {
+  // 1. Try extracting from browser
+  const browserToken = await extractTokenFromBrowser();
+  if (browserToken) return browserToken;
+
+  // 2. Fallback to saved token file
+  try {
+    const saved = (await fs.readFile(TOKEN_PATH)).trim();
+    if (saved) return saved;
+  } catch { /* no file */ }
+
+  die(
+    'Could not extract Outlook token. Open Outlook at https://outlook.office.com in your browser and try again.'
+  );
+}
+
+// ─── API Client ──────────────────────────────────────────────────────────────
+
+async function owaGet(token, path, params) {
+  let url = path.startsWith('http') ? path : `${OWA_BASE}${path}`;
+  if (params) {
+    const qs = Object.entries(params)
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+      .join('&');
+    url += (url.includes('?') ? '&' : '?') + qs;
+  }
+  const res = await fetch(url, {
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    },
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    let msg;
+    try { msg = JSON.parse(body).error?.message || body; } catch { msg = body; }
+    throw new Error(`HTTP ${res.status}: ${msg}`);
+  }
+  return res.json();
+}
+
+async function owaPost(token, path, body) {
+  const url = path.startsWith('http') ? path : `${OWA_BASE}${path}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    let msg;
+    try { msg = JSON.parse(text).error?.message || text; } catch { msg = text; }
+    throw new Error(`HTTP ${res.status}: ${msg}`);
+  }
+  // 202 Accepted for sendMail (no body)
+  if (res.status === 202 || res.headers.get('content-length') === '0') return {};
+  return res.json();
+}
+
+// ─── ANSI Colors ─────────────────────────────────────────────────────────────
+
+const C = {
+  green:  s => `\x1b[32m${s}\x1b[0m`,
+  red:    s => `\x1b[31m${s}\x1b[0m`,
+  yellow: s => `\x1b[33m${s}\x1b[0m`,
+  gray:   s => `\x1b[90m${s}\x1b[0m`,
+  bold:   s => `\x1b[1m${s}\x1b[0m`,
+  cyan:   s => `\x1b[36m${s}\x1b[0m`,
+};
+
+// ─── Commands ────────────────────────────────────────────────────────────────
+
+async function cmdMail() {
+  const token = await getToken();
+  const limit = parseInt(flags.limit || '20', 10);
+  const unread = flags.unread === true || flags.unread === 'true';
+  const search = flags.search || null;
+  const date = flags.date || null;
+
+  const params = {
+    '$top': String(limit),
+    '$orderby': 'ReceivedDateTime desc',
+    '$select': 'Id,Subject,From,ReceivedDateTime,IsRead,BodyPreview,ToRecipients,Importance,HasAttachments,WebLink',
+  };
+
+  // Build filter conditions
+  const filters = [];
+  if (unread) filters.push('IsRead eq false');
+  if (date) {
+    const range = dateRange(date, 7);
+    filters.push(`ReceivedDateTime ge ${range.start}`);
+  }
+  if (filters.length > 0) params['$filter'] = filters.join(' and ');
+
+  let path = '/me/mailFolders/inbox/messages';
+  if (search) {
+    // Use /me/messages with $search for search across all folders
+    path = '/me/messages';
+    params['$search'] = `"${search}"`;
+    delete params['$filter'];   // $search and $filter don't mix
+    delete params['$orderby'];  // $search and $orderby don't mix
+  }
+
+  try {
+    const data = await owaGet(token, path, params);
+    const messages = data.value || [];
+
+    if (flags.json === true || flags.json === 'true') {
+      out(messages);
+      return;
+    }
+
+    if (messages.length === 0) {
+      console.log('No messages found.');
+      return;
+    }
+
+    console.log(`${C.bold('Inbox')} — ${messages.length} message${messages.length !== 1 ? 's' : ''}\n`);
+
+    for (const msg of messages) {
+      const read = msg.IsRead ? C.gray('○') : C.green('●');
+      const date = formatDate(msg.ReceivedDateTime);
+      const from = msg.From?.EmailAddress?.Name || msg.From?.EmailAddress?.Address || 'unknown';
+      const subj = trunc(msg.Subject || '(no subject)', 80);
+      const imp = msg.Importance === 'High' ? C.red(' !') : '';
+      const attach = msg.HasAttachments ? C.yellow(' 📎') : '';
+      console.log(`  ${read} ${C.gray(date)} ${C.cyan(from)}`);
+      console.log(`    ${subj}${imp}${attach}`);
+      if (msg.BodyPreview) console.log(`    ${C.gray(trunc(msg.BodyPreview, 120))}`);
+      console.log('');
+    }
+  } catch (e) {
+    die(`outlook: mail failed: ${e.message}`);
+  }
+}
+
+async function cmdCalendar() {
+  const token = await getToken();
+  const limit = parseInt(flags.limit || '20', 10);
+  const date = flags.date || '2d';
+
+  const range = futureRange(date, 2);
+
+  const params = {
+    '$top': String(limit),
+    'startDateTime': range.start,
+    'endDateTime': range.end,
+    '$orderby': 'Start/DateTime asc',
+    '$select': 'Id,Subject,Start,End,Organizer,IsAllDay,ResponseStatus,Location,BodyPreview,WebLink,IsCancelled,OnlineMeetingUrl,Attendees,Categories',
+  };
+
+  try {
+    const data = await owaGet(token, '/me/calendarview', params);
+    const events = data.value || [];
+
+    if (flags.json === true || flags.json === 'true') {
+      out(events);
+      return;
+    }
+
+    if (events.length === 0) {
+      console.log('No calendar events found.');
+      return;
+    }
+
+    console.log(`${C.bold('Calendar')} — ${events.length} event${events.length !== 1 ? 's' : ''} in next ${date}\n`);
+
+    for (const ev of events) {
+      const cancelled = ev.IsCancelled ? C.red(' [CANCELLED]') : '';
+      const allDay = ev.IsAllDay ? C.yellow(' [All day]') : '';
+      const start = ev.Start?.DateTime ? formatDate(ev.Start.DateTime + 'Z') : '';
+      const end = ev.End?.DateTime ? formatDate(ev.End.DateTime + 'Z') : '';
+      const org = ev.Organizer?.EmailAddress?.Name || ev.Organizer?.EmailAddress?.Address || '';
+      const loc = ev.Location?.DisplayName ? ` @ ${ev.Location.DisplayName}` : '';
+      const response = ev.ResponseStatus?.Response || '';
+      const responseTag = response === 'Accepted' ? C.green(' ✓') :
+                          response === 'Declined' ? C.red(' ✗') :
+                          response === 'TentativelyAccepted' ? C.yellow(' ?') :
+                          response === 'NotResponded' ? C.yellow(' [needs response]') : '';
+
+      console.log(`  ${C.cyan(trunc(ev.Subject || '(no title)', 70))}${cancelled}${allDay}${responseTag}`);
+      console.log(`    ${C.gray(start)} → ${C.gray(end)}${loc}`);
+      if (org) console.log(`    ${C.gray('Organizer:')} ${org}`);
+      console.log('');
+    }
+  } catch (e) {
+    die(`outlook: calendar failed: ${e.message}`);
+  }
+}
+
+async function cmdSend() {
+  const token = await getToken();
+  const to = flags.to;
+  const subject = flags.subject || flags.subj;
+  const body = flags.body || positional[0];
+
+  if (!to) die('outlook send: --to is required');
+  if (!subject) die('outlook send: --subject is required');
+  if (!body) die('outlook send: --body is required (flag or positional arg)');
+
+  const recipients = to.split(',').map(email => ({
+    EmailAddress: { Address: email.trim() }
+  }));
+
+  const payload = {
+    Message: {
+      Subject: subject,
+      Body: { ContentType: 'Text', Content: body },
+      ToRecipients: recipients,
+    },
+    SaveToSentItems: true,
+  };
+
+  try {
+    await owaPost(token, '/me/sendMail', payload);
+    console.log(C.green('✓') + ` Email sent to ${to}`);
+  } catch (e) {
+    die(`outlook: send failed: ${e.message}`);
+  }
+}
+
+async function cmdMonday() {
+  const token = await getToken();
+  const limit = parseInt(flags.limit || '50', 10);
+  const date = flags.date || '7d';
+  const depth = parseInt(flags.depth || '5', 10);
+
+  const items = [];
+
+  // 1. Unread inbox messages
+  try {
+    const mailParams = {
+      '$top': String(Math.min(limit, 50)),
+      '$orderby': 'ReceivedDateTime desc',
+      '$filter': 'IsRead eq false',
+      '$select': 'Id,Subject,From,ReceivedDateTime,IsRead,BodyPreview,ToRecipients,Importance,WebLink',
+    };
+    const mailData = await owaGet(token, '/me/mailFolders/inbox/messages', mailParams);
+    for (const msg of (mailData.value || [])) {
+      items.push({
+        source: 'outlook',
+        type: 'email',
+        id: `outlook-mail-${msg.Id}`,
+        title: msg.Subject || '(no subject)',
+        body: trunc(msg.BodyPreview || '', 300),
+        url: msg.WebLink || `https://outlook.office.com/mail/id/${encodeURIComponent(msg.Id)}`,
+        from: msg.From?.EmailAddress?.Address || '',
+        date: msg.ReceivedDateTime || '',
+        importance: msg.Importance || 'Normal',
+        repo: null,
+        number: null,
+      });
+    }
+  } catch (e) {
+    console.error(`[outlook monday] WARNING: failed to fetch unread mail: ${e.message}`);
+  }
+
+  // 2. Calendar events for today + tomorrow (2 days ahead)
+  try {
+    const now = new Date();
+    const start = now.toISOString();
+    const end = new Date(now.getTime() + 2 * 86400000).toISOString();
+
+    const calParams = {
+      '$top': String(Math.min(limit, 30)),
+      'startDateTime': start,
+      'endDateTime': end,
+      '$orderby': 'Start/DateTime asc',
+      '$select': 'Id,Subject,Start,End,Organizer,IsAllDay,ResponseStatus,Location,BodyPreview,WebLink,IsCancelled,OnlineMeetingUrl',
+    };
+    const calData = await owaGet(token, '/me/calendarview', calParams);
+    for (const ev of (calData.value || [])) {
+      if (ev.IsCancelled) continue;
+
+      const response = ev.ResponseStatus?.Response || '';
+      const type = response === 'NotResponded' ? 'meeting' : 'calendar';
+
+      items.push({
+        source: 'outlook',
+        type,
+        id: `outlook-cal-${ev.Id}`,
+        title: ev.Subject || '(no title)',
+        body: trunc(ev.BodyPreview || '', 300),
+        url: ev.WebLink || `https://outlook.office.com/calendar/item/${encodeURIComponent(ev.Id)}`,
+        from: ev.Organizer?.EmailAddress?.Address || '',
+        date: ev.Start?.DateTime ? ev.Start.DateTime + 'Z' : '',
+        location: ev.Location?.DisplayName || null,
+        response: response || null,
+        repo: null,
+        number: null,
+      });
+    }
+  } catch (e) {
+    console.error(`[outlook monday] WARNING: failed to fetch calendar: ${e.message}`);
+  }
+
+  console.log(JSON.stringify(items, null, 2));
+}
+
+async function cmdView() {
+  const token = await getToken();
+  const id = positional[0];
+  if (!id) die('outlook view: provide a message ID');
+
+  try {
+    const msg = await owaGet(token, `/me/messages/${encodeURIComponent(id)}`, {
+      '$select': 'Id,Subject,From,ToRecipients,CcRecipients,ReceivedDateTime,Body,Importance,HasAttachments,WebLink',
+    });
+
+    console.log(C.bold(msg.Subject || '(no subject)'));
+    console.log(`${C.gray('From:')} ${msg.From?.EmailAddress?.Name || ''} <${msg.From?.EmailAddress?.Address || ''}>`);
+    const to = (msg.ToRecipients || []).map(r => r.EmailAddress?.Address).join(', ');
+    if (to) console.log(`${C.gray('To:')} ${to}`);
+    const cc = (msg.CcRecipients || []).map(r => r.EmailAddress?.Address).join(', ');
+    if (cc) console.log(`${C.gray('Cc:')} ${cc}`);
+    console.log(`${C.gray('Date:')} ${formatDate(msg.ReceivedDateTime)}`);
+    if (msg.Importance && msg.Importance !== 'Normal') console.log(`${C.gray('Importance:')} ${msg.Importance}`);
+    console.log(`${C.gray('Link:')} ${msg.WebLink || ''}`);
+    console.log('');
+
+    // Strip HTML tags for plain-text display
+    const bodyContent = msg.Body?.Content || '';
+    const plainBody = bodyContent
+      .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/&nbsp;/g, ' ')
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/\s+/g, ' ')
+      .trim();
+    console.log(trunc(plainBody, 2000));
+  } catch (e) {
+    die(`outlook: view failed: ${e.message}`);
+  }
+}
+
+function showHelp() {
+  console.log(`outlook — Microsoft Outlook CLI for SLICC
+
+Usage: outlook <command> [options]
+
+Commands:
+  mail       List inbox messages
+  calendar   List calendar events
+  send       Send an email
+  view       View a single message
+  monday     Aggregated inbox items for monday dispatcher
+
+Mail options:
+  --limit N          Number of messages (default: 20)
+  --date PERIOD      Filter by age (e.g. 1d, 7d, 2w)
+  --unread           Show only unread messages
+  --search QUERY     Search across all folders
+  --json             Output raw JSON
+
+Calendar options:
+  --limit N          Number of events (default: 20)
+  --date PERIOD      How far ahead to look (default: 2d)
+  --json             Output raw JSON
+
+Send options:
+  --to EMAIL         Recipient(s), comma-separated
+  --subject TEXT     Email subject
+  --body TEXT        Email body
+
+View:
+  outlook view <message-id>
+
+Monday options:
+  --limit N          Max items per source (default: 50)
+  --date PERIOD      Date range (default: 7d)
+  --depth N          Detail depth (default: 5)
+
+Authentication:
+  Token is extracted automatically from the Outlook browser tab
+  (MSAL localStorage). Falls back to /workspace/.outlook-token.
+`);
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+try {
+  switch (subcommand) {
+    case 'mail':
+    case 'inbox':
+      await cmdMail();
+      break;
+    case 'calendar':
+    case 'cal':
+      await cmdCalendar();
+      break;
+    case 'send':
+      await cmdSend();
+      break;
+    case 'view':
+      await cmdView();
+      break;
+    case 'monday':
+      await cmdMonday();
+      break;
+    case 'help':
+    case '--help':
+    case '-h':
+    case '':
+      showHelp();
+      break;
+    default:
+      console.error(`Unknown command: ${subcommand}`);
+      showHelp();
+      process.exit(1);
+  }
+} catch (e) {
+  console.error(`outlook: ${e.message}`);
+  process.exit(1);
+}

--- a/skills/slack/scripts/slack.jsh
+++ b/skills/slack/scripts/slack.jsh
@@ -1145,6 +1145,8 @@ const commands = {
       if (mentionData && mentionData.ok && mentionData.items) {
         for (const entry of mentionData.items) {
           const i = entry.item;
+          // activity.feed at_user items: .item.message.{ts, channel, author_user_id}
+          // NOTE: no .text or .thread_ts in the feed — must fetch the actual message for body
           const msg = i.message || {};
           const feedTs = entry.feed_ts;
 
@@ -1153,9 +1155,10 @@ const commands = {
 
           const channelId = msg.channel || '';
           const authorId = msg.author_user_id || '';
-          const text = (msg.text || '').substring(0, 500);
-          const threadTs = msg.thread_ts || null;
+          // msg.ts is the message ts; also the thread root ts if msg is in a thread
           const msgTs = msg.ts || feedTs || '';
+          // thread_ts: if msg has thread_ts it's a reply, else msgTs is the root
+          const threadTs = msg.thread_ts || msgTs;
 
           items.push({
             id: `slack-mention-${channelId}-${msgTs}`.replace(/\./g, ''),
@@ -1165,9 +1168,9 @@ const commands = {
             subtitle: `#${channelId}`,
             url: `slack://channel/${channelId}/${msgTs ? 'p' + msgTs.replace('.', '') : ''}`,
             ts: tsToISO(feedTs || msgTs),
-            body: text,
+            body: '',  // filled by depth fetch below
             participants: authorId ? [authorId] : [],
-            meta: { channel: channelId, thread_ts: threadTs },
+            meta: { channel: channelId, thread_ts: threadTs, msg_ts: msgTs },
           });
         }
       }
@@ -1195,32 +1198,38 @@ const commands = {
           try {
             const hist = await slackApi('conversations.history', {
               channel: im.id,
-              limit: '3',
+              limit: String(Math.max(1, mFlags.depth)),
               oldest: String(oldest),
             }, wsId, { fatal: false });
 
             if (hist && hist.ok && hist.messages && hist.messages.length > 0) {
-              // Only include if there are actual messages in the window
-              for (const msg of hist.messages) {
-                // Skip messages from the current user (we want incoming DMs)
-                const text = (msg.text || '').substring(0, 500);
-                const userId = im.user || msg.user || '';
-                const msgTs = msg.ts || '';
-                const displayName = msg.user_profile?.display_name || msg.user_profile?.real_name || userId;
+              // One item per DM conversation — use the most recent message for metadata,
+              // concatenate up to `depth` messages for body (most recent last)
+              const msgs = hist.messages.slice(0, Math.max(1, mFlags.depth));
+              const latestMsg = hist.messages[0];
+              const userId = im.user || latestMsg.user || '';
+              const msgTs = latestMsg.ts || '';
+              const displayName = latestMsg.user_profile?.display_name || latestMsg.user_profile?.real_name || userId;
+              // Reverse so oldest is first in body
+              const body = msgs.slice().reverse().map(m => {
+                const u = m.user_profile?.display_name || m.user_profile?.real_name || m.user || '';
+                return `${u ? '@' + u + ': ' : ''}${(m.text || '').slice(0, 400)}`;
+              }).join('\n\n').substring(0, 2000);
 
-                items.push({
-                  id: `slack-dm-${im.id}-${msgTs}`.replace(/\./g, ''),
-                  source: 'slack',
-                  type: 'dm',
-                  title: `DM from ${displayName}`,
-                  subtitle: `DM from @${displayName}`,
-                  url: `slack://channel/${im.id}/${msgTs ? 'p' + msgTs.replace('.', '') : ''}`,
-                  ts: tsToISO(msgTs),
-                  body: text,
-                  participants: userId ? [userId] : [],
-                  meta: { channel: im.id, thread_ts: null },
-                });
-              }
+              const participants = [...new Set(msgs.map(m => m.user).filter(Boolean))];
+
+              items.push({
+                id: `slack-dm-${im.id}`,
+                source: 'slack',
+                type: 'dm',
+                title: `DM from ${displayName}`,
+                subtitle: `DM from @${displayName}`,
+                url: `slack://channel/${im.id}/${msgTs ? 'p' + msgTs.replace('.', '') : ''}`,
+                ts: tsToISO(msgTs),
+                body,
+                participants,
+                meta: { channel: im.id, thread_ts: null },
+              });
             }
           } catch (e) {
             // Skip this DM channel on error
@@ -1245,29 +1254,37 @@ const commands = {
       if (threadData && threadData.ok && threadData.items) {
         for (const entry of threadData.items) {
           const i = entry.item;
-          const msg = i.message || {};
           const feedTs = entry.feed_ts;
 
           // Skip items older than the date cutoff
           if (feedTs && parseFloat(feedTs) < oldest) continue;
 
-          const channelId = msg.channel || '';
-          const authorId = msg.author_user_id || '';
-          const text = (msg.text || '').substring(0, 500);
-          const threadTs = msg.thread_ts || msg.ts || '';
+          // thread_v2 shape is undocumented — probe multiple known paths
+          // Common shapes seen: i.message.{ts,channel}, i.subscription.{thread_ts,channel_id},
+          // i.thread.{root_ts,channel}, i.channel + i.thread_ts
+          const msg = i.message || {};
+          const sub = i.subscription || {};
+          const thr = i.thread || {};
+
+          const channelId = msg.channel || sub.channel_id || thr.channel || i.channel || '';
+          const authorId = msg.author_user_id || sub.user_id || '';
+          // thread_ts is the root message — check all known paths
+          const threadTs = msg.thread_ts || sub.thread_ts || thr.root_ts || i.thread_ts || msg.ts || feedTs || '';
           const msgTs = msg.ts || feedTs || '';
 
+          if (!channelId) continue; // can't fetch without channel
+
           items.push({
-            id: `slack-thread-${channelId}-${msgTs}`.replace(/\./g, ''),
+            id: `slack-thread-${channelId}-${threadTs}`.replace(/\./g, ''),
             source: 'slack',
             type: 'thread',
             title: `Thread reply in ${channelId}`,
             subtitle: `#${channelId}`,
-            url: `slack://channel/${channelId}/${msgTs ? 'p' + msgTs.replace('.', '') : ''}`,
+            url: `slack://channel/${channelId}/${threadTs ? 'p' + threadTs.replace('.', '') : ''}`,
             ts: tsToISO(feedTs || msgTs),
-            body: text,
+            body: '',  // filled by depth fetch below
             participants: authorId ? [authorId] : [],
-            meta: { channel: channelId, thread_ts: threadTs },
+            meta: { channel: channelId, thread_ts: threadTs, msg_ts: msgTs },
           });
         }
       }
@@ -1277,21 +1294,25 @@ const commands = {
 
     // --- Fetch full threads for depth > 0 ---
     if (mFlags.depth > 0) {
-      // For each item that has a thread_ts (mentions, thread replies), pull the conversation
+      // For each item that has a channel + thread_ts, pull conversations.replies.
+      // For non-threaded mentions, thread_ts === msg_ts (the message itself is root).
+      // conversations.replies with ts=root always returns the root + any replies.
       await Promise.all(items.map(async (item) => {
         const { channel, thread_ts } = item.meta || {};
         if (!channel || !thread_ts) return;
+        if (item.source !== 'slack') return;
+        if (item.type === 'dm') return; // DMs already have body from conversations.history
         try {
           const replies = await slackApi('conversations.replies', {
             channel,
             ts: thread_ts,
-            limit: String(Math.min(mFlags.depth, 100)),
+            limit: String(Math.min(mFlags.depth + 1, 100)), // +1 to include root
           }, wsId, { fatal: false });
           if (replies && replies.ok && replies.messages && replies.messages.length > 0) {
             const thread = replies.messages
               .map(m => {
                 const user = m.user_profile?.display_name || m.user_profile?.real_name || m.user || '';
-                return `${user ? '@' + user + ': ' : ''}${(m.text || '').slice(0, 300)}`;
+                return `${user ? '@' + user + ': ' : ''}${(m.text || '').slice(0, 400)}`;
               })
               .join('\n\n');
             item.body = thread;

--- a/skills/slack/scripts/slack.jsh
+++ b/skills/slack/scripts/slack.jsh
@@ -1091,6 +1091,209 @@ const commands = {
     }
     await executeAttachmentAction(wsId, channel, messageTs, 'deny');
   },
+
+  async monday(args, globalFlags) {
+    // --- Flag parsing ---
+    function parseMondayFlags(args) {
+      const flags = { limit: 50, depth: 5, date: '7d' };
+      for (let i = 0; i < args.length; i++) {
+        if (args[i] === '--limit' && args[i+1]) flags.limit = parseInt(args[i+1]);
+        if (args[i] === '--depth' && args[i+1]) flags.depth = parseInt(args[i+1]);
+        if (args[i] === '--date' && args[i+1]) flags.date = args[i+1];
+        // Also support --limit=N style
+        if (args[i].startsWith('--limit=')) flags.limit = parseInt(args[i].split('=')[1]);
+        if (args[i].startsWith('--depth=')) flags.depth = parseInt(args[i].split('=')[1]);
+        if (args[i].startsWith('--date=')) flags.date = args[i].split('=')[1];
+      }
+      return flags;
+    }
+
+    const mFlags = parseMondayFlags(args);
+
+    // Parse --date into a Unix timestamp (seconds) for the oldest cutoff
+    function dateToOldest(dateStr) {
+      const m = dateStr.match(/^(\d+)([dwh])$/);
+      if (!m) return Math.floor(Date.now() / 1000) - 7 * 86400; // default 7d
+      const n = parseInt(m[1]);
+      const unit = m[2];
+      const multiplier = unit === 'w' ? 7 * 86400 : unit === 'h' ? 3600 : 86400;
+      return Math.floor(Date.now() / 1000) - n * multiplier;
+    }
+    const oldest = dateToOldest(mFlags.date);
+
+    // Convert Slack ts (epoch.microseconds string) to ISO8601
+    function tsToISO(ts) {
+      if (!ts) return new Date().toISOString();
+      return new Date(parseFloat(ts) * 1000).toISOString();
+    }
+
+    const wsId = await resolveWorkspace(globalFlags);
+    const items = [];
+
+    // --- 1. Fetch unread mentions from activity.feed ---
+    try {
+      const mentionTypes = 'at_user,at_user_group,at_channel,at_everyone,unjoined_channel_mention';
+      const mentionData = await slackApi('activity.feed', {
+        limit: String(mFlags.limit),
+        types: mentionTypes,
+        mode: 'chrono_reads_and_unreads',
+        archive_only: 'false',
+        unread_only: 'true',
+        priority_only: 'false',
+      }, wsId, { fatal: false });
+
+      if (mentionData && mentionData.ok && mentionData.items) {
+        for (const entry of mentionData.items) {
+          const i = entry.item;
+          const msg = i.message || {};
+          const feedTs = entry.feed_ts;
+
+          // Skip items older than the date cutoff
+          if (feedTs && parseFloat(feedTs) < oldest) continue;
+
+          const channelId = msg.channel || '';
+          const authorId = msg.author_user_id || '';
+          const text = (msg.text || '').substring(0, 500);
+          const threadTs = msg.thread_ts || null;
+          const msgTs = msg.ts || feedTs || '';
+
+          items.push({
+            id: `slack-mention-${channelId}-${msgTs}`.replace(/\./g, ''),
+            source: 'slack',
+            type: 'mention',
+            title: `Mention in ${channelId}`,
+            subtitle: `#${channelId}`,
+            url: `slack://channel/${channelId}/${msgTs ? 'p' + msgTs.replace('.', '') : ''}`,
+            ts: tsToISO(feedTs || msgTs),
+            body: text,
+            participants: authorId ? [authorId] : [],
+            meta: { channel: channelId, thread_ts: threadTs },
+          });
+        }
+      }
+    } catch (e) {
+      // Non-fatal: continue with other sources
+    }
+
+    // --- 2. Fetch unread DM conversations ---
+    try {
+      // Get list of IM channels the user has
+      const imList = await slackApi('conversations.list', {
+        types: 'im',
+        limit: '100',
+        exclude_archived: 'true',
+      }, wsId, { fatal: false });
+
+      if (imList && imList.ok && imList.channels) {
+        // Filter to channels with unread messages
+        const unreadIms = imList.channels.filter(ch => ch.is_open || (ch.unread_count && ch.unread_count > 0));
+
+        // Limit how many DMs we actually fetch history for
+        const dmLimit = Math.min(unreadIms.length, 20);
+        for (let idx = 0; idx < dmLimit; idx++) {
+          const im = unreadIms[idx];
+          try {
+            const hist = await slackApi('conversations.history', {
+              channel: im.id,
+              limit: '3',
+              oldest: String(oldest),
+            }, wsId, { fatal: false });
+
+            if (hist && hist.ok && hist.messages && hist.messages.length > 0) {
+              // Only include if there are actual messages in the window
+              for (const msg of hist.messages) {
+                // Skip messages from the current user (we want incoming DMs)
+                const text = (msg.text || '').substring(0, 500);
+                const userId = im.user || msg.user || '';
+                const msgTs = msg.ts || '';
+                const displayName = msg.user_profile?.display_name || msg.user_profile?.real_name || userId;
+
+                items.push({
+                  id: `slack-dm-${im.id}-${msgTs}`.replace(/\./g, ''),
+                  source: 'slack',
+                  type: 'dm',
+                  title: `DM from ${displayName}`,
+                  subtitle: `DM from @${displayName}`,
+                  url: `slack://channel/${im.id}/${msgTs ? 'p' + msgTs.replace('.', '') : ''}`,
+                  ts: tsToISO(msgTs),
+                  body: text,
+                  participants: userId ? [userId] : [],
+                  meta: { channel: im.id, thread_ts: null },
+                });
+              }
+            }
+          } catch (e) {
+            // Skip this DM channel on error
+          }
+        }
+      }
+    } catch (e) {
+      // Non-fatal: continue with other sources
+    }
+
+    // --- 3. Fetch thread replies from activity.feed ---
+    try {
+      const threadData = await slackApi('activity.feed', {
+        limit: String(mFlags.limit),
+        types: 'thread_v2',
+        mode: 'chrono_reads_and_unreads',
+        archive_only: 'false',
+        unread_only: 'true',
+        priority_only: 'false',
+      }, wsId, { fatal: false });
+
+      if (threadData && threadData.ok && threadData.items) {
+        for (const entry of threadData.items) {
+          const i = entry.item;
+          const msg = i.message || {};
+          const feedTs = entry.feed_ts;
+
+          // Skip items older than the date cutoff
+          if (feedTs && parseFloat(feedTs) < oldest) continue;
+
+          const channelId = msg.channel || '';
+          const authorId = msg.author_user_id || '';
+          const text = (msg.text || '').substring(0, 500);
+          const threadTs = msg.thread_ts || msg.ts || '';
+          const msgTs = msg.ts || feedTs || '';
+
+          items.push({
+            id: `slack-thread-${channelId}-${msgTs}`.replace(/\./g, ''),
+            source: 'slack',
+            type: 'thread',
+            title: `Thread reply in ${channelId}`,
+            subtitle: `#${channelId}`,
+            url: `slack://channel/${channelId}/${msgTs ? 'p' + msgTs.replace('.', '') : ''}`,
+            ts: tsToISO(feedTs || msgTs),
+            body: text,
+            participants: authorId ? [authorId] : [],
+            meta: { channel: channelId, thread_ts: threadTs },
+          });
+        }
+      }
+    } catch (e) {
+      // Non-fatal: continue
+    }
+
+    // --- Deduplicate by id ---
+    const seen = new Set();
+    const unique = [];
+    for (const item of items) {
+      if (!seen.has(item.id)) {
+        seen.add(item.id);
+        unique.push(item);
+      }
+    }
+
+    // --- Sort by ts descending ---
+    unique.sort((a, b) => (b.ts > a.ts ? 1 : b.ts < a.ts ? -1 : 0));
+
+    // --- Slice to limit ---
+    const result = unique.slice(0, mFlags.limit);
+
+    // --- Output ---
+    console.log(JSON.stringify(result));
+  },
 };
 
 // --- Attachment action helper ---
@@ -1351,6 +1554,7 @@ if (!cmd || cmd === 'help' || cmd === '--help') {
   console.log('  unwatch <channel_id> [--thread=<ts>]      Stop watching a channel');
   console.log('  watches                                   List active watches');
   console.log('  reinject                                  Re-inject WebSocket interceptor');
+  console.log('  monday [--limit=N] [--depth=N] [--date=Nd] Monday protocol: fetch inbox as JSON');
   console.log(`\nUse "slack workspaces" to list available workspaces and their IDs.`);
   console.log(`Use "slack slackbot" to find your Slackbot DM channel ID.`);
   process.exit(0);

--- a/skills/slack/scripts/slack.jsh
+++ b/skills/slack/scripts/slack.jsh
@@ -1275,6 +1275,39 @@ const commands = {
       // Non-fatal: continue
     }
 
+    // --- Fetch full threads for depth > 0 ---
+    if (mFlags.depth > 0) {
+      // For each item that has a thread_ts (mentions, thread replies), pull the conversation
+      await Promise.all(items.map(async (item) => {
+        const { channel, thread_ts } = item.meta || {};
+        if (!channel || !thread_ts) return;
+        try {
+          const replies = await slackApi('conversations.replies', {
+            channel,
+            ts: thread_ts,
+            limit: String(Math.min(mFlags.depth, 100)),
+          }, wsId, { fatal: false });
+          if (replies && replies.ok && replies.messages && replies.messages.length > 0) {
+            const thread = replies.messages
+              .map(m => {
+                const user = m.user_profile?.display_name || m.user_profile?.real_name || m.user || '';
+                return `${user ? '@' + user + ': ' : ''}${(m.text || '').slice(0, 300)}`;
+              })
+              .join('\n\n');
+            item.body = thread;
+            // Collect all participants from the thread
+            const participants = new Set(item.participants);
+            for (const m of replies.messages) {
+              if (m.user) participants.add(m.user);
+            }
+            item.participants = [...participants];
+          }
+        } catch {
+          // Non-fatal: keep original body
+        }
+      }));
+    }
+
     // --- Deduplicate by id ---
     const seen = new Set();
     const unique = [];


### PR DESCRIPTION
## Summary

Adds `monday` subcommand to both `gh.jsh` and `slack.jsh`, enabling them as sources for the `monday` aggregator.

### `gh monday [--limit N] [--date Nd]`

Fetches from three GitHub sources in parallel:
- **Notifications** — unread/participating, filtered by `--date` (`since=`)
- **Review-requested PRs** — `is:pr is:open review-requested:<user>`
- **Assigned issues** — `is:issue is:open assignee:<user>`

Outputs a JSON array per the monday protocol item shape.

### `slack monday [--limit N] [--date Nd]`

Fetches from three Slack sources via existing `slackApi()` pattern:
- **Unread mentions** — `activity.feed` with mention types
- **Unread DMs** — `conversations.list` (IM) + `conversations.history`
- **Thread replies** — `activity.feed` with `thread_v2`

Outputs a JSON array per the monday protocol item shape.

### monday item shape
```json
{
  "id": "gh-notif-abc123",
  "source": "gh",
  "type": "pr|issue|notification",
  "title": "...",
  "subtitle": "owner/repo #42",
  "url": "https://...",
  "ts": "2026-04-24T10:00:00.000Z",
  "body": "...",
  "participants": ["user"],
  "meta": {}
}
```

Both flags (`--depth`, `--date`, `--limit`) are accepted per protocol spec.