### PR TITLE
feat(pm-prd): rewrite as decision-forcing interview skill (supersedes #57)

### DIFF
--- a/skills/pm-prd/SKILL.md
+++ b/skills/pm-prd/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pm-prd
 description: Interview a product manager until the bet is real, then capture it as a Product Requirements Document. Use when a PM asks to write a PRD, define requirements, scope an MVP, plan a roadmap, or draft a launch plan. Triggers on phrases like "write a PRD", "create a spec", "define requirements", "what should we build", "MVP for X", "roadmap for X", "GTM plan", "launch plan", "product spec", or "I need to document this feature".
+allowed-tools: bash
 ---
 
 # PM PRD
@@ -16,10 +17,10 @@ five decision clusters below. Mark unresolved cells `OPEN QUESTION` rather
 than fabricating answers.
 
 Refusal patterns:
-- "Users want this feature" → ask the **Customer & Job** questions; do not paraphrase the feature into a problem statement.
-- "Improve retention" → ask for the moment of struggle and the leading indicator before any roadmap.
-- "Just draft it" → draft, but the first section is the unanswered questions and every unverified claim is tagged as an assumption.
-- "Make it sound better" → never. Ambiguity is signal, not a wording problem.
+- "Users want this feature" → ask Customer & Job questions; do not paraphrase the feature into a problem statement.
+- "Improve retention" → demand the moment of struggle and the leading indicator before any roadmap.
+- "Just draft it" → draft, but prepend an `Open Questions & Unverified Claims` callout before section 1 and tag unverified claims as assumptions (Phase 4).
+- "Make it sound better" → never. Ambiguity is signal, not wording.
 
 ## The five decision clusters
 
@@ -67,7 +68,9 @@ Force:
 
 ### Phase 4 — Draft
 
-Use [references/prd-template.md](references/prd-template.md). Section order is intentional: bet → customer → assumptions → success-and-kill → smallest learnable bet → roadmap → GTM. Features are a *consequence*, not the headline. Mark unresolved cells `OPEN QUESTION`; never invent values.
+Use [references/prd-template.md](references/prd-template.md). Section order is intentional: bet → customer → assumptions → success-and-kill → smallest learnable bet → roadmap → GTM. Features are a *consequence*, not the headline. Mark unresolved cells `OPEN QUESTION`; never invent values. The full list of open questions also lives in the appendix.
+
+**If the user bypassed the gates** ("just draft it"): keep the template's section order, but prepend an `## Open Questions & Unverified Claims` callout *before* section 1 that lists every gate that wasn't passed and every fabricated value. The reader must see the gaps before the bet.
 
 ### Phase 5 — Review
 
@@ -81,15 +84,19 @@ Revise specific sections; do not rewrite for tone.
 
 ### Phase 6 — Save
 
-Write to `product-docs/prds/active/<feature-name>-prd.md`. Create the directory if needed.
+Ask the user where to save before writing any files. Suggest, in order:
+1. `product-docs/prds/active/<feature-name>-prd.md` if the repo already has a `product-docs/` convention.
+2. `docs/prds/<feature-name>-prd.md` if the repo has a `docs/` directory.
+3. Otherwise `<feature-name>-prd.md` in the current working directory.
+
+Create the target directory only after the user confirms the location.
 
 ## Writing principles
 
 - **Diagnosis before solution.** If the diagnosis is one line and the feature list is two pages, the PRD is upside down.
-- **One bet per PRD.** A PRD with three bets is three PRDs. Split them.
+- **One bet per PRD.** Three bets = three PRDs.
 - **Specific over vague.** "Fast" → "loads in under 200 ms." "Better retention" → "D30 from 28 % to 38 %."
-- **Unanswered is fine; fabricated is not.** Mark unknowns as `OPEN QUESTION` with an owner. Never write a confident sentence where a question belongs.
-- **Living document.** Version, last-updated date, change-log.
+- **Unanswered is fine; fabricated is not.** Mark unknowns `OPEN QUESTION` with an owner.
 
 ## References
 

--- a/skills/pm-prd/SKILL.md
+++ b/skills/pm-prd/SKILL.md
@@ -11,10 +11,13 @@ the bet is real, then capture answers and open questions.
 
 ## Operating principle
 
-**Refuse to draft until the bet is real.** When the user says "write a PRD
-for X", do not start writing prose. Conduct a gated interview across the
-five decision clusters below. Mark unresolved cells `OPEN QUESTION` rather
-than fabricating answers.
+**Refuse to draft until the bet is real.** Conduct a gated interview across
+the six decision clusters below. Mark unresolved cells `OPEN QUESTION`
+rather than fabricating answers.
+
+**Use above everything (meta-gate).** Success must be expressible as
+*unprompted use*. A PRD whose definition of done would still be a win when
+shipped-but-unused is not a PRD.
 
 Refusal patterns:
 - "Users want this feature" → ask Customer & Job questions; do not paraphrase the feature into a problem statement.
@@ -22,15 +25,16 @@ Refusal patterns:
 - "Just draft it" → draft, but prepend an `Open Questions & Unverified Claims` callout before section 1 and tag unverified claims as assumptions (Phase 4).
 - "Make it sound better" → never. Ambiguity is signal, not wording.
 
-## The five decision clusters
+## The six decision clusters
 
 If a cluster is empty or vague, the PRD is not ready — keep interviewing.
 
 1. **Customer & Job** — who the customer is, the moment of struggle, the progress they're making, the trigger, and what holds them back.
 2. **The Bet** — diagnosis of what's actually going on, the crux constraint, opportunity size, why this team can act now.
-3. **Assumptions, Hypotheses & Risks** — for each of the four product risks (value, usability, feasibility, business viability): a falsifiable claim, its evidence, its invalidator, and the cheapest test.
-4. **Success That Can Fail** — observable aha moment, one primary metric, guardrails, and a mandatory kill criterion.
+3. **Assumptions, Hypotheses & Risks** — for each of the five product risks (value, usability, feasibility, business viability, **adoption / org readiness**): a falsifiable claim, its evidence, its invalidator, and the cheapest test. Adoption is distinct from feasibility and viability — see [references/decision-forcing-questions.md](references/decision-forcing-questions.md).
+4. **Success That Can Fail** — aha moment as unprompted use, one primary usage metric, guardrails, and a mandatory kill criterion.
 5. **Cost of Delay & Smallest Learnable Bet** — what waiting costs, the smallest experiment that disambiguates the riskiest assumption, and an explicit not-building list.
+6. **Pricing & Value Capture** — the willingness-to-pay shape and where it breaks: price-to-value, hard choices, customer → segmentation → self-segmentation, point of diminishing returns. Cost-plus and competition-minus are disqualified.
 
 Full question bank: [references/decision-forcing-questions.md](references/decision-forcing-questions.md). Quote it when the PM is stuck.
 
@@ -47,13 +51,13 @@ Ask in one batch:
 
 **Gate**: a one-paragraph moment-of-struggle story, a one-sentence diagnosis, and an "only we can" claim with at least one piece of evidence. Otherwise log as open questions and only proceed with explicit user approval.
 
-### Phase 2 — Surface assumptions and define success
+### Phase 2 — Surface assumptions, define success, set price
 
-For each of the four product risks (value, usability, feasibility, business viability), force at least one assumption stated as a falsifiable claim, with: supporting evidence, what would invalidate it, and the cheapest test runnable before code is written.
+For each of the **five** product risks (value, usability, feasibility, business viability, **adoption / org readiness**), force one falsifiable claim with evidence, invalidator, and cheapest test.
 
-Then force: the aha moment (observable user behavior), one primary outcome metric, guardrail metrics, the **kill criterion**, and 30 / 60 / 90-day signals.
+Then force the aha moment (unprompted use, not a notification click), one primary usage metric, guardrails, the **kill criterion**, 30 / 60 / 90-day signals, and the pricing shape (cluster 6).
 
-**Gate**: every risk has at least one assumption with an invalidator, and a kill criterion exists. No kill criterion = wish-list, not a bet.
+**Gate**: 5/5 risks have an assumption with an invalidator; kill criterion exists; price is tied to value (not cost-plus, not competition-minus); success metric measures *use*.
 
 ### Phase 3 — Define the smallest learnable bet
 
@@ -68,7 +72,7 @@ Force:
 
 ### Phase 4 — Draft
 
-Use [references/prd-template.md](references/prd-template.md). Section order is intentional: bet → customer → assumptions → success-and-kill → smallest learnable bet → roadmap → GTM. Features are a *consequence*, not the headline. Mark unresolved cells `OPEN QUESTION`; never invent values. The full list of open questions also lives in the appendix.
+Use [references/prd-template.md](references/prd-template.md). Section order is intentional: bet → customer → assumptions (5 risks) → success-and-kill → smallest learnable bet → roadmap → requirements (FFOB) → pricing → GTM. Features are a *consequence*, not the headline. Each requirement is rendered as Feature → Function (proof) → Outcome (first-order quantified) → Benefits (plural). Mark unresolved cells `OPEN QUESTION`; never invent values. The full list of open questions also lives in the appendix.
 
 **If the user bypassed the gates** ("just draft it"): keep the template's section order, but prepend an `## Open Questions & Unverified Claims` callout *before* section 1 that lists every gate that wasn't passed and every fabricated value. The reader must see the gaps before the bet.
 
@@ -79,6 +83,8 @@ Ask in order:
 2. Which assumption are you least sure about, and is its invalidator one we'd actually accept?
 3. If the kill criterion fired in 60 days, would we actually pull back? If not, the kill criterion is wrong.
 4. Is the smallest learnable bet really the smallest?
+5. **Use above everything check**: if this shipped exactly as written but no customer used it on their own initiative, would we still call it a win? If yes, the success definition is wrong.
+6. Pricing check: is the price tied to value or to cost? If cost, redo cluster 6.
 
 Revise specific sections; do not rewrite for tone.
 

--- a/skills/pm-prd/SKILL.md
+++ b/skills/pm-prd/SKILL.md
@@ -5,126 +5,75 @@ description: Interview a product manager until the bet is real, then capture it 
 
 # PM PRD
 
-A PRD is a forcing function for decisions, not a polished artifact. The job
-of this skill is to interview the product manager hard enough that the
-unanswered questions surface, *then* capture the answers (and the open
-questions) in a document the team can actually act on.
-
-A PRD that polishes an unrefined idea hides risk. A PRD that surfaces the
-unanswered questions reduces it.
+Treat the PRD as a forcing function for decisions. Interview the PM until
+the bet is real, then capture answers and open questions.
 
 ## Operating principle
 
 **Refuse to draft until the bet is real.** When the user says "write a PRD
-for X", do not start writing prose. Conduct a structured interview across
-five decision clusters (below). Only when each cluster has at least a
-provisional answer do you draft the document — and even then, mark
-unresolved cells `OPEN QUESTION` rather than fabricating answers.
+for X", do not start writing prose. Conduct a gated interview across the
+five decision clusters below. Mark unresolved cells `OPEN QUESTION` rather
+than fabricating answers.
 
-Anti-patterns to refuse:
-- "Users want this feature" → respond with the **Customer & Job** questions; do not paraphrase the feature into a problem statement.
+Refusal patterns:
+- "Users want this feature" → ask the **Customer & Job** questions; do not paraphrase the feature into a problem statement.
 - "Improve retention" → ask for the moment of struggle and the leading indicator before any roadmap.
-- "Just draft it" → draft a PRD whose first visible section lists the unanswered questions, with each unverified claim explicitly marked as an assumption.
+- "Just draft it" → draft, but the first section is the unanswered questions and every unverified claim is tagged as an assumption.
 - "Make it sound better" → never. Ambiguity is signal, not a wording problem.
 
 ## The five decision clusters
 
-Each cluster names a class of decision the PRD must capture explicitly. If a
-cluster is empty or vague, the PRD is not ready and the skill keeps interviewing.
+If a cluster is empty or vague, the PRD is not ready — keep interviewing.
 
-1. **Customer & Job** — who the customer is, the moment of struggle, the
-   progress they're trying to make, what triggers them today, and what holds
-   them back.
-2. **The Bet** — the diagnosis of what's actually going on, the crux
-   constraint, the opportunity size, and why this team is best suited to
-   take the bet now.
-3. **Assumptions, Hypotheses & Risks** — the leap-of-faith claims surfaced
-   for each of the four product risks (value, usability, feasibility,
-   business viability), each with its evidence, its invalidator, and the
-   cheapest test that could falsify it before code is written.
-4. **Success That Can Fail** — the observable signal that the user's job
-   was done, the primary outcome metric, the guardrails, and (mandatory)
-   the kill criterion.
-5. **Cost of Delay & Smallest Learnable Bet** — what waiting costs, the
-   smallest experiment that disambiguates the riskiest assumption, and an
-   explicit list of what we are *not* building.
+1. **Customer & Job** — who the customer is, the moment of struggle, the progress they're making, the trigger, and what holds them back.
+2. **The Bet** — diagnosis of what's actually going on, the crux constraint, opportunity size, why this team can act now.
+3. **Assumptions, Hypotheses & Risks** — for each of the four product risks (value, usability, feasibility, business viability): a falsifiable claim, its evidence, its invalidator, and the cheapest test.
+4. **Success That Can Fail** — observable aha moment, one primary metric, guardrails, and a mandatory kill criterion.
+5. **Cost of Delay & Smallest Learnable Bet** — what waiting costs, the smallest experiment that disambiguates the riskiest assumption, and an explicit not-building list.
 
-The full question bank for each cluster lives in
-[references/decision-forcing-questions.md](references/decision-forcing-questions.md).
-Quote from it directly when the PM is stuck.
+Full question bank: [references/decision-forcing-questions.md](references/decision-forcing-questions.md). Quote it when the PM is stuck.
 
 ## Workflow
 
 ### Phase 1 — Frame the bet
 
-Goal: get a real customer-and-job statement and a real diagnosis.
-
-Ask, in one batch:
-1. Who is the customer? Describe them by the problem they're in, not their job title or demographics.
-2. Walk me through the last time someone you know hit this problem. What were they doing, what triggered them to look for a solution, what did they try first, and what was frustrating about it?
-3. What is *actually going on* in this market or workflow? What's the underlying knot? (Not the symptom — the cause.)
-4. Of the things that make this hard, which one, if it relaxed, would unlock the rest?
+Ask in one batch:
+1. Who is the customer? Describe by problem, not job title or demographics.
+2. Walk me through the last time someone hit this problem. What were they doing, what triggered them, what did they try first, what was frustrating?
+3. What is actually going on in this market or workflow? What's the underlying knot, not the symptom?
+4. Of the things that make this hard, which one, if relaxed, unlocks the rest?
 5. Why is this team uniquely able to act on this now?
 
-Gate: do not advance to Phase 2 until you can write a one-paragraph story
-naming a real moment of struggle, a one-sentence diagnosis of the underlying
-cause, and an "only we can" claim with at least one piece of evidence. If the
-PM cannot supply these, log them as open questions and proceed only on
-explicit user approval.
+**Gate**: a one-paragraph moment-of-struggle story, a one-sentence diagnosis, and an "only we can" claim with at least one piece of evidence. Otherwise log as open questions and only proceed with explicit user approval.
 
 ### Phase 2 — Surface assumptions and define success
 
-Goal: make the leap-of-faith assumptions visible and define a kill criterion.
+For each of the four product risks (value, usability, feasibility, business viability), force at least one assumption stated as a falsifiable claim, with: supporting evidence, what would invalidate it, and the cheapest test runnable before code is written.
 
-For each of the four product risks (value, usability, feasibility, business
-viability):
-- Force at least one assumption stated as a falsifiable claim.
-- For each assumption, capture: supporting evidence, what would invalidate
-  it, and the cheapest test that could run *before* the team builds.
+Then force: the aha moment (observable user behavior), one primary outcome metric, guardrail metrics, the **kill criterion**, and 30 / 60 / 90-day signals.
 
-Then force:
-- The observable user behavior that means the job was done (the "aha moment").
-- The primary outcome metric — exactly one.
-- The guardrail metrics that must not regress.
-- The **kill criterion**: what data would make us pull this back.
-- 30 / 60 / 90-day signals.
-
-Gate: do not advance to Phase 3 until every risk category has at least one
-assumption with an invalidator, and a kill criterion exists. A PRD with no
-condition under which the work would be killed is a wish-list, not a bet.
+**Gate**: every risk has at least one assumption with an invalidator, and a kill criterion exists. No kill criterion = wish-list, not a bet.
 
 ### Phase 3 — Define the smallest learnable bet
 
-Goal: scope an MVP that resolves the riskiest assumption, not the smallest
-buildable thing.
-
 Force:
-- What does waiting another quarter cost us? (Customers, revenue, learning, optionality.)
-- Which assumption is riskiest? What is the smallest experiment that disambiguates it?
-- Is that experiment a build, a prototype, a concierge, a wizard-of-oz, or something else?
-- What are we explicitly *not* building, and why is now not the time?
-- What is the rollback path if the signal is bad?
+- What does waiting another quarter cost (customers, revenue, learning, optionality)?
+- Which assumption is riskiest? What's the smallest experiment that disambiguates *it*?
+- What form: build, prototype, concierge, wizard-of-oz, landing page?
+- What are we explicitly *not* building, and why now is not the time?
+- Rollback path if the signal is bad?
 
-Gate: the MVP description must name the riskiest assumption and explain how
-the MVP tests it. "MVP = a smaller version of what we want to build
-eventually" is not sufficient.
+**Gate**: the MVP names the riskiest assumption and explains how it tests it. "Smaller version of the eventual product" is not sufficient.
 
-### Phase 4 — Draft the PRD
+### Phase 4 — Draft
 
-Use [references/prd-template.md](references/prd-template.md). The order of
-sections is intentional: bet → customer in context → assumptions →
-success-and-kill criteria → smallest learnable bet → roadmap → GTM. The
-feature list is a *consequence* of the earlier sections, not the headline.
-
-Mark unresolved cells `OPEN QUESTION` and list them in the appendix. Never
-invent values. A PRD with five honest open questions is more useful than a
-PRD with thirty fabricated certainties.
+Use [references/prd-template.md](references/prd-template.md). Section order is intentional: bet → customer → assumptions → success-and-kill → smallest learnable bet → roadmap → GTM. Features are a *consequence*, not the headline. Mark unresolved cells `OPEN QUESTION`; never invent values.
 
 ### Phase 5 — Review
 
-Present the draft. Ask, in this order:
+Ask in order:
 1. Does the diagnosis ring true? Is the crux right?
-2. Which assumption are you least sure about, and is its invalidator something we'd actually accept?
+2. Which assumption are you least sure about, and is its invalidator one we'd actually accept?
 3. If the kill criterion fired in 60 days, would we actually pull back? If not, the kill criterion is wrong.
 4. Is the smallest learnable bet really the smallest?
 
@@ -132,28 +81,15 @@ Revise specific sections; do not rewrite for tone.
 
 ### Phase 6 — Save
 
-Write to `product-docs/prds/active/<feature-name>-prd.md`. Create the
-directory if it doesn't exist.
+Write to `product-docs/prds/active/<feature-name>-prd.md`. Create the directory if needed.
 
 ## Writing principles
 
-- **Diagnosis before solution.** Spend more words on what's actually going on
-  than on what we'll build. If the diagnosis is one line and the feature
-  list is two pages, the PRD is upside down.
+- **Diagnosis before solution.** If the diagnosis is one line and the feature list is two pages, the PRD is upside down.
 - **One bet per PRD.** A PRD with three bets is three PRDs. Split them.
-- **Every assumption has an invalidator.** If a claim has no condition under
-  which it could be wrong, it is not an assumption — it's faith.
-- **Specific over vague.** "Fast" → "loads in under 200 ms." "Better
-  retention" → "D30 retention from 28 % to 38 %."
-- **Out of scope is mandatory.** What we are *not* building is as
-  load-bearing as what we are.
-- **Kill criterion is mandatory.** If there is no result that would cause us
-  to pull this back, success is unfalsifiable.
-- **Unanswered is fine; fabricated is not.** Mark unknowns as
-  `OPEN QUESTION` and assign an owner. Never write a confident sentence
-  where you should write a question.
-- **Living document.** Version, last-updated date, change-log. A PRD that
-  never changes was never read.
+- **Specific over vague.** "Fast" → "loads in under 200 ms." "Better retention" → "D30 from 28 % to 38 %."
+- **Unanswered is fine; fabricated is not.** Mark unknowns as `OPEN QUESTION` with an owner. Never write a confident sentence where a question belongs.
+- **Living document.** Version, last-updated date, change-log.
 
 ## References
 

--- a/skills/pm-prd/SKILL.md
+++ b/skills/pm-prd/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: bash
 Treat the PRD as a forcing function for decisions. Interview the PM until
 the bet is real, then capture answers and open questions.
 
-## Operating principle
+## Operating principles
 
 **Refuse to draft until the bet is real.** Conduct a gated interview across
 the six decision clusters below. Mark unresolved cells `OPEN QUESTION`
@@ -19,11 +19,18 @@ rather than fabricating answers.
 *unprompted use*. A PRD whose definition of done would still be a win when
 shipped-but-unused is not a PRD.
 
+**Build before align, ship after learn.** Building is cheap, shipping
+is not. Vibe-code the Phase 2 artifact before articulating risks; decks
+and sign-offs sit downstream of evidence, not upstream.
+
 Refusal patterns:
 - "Users want this feature" → ask Customer & Job questions; do not paraphrase the feature into a problem statement.
 - "Improve retention" → demand the moment of struggle and the leading indicator before any roadmap.
-- "Just draft it" → draft, but prepend an `Open Questions & Unverified Claims` callout before section 1 and tag unverified claims as assumptions (Phase 4).
+- "Just draft it" → draft, but prepend an `Open Questions & Unverified Claims` callout before section 1 and tag unverified claims as assumptions (Phase 5).
 - "Make it sound better" → never. Ambiguity is signal, not wording.
+- "We need an eng estimate first" → that's for shipping. Vibe-code the test now.
+- "We need alignment first" → alignment is downstream of evidence.
+- "Five happy users, ship it" → see the Phase 4 callout.
 
 ## The six decision clusters
 
@@ -33,7 +40,7 @@ If a cluster is empty or vague, the PRD is not ready — keep interviewing.
 2. **The Bet** — diagnosis of what's actually going on, the crux constraint, opportunity size, why this team can act now.
 3. **Assumptions, Hypotheses & Risks** — for each of the five product risks (value, usability, feasibility, business viability, **adoption / org readiness**): a falsifiable claim, its evidence, its invalidator, and the cheapest test. Adoption is distinct from feasibility and viability — see [references/decision-forcing-questions.md](references/decision-forcing-questions.md).
 4. **Success That Can Fail** — aha moment as unprompted use, one primary usage metric, guardrails, and a mandatory kill criterion.
-5. **Cost of Delay & Smallest Learnable Bet** — what waiting costs, the smallest experiment that disambiguates the riskiest assumption, and an explicit not-building list.
+5. **Cost of Delay & Smallest Shippable Bet** — what waiting costs, what the discovery artifact already validated, what new risks shipping introduces (scale, security, compliance, retention, network effects — *ship debt*), and an explicit not-building list.
 6. **Pricing & Value Capture** — the willingness-to-pay shape and where it breaks: price-to-value, hard choices, customer → segmentation → self-segmentation, point of diminishing returns. Cost-plus and competition-minus are disqualified.
 
 Full question bank: [references/decision-forcing-questions.md](references/decision-forcing-questions.md). Quote it when the PM is stuck.
@@ -51,44 +58,57 @@ Ask in one batch:
 
 **Gate**: a one-paragraph moment-of-struggle story, a one-sentence diagnosis, and an "only we can" claim with at least one piece of evidence. Otherwise log as open questions and only proceed with explicit user approval.
 
-### Phase 2 — Surface assumptions, define success, set price
+### Phase 2 — Build the discovery artifact
 
-For each of the **five** product risks (value, usability, feasibility, business viability, **adoption / org readiness**), force one falsifiable claim with evidence, invalidator, and cheapest test.
+Vibe-code a working version of the smallest plausible expression of the bet, in under one day (Cursor / Claude Code / Replit / v0 / Bolt / Lovable / Windsurf). Show it to 3–5 real customers or the bet's hardest internal critic. Keep a *what surprised me* log.
 
-Then force the aha moment (unprompted use, not a notification click), one primary usage metric, guardrails, the **kill criterion**, 30 / 60 / 90-day signals, and the pricing shape (cluster 6).
+The artifact is **not the product** — it is the discovery instrument for Phase 3.
 
-**Gate**: 5/5 risks have an assumption with an invalidator; kill criterion exists; price is tied to value (not cost-plus, not competition-minus); success metric measures *use*.
+If the bet is not vibe-codable in under a day (hardware, regulated, compliance, network-effects-only-at-scale, on-prem), fall back, in order: concierge → wizard-of-oz → landing page → sales pitch.
 
-### Phase 3 — Define the smallest learnable bet
+**Gate**: a runnable artifact exists, and the *what surprised me* log captures at least three things that were not anticipated before building.
+
+### Phase 3 — Surface assumptions, define success, set price (informed by the artifact)
+
+For each of the **five** product risks (value, usability, feasibility, business viability, **adoption / org readiness**), force one falsifiable claim with evidence, invalidator, cheapest test, and **whether the artifact already validated it, refuted it, or left it open**.
+
+Then force the aha moment (anchored in observed artifact use where possible), one primary usage metric, guardrails, the **kill criterion**, 30 / 60 / 90-day signals, and the pricing shape (cluster 6).
+
+**Gate**: 5/5 risks have an assumption with an invalidator; the artifact-validation column is filled for each (Y / N / partial / not testable); kill criterion exists; price is tied to value (not cost-plus, not competition-minus); success metric measures *use*.
+
+### Phase 4 — Define the smallest shippable bet
 
 Force:
 - What does waiting another quarter cost (customers, revenue, learning, optionality)?
-- Which assumption is riskiest? What's the smallest experiment that disambiguates *it*?
-- What form: build, prototype, concierge, wizard-of-oz, landing page?
-- What are we explicitly *not* building, and why now is not the time?
+- Given the artifact's evidence, what's the smallest *shippable* version that captures the validated value?
+- What new risks does shipping introduce that the artifact did not test? List them as **ship debt**.
+- What are we explicitly *not* building (or shipping), and why now is not the time?
 - Rollback path if the signal is bad?
 
-**Gate**: the MVP names the riskiest assumption and explains how it tests it. "Smaller version of the eventual product" is not sufficient.
+> **What vibe coding cannot test** (treat as ship debt, not as validated): scale, security, retention >30d, network effects, compliance, edge cases, ops, billing, support. Detail: [references/decision-forcing-questions.md](references/decision-forcing-questions.md).
 
-### Phase 4 — Draft
+**Gate**: the smallest shippable bet names the artifact-validated value, lists at least three ship-debt items, and explains why each must be paid before launch (or accepted as known risk). "Smaller version of the eventual product" is not sufficient.
 
-Use [references/prd-template.md](references/prd-template.md). Section order is intentional: bet → customer → assumptions (5 risks) → success-and-kill → smallest learnable bet → roadmap → requirements (FFOB) → pricing → GTM. Features are a *consequence*, not the headline. Each requirement is rendered as Feature → Function (proof) → Outcome (first-order quantified) → Benefits (plural). Mark unresolved cells `OPEN QUESTION`; never invent values. The full list of open questions also lives in the appendix.
+### Phase 5 — Draft
+
+Use [references/prd-template.md](references/prd-template.md). Section order is intentional: bet → customer → discovery artifact → assumptions (5 risks, with artifact-validation column) → success-and-kill → smallest shippable bet (with ship debt) → roadmap → requirements (FFOB) → pricing → GTM. Features are a *consequence*, not the headline. Each requirement is rendered as Feature → Function (proof — link the artifact here) → Outcome (first-order quantified) → Benefits (plural). Mark unresolved cells `OPEN QUESTION`; never invent values. The full list of open questions also lives in the appendix.
 
 **If the user bypassed the gates** ("just draft it"): keep the template's section order, but prepend an `## Open Questions & Unverified Claims` callout *before* section 1 that lists every gate that wasn't passed and every fabricated value. The reader must see the gaps before the bet.
 
-### Phase 5 — Review
+### Phase 6 — Review
 
 Ask in order:
 1. Does the diagnosis ring true? Is the crux right?
-2. Which assumption are you least sure about, and is its invalidator one we'd actually accept?
-3. If the kill criterion fired in 60 days, would we actually pull back? If not, the kill criterion is wrong.
-4. Is the smallest learnable bet really the smallest?
-5. **Use above everything check**: if this shipped exactly as written but no customer used it on their own initiative, would we still call it a win? If yes, the success definition is wrong.
-6. Pricing check: is the price tied to value or to cost? If cost, redo cluster 6.
+2. Did the artifact actually surprise you, or did you only see what you expected to see? If only what you expected, the artifact wasn't probing the right edge.
+3. Which assumption are you least sure about, and is its invalidator one we'd actually accept?
+4. If the kill criterion fired in 60 days, would we actually pull back? If not, the kill criterion is wrong.
+5. Is the smallest *shippable* bet really the smallest, or is it the artifact plus ship debt nobody scoped?
+6. **Unprompted-use check**: if this shipped but no customer used it unprompted, would it still be a win? If yes, redo cluster 4.
+7. **Pricing check**: tied to value or to cost? If cost, redo cluster 6.
 
 Revise specific sections; do not rewrite for tone.
 
-### Phase 6 — Save
+### Phase 7 — Save
 
 Ask the user where to save before writing any files. Suggest, in order:
 1. `product-docs/prds/active/<feature-name>-prd.md` if the repo already has a `product-docs/` convention.

--- a/skills/pm-prd/SKILL.md
+++ b/skills/pm-prd/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: pm-prd
+description: Interview a product manager until the bet is real, then capture it as a Product Requirements Document. Use when a PM asks to write a PRD, define requirements, scope an MVP, plan a roadmap, or draft a launch plan. Triggers on phrases like "write a PRD", "create a spec", "define requirements", "what should we build", "MVP for X", "roadmap for X", "GTM plan", "launch plan", "product spec", or "I need to document this feature".
+---
+
+# PM PRD
+
+A PRD is a forcing function for decisions, not a polished artifact. The job
+of this skill is to interview the product manager hard enough that the
+unanswered questions surface, *then* capture the answers (and the open
+questions) in a document the team can actually act on.
+
+A PRD that polishes an unrefined idea hides risk. A PRD that surfaces the
+unanswered questions reduces it.
+
+## Operating principle
+
+**Refuse to draft until the bet is real.** When the user says "write a PRD
+for X", do not start writing prose. Conduct a structured interview across
+five decision clusters (below). Only when each cluster has at least a
+provisional answer do you draft the document — and even then, mark
+unresolved cells `OPEN QUESTION` rather than fabricating answers.
+
+Anti-patterns to refuse:
+- "Users want this feature" → respond with the **Customer & Job** questions; do not paraphrase the feature into a problem statement.
+- "Improve retention" → ask for the moment of struggle and the leading indicator before any roadmap.
+- "Just draft it" → draft a PRD whose first visible section lists the unanswered questions, with each unverified claim explicitly marked as an assumption.
+- "Make it sound better" → never. Ambiguity is signal, not a wording problem.
+
+## The five decision clusters
+
+Each cluster names a class of decision the PRD must capture explicitly. If a
+cluster is empty or vague, the PRD is not ready and the skill keeps interviewing.
+
+1. **Customer & Job** — who the customer is, the moment of struggle, the
+   progress they're trying to make, what triggers them today, and what holds
+   them back.
+2. **The Bet** — the diagnosis of what's actually going on, the crux
+   constraint, the opportunity size, and why this team is best suited to
+   take the bet now.
+3. **Assumptions, Hypotheses & Risks** — the leap-of-faith claims surfaced
+   for each of the four product risks (value, usability, feasibility,
+   business viability), each with its evidence, its invalidator, and the
+   cheapest test that could falsify it before code is written.
+4. **Success That Can Fail** — the observable signal that the user's job
+   was done, the primary outcome metric, the guardrails, and (mandatory)
+   the kill criterion.
+5. **Cost of Delay & Smallest Learnable Bet** — what waiting costs, the
+   smallest experiment that disambiguates the riskiest assumption, and an
+   explicit list of what we are *not* building.
+
+The full question bank for each cluster lives in
+[references/decision-forcing-questions.md](references/decision-forcing-questions.md).
+Quote from it directly when the PM is stuck.
+
+## Workflow
+
+### Phase 1 — Frame the bet
+
+Goal: get a real customer-and-job statement and a real diagnosis.
+
+Ask, in one batch:
+1. Who is the customer? Describe them by the problem they're in, not their job title or demographics.
+2. Walk me through the last time someone you know hit this problem. What were they doing, what triggered them to look for a solution, what did they try first, and what was frustrating about it?
+3. What is *actually going on* in this market or workflow? What's the underlying knot? (Not the symptom — the cause.)
+4. Of the things that make this hard, which one, if it relaxed, would unlock the rest?
+5. Why is this team uniquely able to act on this now?
+
+Gate: do not advance to Phase 2 until you can write a one-paragraph story
+naming a real moment of struggle, a one-sentence diagnosis of the underlying
+cause, and an "only we can" claim with at least one piece of evidence. If the
+PM cannot supply these, log them as open questions and proceed only on
+explicit user approval.
+
+### Phase 2 — Surface assumptions and define success
+
+Goal: make the leap-of-faith assumptions visible and define a kill criterion.
+
+For each of the four product risks (value, usability, feasibility, business
+viability):
+- Force at least one assumption stated as a falsifiable claim.
+- For each assumption, capture: supporting evidence, what would invalidate
+  it, and the cheapest test that could run *before* the team builds.
+
+Then force:
+- The observable user behavior that means the job was done (the "aha moment").
+- The primary outcome metric — exactly one.
+- The guardrail metrics that must not regress.
+- The **kill criterion**: what data would make us pull this back.
+- 30 / 60 / 90-day signals.
+
+Gate: do not advance to Phase 3 until every risk category has at least one
+assumption with an invalidator, and a kill criterion exists. A PRD with no
+condition under which the work would be killed is a wish-list, not a bet.
+
+### Phase 3 — Define the smallest learnable bet
+
+Goal: scope an MVP that resolves the riskiest assumption, not the smallest
+buildable thing.
+
+Force:
+- What does waiting another quarter cost us? (Customers, revenue, learning, optionality.)
+- Which assumption is riskiest? What is the smallest experiment that disambiguates it?
+- Is that experiment a build, a prototype, a concierge, a wizard-of-oz, or something else?
+- What are we explicitly *not* building, and why is now not the time?
+- What is the rollback path if the signal is bad?
+
+Gate: the MVP description must name the riskiest assumption and explain how
+the MVP tests it. "MVP = a smaller version of what we want to build
+eventually" is not sufficient.
+
+### Phase 4 — Draft the PRD
+
+Use [references/prd-template.md](references/prd-template.md). The order of
+sections is intentional: bet → customer in context → assumptions →
+success-and-kill criteria → smallest learnable bet → roadmap → GTM. The
+feature list is a *consequence* of the earlier sections, not the headline.
+
+Mark unresolved cells `OPEN QUESTION` and list them in the appendix. Never
+invent values. A PRD with five honest open questions is more useful than a
+PRD with thirty fabricated certainties.
+
+### Phase 5 — Review
+
+Present the draft. Ask, in this order:
+1. Does the diagnosis ring true? Is the crux right?
+2. Which assumption are you least sure about, and is its invalidator something we'd actually accept?
+3. If the kill criterion fired in 60 days, would we actually pull back? If not, the kill criterion is wrong.
+4. Is the smallest learnable bet really the smallest?
+
+Revise specific sections; do not rewrite for tone.
+
+### Phase 6 — Save
+
+Write to `product-docs/prds/active/<feature-name>-prd.md`. Create the
+directory if it doesn't exist.
+
+## Writing principles
+
+- **Diagnosis before solution.** Spend more words on what's actually going on
+  than on what we'll build. If the diagnosis is one line and the feature
+  list is two pages, the PRD is upside down.
+- **One bet per PRD.** A PRD with three bets is three PRDs. Split them.
+- **Every assumption has an invalidator.** If a claim has no condition under
+  which it could be wrong, it is not an assumption — it's faith.
+- **Specific over vague.** "Fast" → "loads in under 200 ms." "Better
+  retention" → "D30 retention from 28 % to 38 %."
+- **Out of scope is mandatory.** What we are *not* building is as
+  load-bearing as what we are.
+- **Kill criterion is mandatory.** If there is no result that would cause us
+  to pull this back, success is unfalsifiable.
+- **Unanswered is fine; fabricated is not.** Mark unknowns as
+  `OPEN QUESTION` and assign an owner. Never write a confident sentence
+  where you should write a question.
+- **Living document.** Version, last-updated date, change-log. A PRD that
+  never changes was never read.
+
+## References
+
+- [references/prd-template.md](references/prd-template.md) — full PRD template
+- [references/decision-forcing-questions.md](references/decision-forcing-questions.md) — question bank organized by decision cluster, with source attribution
+- [references/insights.md](references/insights.md) — synthesis of the underlying frameworks and source bibliography

--- a/skills/pm-prd/SKILL.md
+++ b/skills/pm-prd/SKILL.md
@@ -9,19 +9,11 @@ allowed-tools: bash
 Treat the PRD as a forcing function for decisions. Interview the PM until
 the bet is real, then capture answers and open questions.
 
-## Operating principles
+## Operating principle
 
-**Refuse to draft until the bet is real.** Conduct a gated interview across
-the six decision clusters below. Mark unresolved cells `OPEN QUESTION`
-rather than fabricating answers.
-
-**Use above everything (meta-gate).** Success must be expressible as
-*unprompted use*. A PRD whose definition of done would still be a win when
-shipped-but-unused is not a PRD.
-
-**Build before align, ship after learn.** Building is cheap, shipping
-is not. Vibe-code the Phase 2 artifact before articulating risks; decks
-and sign-offs sit downstream of evidence, not upstream.
+A successful product is one that gets used. Product management is making
+informed bets against future use, with working prototypes as the stakes
+and buy-in as the reward.
 
 Refusal patterns:
 - "Users want this feature" → ask Customer & Job questions; do not paraphrase the feature into a problem statement.

--- a/skills/pm-prd/references/decision-forcing-questions.md
+++ b/skills/pm-prd/references/decision-forcing-questions.md
@@ -182,6 +182,56 @@ deliver outcomes; the cultural shift is the harder part."
 
 ---
 
+## Discovery Artifact — designing the experiment
+
+> Building is now cheap; shipping is still expensive. Each Cluster 3
+> assumption — except those in the *what vibe coding cannot test* set
+> below — should be tested by a vibe-coded artifact before the PRD is
+> written. The artifact is a discovery instrument, not the product.
+
+### Choosing the form
+
+- Can the riskiest assumption be tested by a runnable artifact (web app, script, API stub, data pipeline) that could be vibe-coded in under one day?
+- If yes: vibe-code it. The artifact replaces wishful claims in the Cluster 3 *Cheapest test* column with actual observed behavior.
+- If no (hardware, regulated, compliance, network-effects-only-at-scale, on-prem deployment): fall back, in order, to concierge → wizard-of-oz → landing page → sales pitch.
+
+### Designing the experiment
+
+- For each Cluster 3 assumption, what observable user behavior in the artifact would invalidate the claim? Be specific — "they don't use it" is too vague; "5/5 fail to complete the primary action without prompting" is testable.
+- What is the minimum artifact that could surface that observable behavior? Strip everything else.
+- Who will see it — three to five named real customers, or the hardest internal critic of the bet? Neither one alone will produce honest signal.
+- What is the *what surprised me* log going to capture? If the answer is "we'll know when we see it", you will only see what you already expected.
+
+### Reading the artifact
+
+- For each assumption, did the artifact validate it (Y), refute it (N), partially address it (partial), or sit in the *cannot test* set (not testable)?
+- Three things must have surprised you. If nothing surprised, the artifact wasn't probing the right edge — redesign and re-run.
+- Distinguish "users smiled" from "users used unprompted." A polite reaction is not validation; unprompted return on day 2 is.
+
+### What vibe coding cannot test
+
+> A working artifact validated by five happy users does NOT validate the
+> following. Treat each as ship debt (Cluster 5), not as validated.
+
+- **Scale** — concurrent users, p95 latency under load, queue depth, tail behavior.
+- **Security** — attack surface, secrets handling, auth bypass, multi-tenant isolation, supply chain.
+- **Long-term retention** — anything beyond the artifact's observation window (typically <2 weeks).
+- **Network effects** — cold-start dynamics, marketplace liquidity, two-sided incentive alignment.
+- **Compliance / regulatory** — GDPR, HIPAA, SOC2, FedRAMP, accessibility (WCAG), regional law, financial reporting.
+- **Edge-case data** — Unicode pathologies, time zones, large file sizes, malformed inputs at scale.
+- **Operations & observability** — logging, metrics, alerting, on-call rotation, SLO budgets, change management.
+- **Billing & support** — refunds, dunning, fraud, dispute resolution, support escalation paths, knowledge-base coverage.
+
+For an assumption that falls into any of these categories, mark Cluster 3's *Artifact-validated?* column as **not testable** and move the validation work to Cluster 5's ship-debt list with a real owner and a real cost.
+
+### Test
+
+If the PRD doesn't link a runnable artifact (or a recorded concierge run), Cluster 3's *Artifact-validated?* column will be empty across the board, and the bet is being validated on vibes.
+
+**Sources**: Karpathy, Andrej. *Vibe Coding* (X.com, 2025-02-02) — "fully give in to the vibes, embrace exponentials, and forget that the code even exists." Huesler, Cedric. *Build first, then align* (Slack, AEM PM thread, 2026-04-29) — alignment is downstream of evidence, not upstream of it.
+
+---
+
 ## Cluster 4 — Success That Can Fail
 
 ### Observable behavior
@@ -229,20 +279,25 @@ meta-gate is Nuescheler's Helix design principles, captured 2024-11-04.
 
 ---
 
-## Cluster 5 — Cost of Delay & Smallest Learnable Bet
+## Cluster 5 — Cost of Delay & Smallest Shippable Bet
+
+> The discovery artifact (preceding section) already did the *learning*.
+> This cluster answers: given the artifact's evidence, what's the
+> smallest *shippable* version, and what new risks does shipping
+> introduce that the artifact did not test?
 
 ### Cost of delay
 
 - What does waiting another quarter cost us in customers, revenue, learning, or optionality?
 - Is the cost of delay linear, accelerating, or step-shaped (a window we miss)?
-- What is the cheapest unit of progress we can make this week?
+- What is the cheapest unit of progress we can ship this week?
 
-### Smallest learnable bet
+### Smallest shippable bet
 
-- Of the assumptions in Cluster 3, which is the riskiest right now?
-- What is the smallest experiment that disambiguates *that* assumption — not the smallest buildable thing?
-- Is the right form a build, a prototype, a concierge, a wizard-of-oz, a landing page, or a sales pitch?
-- What is the *learning goal*, stated as the question the experiment answers?
+- Of the assumptions the artifact validated, which one(s) make a shippable bet?
+- What is the smallest *shippable* version that captures the validated value at ship-quality? Not the artifact in production; not the artifact plus everything else.
+- What new risks does shipping introduce that the artifact did not test? List them as **ship debt** — see *what vibe coding cannot test* above.
+- For each ship-debt item: who owns paying it down, by when, and at what cost? Or — explicitly — is it being shipped as known risk?
 
 ### Sequencing & queues
 
@@ -252,18 +307,21 @@ meta-gate is Nuescheler's Helix design principles, captured 2024-11-04.
 
 ### Explicit deferrals
 
-- What are we explicitly *not* building in v1, and why is now not the time?
+- What are we explicitly *not* shipping in v1, and why is now not the time?
 - Which capabilities will be tempting to add mid-flight? What's our rule for resisting them?
 
 ### Test
 
-If "MVP" is "fewer features", this cluster is empty. The MVP must be the
-leanest experiment that disambiguates the riskiest assumption — and must
-explain *which* assumption.
+If "shippable bet" is "the artifact, in production", this cluster is empty.
+The shippable bet must (a) capture the artifact-validated value and (b)
+name the ship debt that shipping introduces, with owners.
 
 **Sources**: Reinertsen — *The Principles of Product Development Flow*
 (cost of delay, queues, batch size); Ries — *The Lean Startup* (MVP,
 build-measure-learn); Pichler — *Agile Product Management with Scrum*.
+The smallest-*shippable* (vs. learnable) framing follows from Karpathy +
+Huesler — the artifact does the learning, the shippable bet captures
+the value, and ship debt is what's left to pay before launch.
 
 ---
 
@@ -340,6 +398,10 @@ gain-sharing constraints (#11 + 2014-10-29 model).
 | "Pricing is sales' problem." | "Pricing is the willingness-to-pay shape of the bet. Which segment do we deliberately not serve at this price, and why?" |
 | "Success = launch." | "Use above everything: would we still call this a win if it shipped exactly as written but no customer used it on their own initiative?" |
 | "We'll requirement it as 'support feature X'." | "That's a Feature with no Function and no Outcome. Show me the proof of viability (demo / diagram) and the first-order quantified result." |
+| "We need an eng estimate first." | "The build estimate is for shipping. Vibe-code an artifact this afternoon to test the assumption — that's a different cost." |
+| "Let's spec it first." | "The spec emerges from the artifact. Build a discovery version, then write the spec around what it surprised you with." |
+| "The prototype validated it, ship it." | "The artifact tested value and usability. Did it test scale, security, retention, compliance, billing, or support? Those are ship debt — list them with owners." |
+| "We need cross-functional alignment first." | "Alignment is downstream of evidence. Show the artifact, then align." |
 
 ---
 
@@ -351,9 +413,11 @@ gain-sharing constraints (#11 + 2014-10-29 model).
 - Trieloff, Lars. *Eleven Pricing Aphorisms* (ProductCamp Berlin, 2014-09-13) and *Gain-Sharing Pricing Model* (Apple Notes, 2014-10-29). Pricing as a decision cluster: price-to-value, hard choices, segmentation ladder, disqualified defaults, gain-sharing constraints.
 - Trieloff, Lars. *Performance Culture* (CMS Summit, 2025). Source for the adoption / org-readiness risk axis: technology alone does not deliver outcomes; the organizational and cultural shift is the harder part.
 - Nuescheler, David. *Helix Design Principles* (captured 2024-11-04). Source for the "use above everything" meta-gate: usage trumps everything, including theoretical correctness.
+- Huesler, Cedric. *Build first, then align* (Slack, AEM PM thread, 2026-04-29). Source for the "build before align, ship after learn" operating principle: alignment artifacts (decks, sign-offs, SLC checklists) are downstream of the discovery artifact's evidence, not upstream of it.
 
 ### Canonical bibliography
 
+- Karpathy, Andrej. *Vibe Coding* (X.com, 2025-02-02). The frame for treating coding agents as a discovery instrument. Building becomes cheap; shipping remains expensive. Source for the Phase 2 vibe-coded artifact and for the *what vibe coding cannot test* set.
 - Cagan, Marty. *Inspired: How to Create Products Customers Love.*
 - Christensen, Clayton M., Taddy Hall, Karen Dillon, and David S. Duncan. *Competing Against Luck: The Story of Innovation and Customer Choice.*
 - Christensen, Clayton M. *The Innovator's Dilemma: When New Technologies Cause Great Firms to Fail.*

--- a/skills/pm-prd/references/decision-forcing-questions.md
+++ b/skills/pm-prd/references/decision-forcing-questions.md
@@ -1,0 +1,274 @@
+# Decision-Forcing Questions
+
+Question banks for each of the five decision clusters. Use these to
+interview the PM when the answers in a draft PRD are vague. Quote them
+directly when the user is stuck.
+
+The questions are paraphrased and grouped by decision cluster. Original
+sources are listed at the end of each section so the PM can read further.
+
+---
+
+## Cluster 1 — Customer & Job
+
+### Who, in context
+
+- Who exactly is the customer? Describe them by the problem and circumstance, not demographics or job title.
+- What progress are they trying to make — functionally, emotionally, and socially?
+- In what circumstance does the struggle show up? When, where, while doing what?
+- Who else is in the room when the struggle happens? What are they saying?
+
+### The trigger
+
+- What triggered them *today* to start looking for a solution?
+- What was the moment they said "Today is the day I'm going to do something about this"?
+- Was the trigger a one-time event, a slow build-up, or a recurring frustration?
+
+### The forces of progress
+
+- What is unacceptable about the situation today? (Push of the old.)
+- What is appealing about a different way? (Pull of the new.)
+- What worries them about switching? (Anxiety of the new.)
+- What is comfortable about staying put? (Habit of the present.)
+
+### The workaround
+
+- What are they doing today? Cobbling together which products?
+- What do they wish would just go away?
+- Where are they spending effort that creates no value for them?
+
+### Their measure of progress
+
+- In their own words, how would they know this got better?
+- What would they tell a friend they're now able to do?
+- What would they stop saying or doing if this worked?
+
+### Test
+
+If the PRD doesn't tell a one-paragraph "moment of struggle" story with a
+real person, a real time, and a real frustration, this cluster is empty.
+
+**Sources**: Christensen — *Competing Against Luck*; Ulwick — *Jobs to Be
+Done: Theory to Practice*; Moesta — *Demand-Side Sales 101*; Cagan —
+*Inspired*; Jiwa — *Meaningful*.
+
+---
+
+## Cluster 2 — The Bet
+
+### The diagnosis
+
+- What is *actually going on* in this market or workflow? What is the underlying knot?
+- Why has this not been solved already? What did previous attempts get wrong?
+- What is changing right now that makes this addressable when it wasn't before?
+- What are the competing solutions actually doing well? (Don't dismiss them — diagnose them.)
+
+### The crux
+
+- Of the things that make this hard, which one, if it relaxed, would unlock the rest?
+- What is the keystone constraint that, if broken, makes the rest tractable?
+- Are we sure the crux is real, or are we attacking a symptom?
+
+### The opportunity
+
+- Exactly what problem will this solve, and for whom, in what circumstance?
+- How big is the segment? How often does the job arise?
+- What are people willing to pay or do today to get this job done — even badly?
+- How will we measure that the opportunity is real?
+
+### Why us, why now
+
+- Why is *this* team uniquely able to act on this? What is our unfair advantage?
+- What window are we acting inside? What changes if we wait a year?
+- What can we do that competitors structurally cannot?
+- What would the most credible challenge to "we are the right team" sound like?
+
+### Coherent action
+
+- Which actions follow from this diagnosis?
+- Which possible actions are explicitly *not* part of our policy, even though they're tempting?
+- Are the actions reinforcing, or do they pull in different directions?
+
+### Test
+
+If "the bet" reduces to "users want this feature", this cluster is empty.
+A good bet names a diagnosis, a crux, an opportunity, and an unfair advantage.
+
+**Sources**: Rumelt — *Good Strategy / Bad Strategy* and *The Crux*; Cagan —
+*Inspired* (opportunity assessment); McGrath — *Product Strategy for High
+Technology Companies*; Reeves — *Building Products for the Enterprise*;
+Neumeier — *ZAG*.
+
+---
+
+## Cluster 3 — Assumptions, Hypotheses & Risks
+
+Use Cagan's four product risks to force at least one assumption per category.
+
+### Value risk — will customers buy or use this?
+
+- What is our specific, falsifiable claim about why customers will choose this over the alternatives (including "do nothing")?
+- What evidence do we have today that this is true?
+- What evidence would prove us wrong?
+- What is the cheapest experiment that could test it before we build code?
+- Are we testing a value hypothesis (does it deliver value when used?) or a growth hypothesis (will adoption spread?) — and is this PRD clear about which?
+
+### Usability risk — can users figure out how to use it?
+
+- What is the specific path the user must walk to get value? Is it discoverable, learnable, recoverable?
+- Where are users most likely to get stuck or drop off?
+- What evidence do we have that this path is intuitive — and what would prove it isn't?
+- What is the cheapest usability test we can run before building?
+
+### Feasibility risk — can our engineers build this with the time, skills, and tech we have?
+
+- What is technically novel about this, and what is well-trodden?
+- What unknowns about latency, scale, integrations, data, or compliance could blow up the schedule?
+- What spike or prototype could resolve the largest technical unknown in a week?
+- What would we ship if the hardest technical bet didn't work?
+
+### Business viability risk — does this work for our business?
+
+- Does this fit our business model, or does it require a new one?
+- What does sales, marketing, finance, legal, support, and partner functions need to have in place?
+- What pricing or packaging would make this economically rational? What would invalidate it?
+- What is the unit economics story, and where is it most fragile?
+
+### Cross-cutting questions for every assumption
+
+- Stated as a falsifiable claim, what is the assumption?
+- What evidence — actual evidence, not vibes — supports it today?
+- What specific, observable thing would invalidate it?
+- What is the cheapest experiment that could falsify it before we commit engineering resources?
+- Who owns the experiment, and by when does it deliver a verdict?
+
+### Test
+
+If every assumption reads as "we're confident", this cluster is empty.
+"Confident" is not an assumption — it's a claim that there is no risk, which
+is almost never true.
+
+**Sources**: Cagan — *Inspired* (four product risks); Ries — *The Lean
+Startup* (leap-of-faith assumptions, value vs growth hypothesis,
+build-measure-learn); Christensen — *The Innovator's Dilemma*.
+
+---
+
+## Cluster 4 — Success That Can Fail
+
+### Observable behavior
+
+- What user-visible behavior should we see in real usage data when this works?
+- What is the "aha moment" — the single observable signal that the job was actually done?
+- Which behavior, if absent, tells us users got the feature but not the value?
+
+### Metrics
+
+- What is the primary outcome metric — exactly one? Why this one?
+- What guardrail metrics must *not* regress for this work to count as a win?
+- Are these metrics measurable today? If not, what instrumentation has to ship before launch?
+
+### Time horizons
+
+- What does success look like at 30 days, 60 days, 90 days?
+- What signals at each horizon would distinguish "this is working" from "we got lucky" or "we got unlucky"?
+- What is the minimum useful sample size at each horizon? Will we have it?
+
+### The kill criterion
+
+- What data would cause us to pull this back?
+- If that data showed up in 60 days, would we *actually* pull back? If not, the kill criterion is wrong — pick one we'd actually honor.
+- Who has the authority to pull the kill?
+- What is the rollback plan, and what do we tell affected customers?
+
+### Learning even on failure
+
+- If we kill this, what will we know that we didn't know before?
+- Is the learning worth the cost of running the experiment, even if we fail?
+
+### Test
+
+A PRD with no condition under which the work would be killed is a wish-list,
+not a bet. If success is unfalsifiable, this cluster is empty.
+
+**Sources**: Olson — *The Product-Led Organization* (aha moment, observable
+usage); Reeves — *Building Products for the Enterprise* (rollout
+sequencing); Ulwick — *Jobs to Be Done: Theory to Practice* (outcomes); Ries
+— *The Lean Startup* (innovation accounting).
+
+---
+
+## Cluster 5 — Cost of Delay & Smallest Learnable Bet
+
+### Cost of delay
+
+- What does waiting another quarter cost us in customers, revenue, learning, or optionality?
+- Is the cost of delay linear, accelerating, or step-shaped (a window we miss)?
+- What is the cheapest unit of progress we can make this week?
+
+### Smallest learnable bet
+
+- Of the assumptions in Cluster 3, which is the riskiest right now?
+- What is the smallest experiment that disambiguates *that* assumption — not the smallest buildable thing?
+- Is the right form a build, a prototype, a concierge, a wizard-of-oz, a landing page, or a sales pitch?
+- What is the *learning goal*, stated as the question the experiment answers?
+
+### Sequencing & queues
+
+- Is this the highest-value thing this team can do right now? What did it displace from the queue?
+- What is the next bet in the queue if this one fires the kill criterion?
+- What batch size of work can ship this week? What's keeping us from shipping smaller?
+
+### Explicit deferrals
+
+- What are we explicitly *not* building in v1, and why is now not the time?
+- Which capabilities will be tempting to add mid-flight? What's our rule for resisting them?
+
+### Test
+
+If "MVP" is "fewer features", this cluster is empty. The MVP must be the
+leanest experiment that disambiguates the riskiest assumption — and must
+explain *which* assumption.
+
+**Sources**: Reinertsen — *The Principles of Product Development Flow*
+(cost of delay, queues, batch size); Ries — *The Lean Startup* (MVP,
+build-measure-learn); Pichler — *Agile Product Management with Scrum*.
+
+---
+
+## Quick reference — when the user gets stuck
+
+| If the PM says… | Quote back this question |
+|---|---|
+| "Users want this." | "Walk me through the last time someone you know hit this problem. What triggered them, what did they try first, and what was frustrating?" |
+| "Everyone needs this." | "Who is the first ten customers? Name them by problem and circumstance, not demographics." |
+| "It will improve retention." | "What user-visible behavior should we see in real usage data when this works? What's the aha moment?" |
+| "We're confident." | "Stated as a falsifiable claim, what is the assumption? What would invalidate it?" |
+| "We'll measure success." | "What is the primary outcome metric — exactly one? And what data would cause us to pull this back?" |
+| "MVP is just fewer features." | "Which assumption is riskiest? What is the smallest experiment that disambiguates *that* assumption?" |
+| "We don't have time to test it." | "What does waiting cost us? And what is the cheapest experiment that could run this week?" |
+| "Just draft it." | "I'll draft it — but every unverified claim will be marked as an assumption with an open invalidator. Is that OK?" |
+
+---
+
+## Bibliography
+
+- Cagan, Marty. *Inspired: How to Create Products Customers Love.*
+- Christensen, Clayton M., Taddy Hall, Karen Dillon, and David S. Duncan. *Competing Against Luck: The Story of Innovation and Customer Choice.*
+- Christensen, Clayton M. *The Innovator's Dilemma: When New Technologies Cause Great Firms to Fail.*
+- Eyal, Nir. *Hooked: How to Build Habit-Forming Products.*
+- Horowitz, Ben. *The Hard Thing About Hard Things.*
+- Jiwa, Bernadette. *Meaningful: The Story of Ideas That Fly.*
+- Lawley, Brian, and Pamela Schure. *42 Rules of Product Management* (2nd ed.).
+- McGrath, Michael E. *Product Strategy for High Technology Companies.*
+- Moesta, Bob, with Greg Engle. *Demand-Side Sales 101: Stop Selling and Help Your Customers Make Progress.*
+- Neumeier, Marty. *ZAG: The #1 Strategy of High-Performance Brands.*
+- Olson, Todd. *The Product-Led Organization: Drive Growth by Putting Product at the Center of Your Customer Experience.*
+- Pichler, Roman. *Agile Product Management with Scrum: Creating Products that Customers Love.*
+- Pragmatic Marketing. *Strategic Role of Product Management.*
+- Reeves, Blair, and Benjamin Gaines. *Building Products for the Enterprise: Product Management in Enterprise Software.*
+- Reinertsen, Donald G. *The Principles of Product Development Flow: Second Generation Lean Product Development.*
+- Ries, Eric. *The Lean Startup: How Today's Entrepreneurs Use Continuous Innovation to Create Radically Successful Businesses.*
+- Rumelt, Richard P. *Good Strategy / Bad Strategy: The Difference and Why It Matters.*
+- Rumelt, Richard P. *The Crux: How Leaders Become Strategists.*
+- Ulwick, Anthony W. *Jobs to Be Done: Theory to Practice.*

--- a/skills/pm-prd/references/decision-forcing-questions.md
+++ b/skills/pm-prd/references/decision-forcing-questions.md
@@ -1,12 +1,21 @@
 # Decision-Forcing Questions
 
-Question banks for each of the five decision clusters. Use these to
+Question banks for each of the six decision clusters. Use these to
 interview the PM when the answers in a draft PRD are vague. Quote the
 questions in this document directly when the user is stuck; do not quote
 the original sources verbatim.
 
 The questions are paraphrased and grouped by decision cluster. Original
 sources are listed at the end of each section so the PM can read further.
+
+**Meta-gate — "Use above everything" (Nuescheler)**
+
+Before any cluster passes review, ask:
+- Would we still call this a win if it shipped exactly as written but no
+  customer used it on their own initiative? If yes, the bet is not real.
+- Is the success metric in cluster 4 a *use* metric or a *ship* metric?
+- Does the aha moment require us to push, prompt, or notify the user — or
+  is it something they do unprompted?
 
 ---
 
@@ -104,7 +113,8 @@ Neumeier — *ZAG*.
 
 ## Cluster 3 — Assumptions, Hypotheses & Risks
 
-Use Cagan's four product risks to force at least one assumption per category.
+Use Cagan's four product risks **plus a fifth axis (adoption / org
+readiness)** to force at least one assumption per category.
 
 ### Value risk — will customers buy or use this?
 
@@ -132,8 +142,22 @@ Use Cagan's four product risks to force at least one assumption per category.
 
 - Does this fit our business model, or does it require a new one?
 - What does sales, marketing, finance, legal, support, and partner functions need to have in place?
-- What pricing or packaging would make this economically rational? What would invalidate it?
 - What is the unit economics story, and where is it most fragile?
+- *(Pricing decisions are their own cluster — see Cluster 6. Don't collapse them into a single B-row.)*
+
+### Adoption / Org-readiness risk — who has to change behavior post-launch?
+
+> Distinct from feasibility (engineering can build it) and business
+> viability (the company can sell it). Names the behavior shift required
+> on the customer side and inside our own org for the bet to pay off.
+> Technology alone does not deliver outcomes — the cultural shift is
+> usually the harder part.
+
+- Who has to change behavior for this to deliver the outcome — procurement, sales, support, ops, partners, the customer's IT, the customer's end users?
+- For each group: what specifically has to change, what's in it for them, and what is the cost of staying with the current behavior?
+- What evidence do we have that they actually will change, and what would invalidate that evidence?
+- What enablement is required — training, documentation, change management, incentive realignment? Who owns it, and is it staffed?
+- What second- and third-order effects of the new behavior could surprise us? (E.g. higher organic traffic that drops conversion rate because the new traffic doesn't come for the niche product.)
 
 ### Cross-cutting questions for every assumption
 
@@ -151,7 +175,10 @@ is almost never true.
 
 **Sources**: Cagan — *Inspired* (four product risks); Ries — *The Lean
 Startup* (leap-of-faith assumptions, value vs growth hypothesis,
-build-measure-learn); Christensen — *The Innovator's Dilemma*.
+build-measure-learn); Christensen — *The Innovator's Dilemma*. Adoption /
+org-readiness risk is added as a fifth axis from Trieloff,
+*Performance Culture* (CMS Summit 2025) — "technology alone doesn't
+deliver outcomes; the cultural shift is the harder part."
 
 ---
 
@@ -162,6 +189,8 @@ build-measure-learn); Christensen — *The Innovator's Dilemma*.
 - What user-visible behavior should we see in real usage data when this works?
 - What is the "aha moment" — the single observable signal that the job was actually done?
 - Which behavior, if absent, tells us users got the feature but not the value?
+- **Use above everything**: Is the aha moment something the customer does *on their own initiative*, or something we have to push, prompt, or notify them into?
+- If we removed every notification, banner, and email about this feature, would usage still grow? If no, we're measuring obedience, not value.
 
 ### Metrics
 
@@ -195,7 +224,8 @@ not a bet. If success is unfalsifiable, this cluster is empty.
 **Sources**: Olson — *The Product-Led Organization* (aha moment, observable
 usage); Reeves — *Building Products for the Enterprise* (rollout
 sequencing); Ulwick — *Jobs to Be Done: Theory to Practice* (outcomes); Ries
-— *The Lean Startup* (innovation accounting).
+— *The Lean Startup* (innovation accounting). The "use above everything"
+meta-gate is Nuescheler's Helix design principles, captured 2024-11-04.
 
 ---
 
@@ -237,6 +267,62 @@ build-measure-learn); Pichler — *Agile Product Management with Scrum*.
 
 ---
 
+## Cluster 6 — Pricing & Value Capture
+
+> Pricing is decision-forcing in the same shape as Rumelt's
+> diagnosis-crux-action: it requires hard choices and disqualifies
+> defaults. Collapsing it into a row in business-viability risk reduces
+> pricing to "fits our model y/n". The cluster-level question is: what's
+> the willingness-to-pay shape of this bet, and where does it break?
+
+### Price-to-value
+
+- What is the quantified outcome (from Cluster 4 and the Outcome column of section 7) that justifies the price?
+- Stated as one sentence: "[customer] pays [amount] because they get [outcome] worth [value]."
+- If we couldn't quantify the outcome, we cannot price to value. What's the experiment that would let us quantify it?
+
+### Hard choices
+
+- Which segment are we deliberately *not* serving at this price, and why is that the right trade?
+- Which feature(s) we could legitimately charge for separately, but won't — and why?
+- Where is the **point of diminishing returns** for the customer? Have we set the price *at* that point, or somewhere arbitrary?
+
+### Segmentation ladder
+
+- Customer pricing → segmentation → self-segmentation: which level are we at? What gets us to the next?
+- If tiered, what is the *self-segmenting* feature gate (a feature only the higher-need segment will care about), not just feature count or volume cap?
+- Are we accidentally training every customer to land on the lowest tier?
+
+### Disqualified defaults
+
+- Are we cost-plus (price = cost × markup)? If yes, redo from price-to-value.
+- Are we competition-minus (price = competitor − δ)? If yes, redo from price-to-value.
+- Are we "freemium" without a defined paid-upgrade trigger? If yes, define the trigger or drop the free tier.
+
+### Gain-sharing — only if all five are true
+
+- Is this an established solution (not a platform, not a v1 bet)?
+- Is the data we'd measure outcomes against *already in our system*?
+- Can we agree with the customer on the baseline before we start?
+- Is there a defined upside split (e.g. % of profit lift, % of revenue lift)?
+- Is there a price-tier-relief floor so the customer doesn't lose on the upside path?
+
+If any answer is no, gain-sharing is the wrong model right now.
+
+### Test
+
+If "pricing" reduces to "matches what competitors charge" or "covers our
+costs", this cluster is empty. The PRD is selling on price, not on value.
+
+**Sources**: Trieloff, *Eleven Pricing Aphorisms* (ProductCamp Berlin,
+2014-09-13) and *Gain-Sharing Pricing* (2014-10-29). Specific aphorisms
+referenced: price-to-value (#1), no-pricing-without-hard-choices (#10),
+customer-pricing → segmentation → self-segmentation (#8), point of
+diminishing returns (#9), cost-plus / competition-minus disqualified (#7),
+gain-sharing constraints (#11 + 2014-10-29 model).
+
+---
+
 ## Quick reference — when the user gets stuck
 
 | If the PM says… | Quote back this question |
@@ -249,10 +335,24 @@ build-measure-learn); Pichler — *Agile Product Management with Scrum*.
 | "MVP is just fewer features." | "Which assumption is riskiest? What is the smallest experiment that disambiguates *that* assumption?" |
 | "We don't have time to test it." | "What does waiting cost us? And what is the cheapest experiment that could run this week?" |
 | "Just draft it." | "I'll draft it — but every unverified claim will be marked as an assumption with an open invalidator. Is that OK?" |
+| "Engineering can build it." | "That's feasibility — fine. Who has to *change behavior* post-launch for the bet to pay off? That's adoption / org-readiness, a separate axis." |
+| "We'll just match the competitor's price." | "That's competition-minus, which is disqualified. What is the quantified outcome and what is it worth to the customer?" |
+| "Pricing is sales' problem." | "Pricing is the willingness-to-pay shape of the bet. Which segment do we deliberately not serve at this price, and why?" |
+| "Success = launch." | "Use above everything: would we still call this a win if it shipped exactly as written but no customer used it on their own initiative?" |
+| "We'll requirement it as 'support feature X'." | "That's a Feature with no Function and no Outcome. Show me the proof of viability (demo / diagram) and the first-order quantified result." |
 
 ---
 
 ## Bibliography
+
+### In-house frameworks
+
+- Trieloff, Lars. *FFOB — Feature / Function / Outcome / Benefits* (Apple Notes, 2014-06-17). Distinguishes Function (proof-of-viability — demo, diagram, screenshot) from Outcome (first-order quantifiable result), preventing the FAB→FFB collapse where "advantage" becomes a watered-down benefit.
+- Trieloff, Lars. *Eleven Pricing Aphorisms* (ProductCamp Berlin, 2014-09-13) and *Gain-Sharing Pricing Model* (Apple Notes, 2014-10-29). Pricing as a decision cluster: price-to-value, hard choices, segmentation ladder, disqualified defaults, gain-sharing constraints.
+- Trieloff, Lars. *Performance Culture* (CMS Summit, 2025). Source for the adoption / org-readiness risk axis: technology alone does not deliver outcomes; the organizational and cultural shift is the harder part.
+- Nuescheler, David. *Helix Design Principles* (captured 2024-11-04). Source for the "use above everything" meta-gate: usage trumps everything, including theoretical correctness.
+
+### Canonical bibliography
 
 - Cagan, Marty. *Inspired: How to Create Products Customers Love.*
 - Christensen, Clayton M., Taddy Hall, Karen Dillon, and David S. Duncan. *Competing Against Luck: The Story of Innovation and Customer Choice.*

--- a/skills/pm-prd/references/decision-forcing-questions.md
+++ b/skills/pm-prd/references/decision-forcing-questions.md
@@ -1,8 +1,9 @@
 # Decision-Forcing Questions
 
 Question banks for each of the five decision clusters. Use these to
-interview the PM when the answers in a draft PRD are vague. Quote them
-directly when the user is stuck.
+interview the PM when the answers in a draft PRD are vague. Quote the
+questions in this document directly when the user is stuck; do not quote
+the original sources verbatim.
 
 The questions are paraphrased and grouped by decision cluster. Original
 sources are listed at the end of each section so the PM can read further.

--- a/skills/pm-prd/references/insights.md
+++ b/skills/pm-prd/references/insights.md
@@ -2,12 +2,27 @@
 
 This skill is built on the conviction that a PRD is a forcing function for
 decisions, not a polished artifact. It is informed by recurring patterns
-across the canonical product-management bookshelf.
+across the canonical product-management bookshelf and four in-house
+frameworks.
 
-The synthesis below explains *why* the skill is structured around five
-decision clusters, and credits the frameworks each cluster draws from.
+The synthesis below explains *why* the skill is structured around six
+decision clusters and a "use above everything" meta-gate, and credits the
+frameworks each cluster draws from.
 
-## The five decision clusters and where they come from
+## The "use above everything" meta-gate
+
+Before any cluster passes review, the skill applies a meta-gate drawn from
+**Nuescheler's Helix design principles** (captured 2024-11-04): "Use above
+everything." A PRD whose success condition reduces to "shipped" is not a
+PRD. Every cluster must express success as observed *usage on the
+customer's own initiative*. If a draft would still be considered a win when
+shipped-but-unused, the bet is not real yet.
+
+This converts ship metrics, click-through rates on our own notifications,
+and adoption forced by rollout policy into red flags. The aha moment must
+be something the customer does without prompting from us.
+
+## The six decision clusters and where they come from
 
 ### Cluster 1 — Customer & Job
 
@@ -59,6 +74,15 @@ The core cognitive move of modern product work is making leaps of faith
   it out?), **feasibility risk** (can engineering build it?), and
   **business viability risk** (does it work for sales, marketing,
   finance, legal, support, partners?).
+- **Trieloff, *Performance Culture* (CMS Summit 2025)** — adds a fifth
+  axis: **adoption / org-readiness risk**. Technology alone does not
+  deliver outcomes. The behavior shift required of procurement, sales,
+  support, ops, partners, and the customer's own organization is a
+  distinct risk from feasibility (engineering can build it) and from
+  business viability (the company can sell it). The "fast-fashion site
+  case" — where moving from middling to high performance dropped
+  conversion rate because the new organic traffic didn't come for the
+  niche product — is a textbook example of adoption-risk surprise.
 - Ries (*The Lean Startup*) — **leap-of-faith assumptions** are
   identified explicitly and tested with the cheapest experiment that
   disambiguates them; **value hypothesis** vs **growth hypothesis** must
@@ -99,14 +123,67 @@ disambiguates the riskiest assumption.
 - Pichler (*Agile Product Management with Scrum*) — release plans and
   sprint goals are the operational unit of "smaller, sooner".
 
+### Cluster 6 — Pricing & Value Capture
+
+Pricing is decision-forcing in the same shape as Rumelt's
+diagnosis-crux-action: it requires hard choices and disqualifies defaults.
+Collapsing it into one row in business-viability risk reduces pricing to
+"fits our model y/n". The cluster-level question is the willingness-to-pay
+shape of the bet and where it breaks.
+
+- **Trieloff, *Eleven Pricing Aphorisms* (ProductCamp Berlin,
+  2014-09-13)** — price-to-value (#1); freemium is neither a word nor a
+  strategy (#2); the price list is the bad cop to the AE's good cop (#3);
+  start small to get a foot in the door (#4); be the filet mignon, not
+  the steak knife (#5); good pricing is data-driven (#6, #11);
+  cost-plus and competition-minus are a rock and a hard place (#7);
+  customer-pricing → segmentation → self-segmentation (#8); find the
+  point of diminishing returns and price to it (#9); no pricing without
+  hard choices (#10).
+- **Trieloff, *Gain-Sharing Pricing Model* (Apple Notes, 2014-10-29)** —
+  concrete model: 10 % of profit lift, 1 % of revenue lift, price-tier
+  relief on the upside, *only* for established solutions (not platforms),
+  *only* on data already in the system. Five operative rules, all
+  disqualifying.
+
+The cluster's load-bearing decisions: which segment we deliberately don't
+serve at this price, which adjacent feature we could legitimately charge
+for separately but won't, where the point of diminishing returns is, and
+which segmentation level (customer / segmentation / self-segmentation)
+we're operating at.
+
+### Requirements: FFOB
+
+Once the six clusters pass review, requirements render as **Feature →
+Function → Outcome → Benefits**, not as a flat capability list.
+
+- **Trieloff, *FFOB Framework* (Apple Notes, 2014-06-17)** —
+  - **Feature** is the short customer-facing name.
+  - **Function** is the proof of viability — demo, diagram, screenshot,
+    or one-line technical proof. *Skipping the Function column collapses
+    to FAB and lets "advantage" become a watered-down benefit.*
+  - **Outcome** is the first-order quantified result that solves the
+    customer's problem (what FAB calls "advantage", but with a clearer
+    name aligned to job-stories and product discovery).
+  - **Benefits** are higher-order, plural, stacking up through Maslow-
+    style chains toward wealth, power, or status.
+
+Function and Outcome are two distinct bridge pillars between Feature and
+Benefits — the "how" and the "and then". Both are load-bearing in
+high-technology products. Skipping either column produces a FAB-shaped
+requirements list that hides risk.
+
 ## How the workflow operationalises this
 
 The skill is structured as a gated interview:
 
 - **Phase 1** gates on a real Customer & Job and a real Bet (Clusters 1 and 2).
-- **Phase 2** gates on assumptions per risk + a kill criterion (Clusters 3 and 4).
+- **Phase 2** gates on assumptions per risk (5/5), a kill criterion measured in *use*, and the pricing shape (Clusters 3, 4, and 6).
 - **Phase 3** gates on the smallest learnable bet (Cluster 5).
-- **Phases 4–6** draft, review, and save.
+- **Phases 4–6** draft, review (with explicit "use above everything" + pricing-not-cost-plus checks), and save.
+
+The "use above everything" meta-gate runs across every phase: success that
+isn't measured in unprompted use is treated as success-theatre.
 
 The gates are the point. A PRD that is "polished" past empty clusters is
 worse than a PRD that names them as open. The whole skill is a refusal to
@@ -126,8 +203,27 @@ help the user feel finished before the team is actually informed.
   indicator before any roadmap.
 - "We're confident" — the skill rephrases as a falsifiable claim with an
   invalidator. "Confident" is not an assumption.
+- "Engineering can build it" — that's feasibility, fine; but the skill
+  separately demands an adoption / org-readiness assumption naming who
+  has to change behavior post-launch.
+- "Match the competitor's price" — competition-minus is disqualified;
+  the skill demands a price-to-value statement.
+- "Success = launch" — fails the "use above everything" meta-gate. The
+  skill demands an unprompted-use metric.
+- "Support feature X" as a requirement — that's a Feature with no
+  Function and no Outcome. The skill demands proof of viability and the
+  first-order quantified result.
 
 ## Bibliography
+
+### In-house frameworks
+
+- Trieloff, Lars. *FFOB — Feature / Function / Outcome / Benefits* (Apple Notes, 2014-06-17).
+- Trieloff, Lars. *Eleven Pricing Aphorisms* (ProductCamp Berlin, 2014-09-13) and *Gain-Sharing Pricing Model* (Apple Notes, 2014-10-29).
+- Trieloff, Lars. *Performance Culture* (CMS Summit, 2025).
+- Nuescheler, David. *Helix Design Principles — "Use above everything / Uptime / Simple, fast, reliable, secure / Less is more"* (captured 2024-11-04).
+
+### Canonical bibliography
 
 - Cagan, Marty. *Inspired: How to Create Products Customers Love.*
 - Christensen, Clayton M., Taddy Hall, Karen Dillon, and David S. Duncan. *Competing Against Luck.*

--- a/skills/pm-prd/references/insights.md
+++ b/skills/pm-prd/references/insights.md
@@ -22,6 +22,56 @@ This converts ship metrics, click-through rates on our own notifications,
 and adoption forced by rollout policy into red flags. The aha moment must
 be something the customer does without prompting from us.
 
+## The build-before-align, ship-after-learn principle
+
+A second principle, drawn from **Cedric Huesler's "build first, then
+align"** (Slack, AEM PM thread, 2026-04-29) and **Andrej Karpathy's
+*Vibe Coding*** (X.com, 2025-02-02), inverts the canonical bookshelf's
+implicit assumption that *building is expensive*.
+
+For most of product management's history, building was expensive — weeks
+of engineering time, queues, and hand-offs — and the canonical texts
+(Cagan, Ulwick, Ries, Christensen, Reinertsen) accordingly optimized the
+discovery process around *not building*. Concierge, wizard-of-oz,
+landing pages, and prototypes were a hierarchy of not-building, ordered
+by cost.
+
+Vibe coding inverts that economics. Building is now cheap — a working
+artifact is one afternoon away — while *shipping* (auth, billing, scale,
+security, support, compliance, ops) remains expensive. The skill
+therefore inserts **Phase 2: Build the discovery artifact** before risk
+articulation. The artifact is a discovery instrument, not the product.
+The act of building it surfaces assumptions the PM could not articulate
+alone, and gives Cluster 3 a real validation column instead of a
+wish-list of "cheapest tests".
+
+This produces three downstream consequences:
+
+1. **Cluster 5 is renamed** from *Smallest Learnable Bet* to
+   *Smallest Shippable Bet*. The discovery artifact already did the
+   learning; Cluster 5's job is to identify what shipping introduces
+   that the artifact did not test (ship debt) and what the smallest
+   shippable version of the validated value is.
+2. **Cluster 3's risk weights shift.** Cagan's feasibility risk ("can
+   engineering build it?") shrinks dramatically — the answer is
+   usually yes, by Tuesday. What replaces it is a *shipping* risk:
+   scale, security, retention >30 days, network effects, compliance,
+   ops. These remain off-limits to the artifact and become first-class
+   items in Cluster 5's ship-debt list.
+3. **Cross-functional alignment becomes downstream of evidence.**
+   Alignment artifacts (decks, sign-offs, SLC checklists) sit *after*
+   the artifact's evidence, not *before* it. Treating alignment as
+   upstream of evidence is the failure mode Huesler's principle
+   diagnoses: elaborate stakeholder rituals conducted on a bet that no
+   one has touched in any reality-checking way.
+
+The skill enforces this by refusing to draft the PRD until either (a) a
+runnable artifact exists with a *what surprised me* log of at least
+three items, or (b) the bet is explicitly in the not-vibe-codable set
+(hardware, regulated, network-effects-only-at-scale, on-prem) and a
+fallback discovery instrument (concierge, wizard-of-oz, landing page,
+sales pitch) has run.
+
 ## The six decision clusters and where they come from
 
 ### Cluster 1 — Customer & Job
@@ -108,20 +158,29 @@ criterion is the load-bearing element.
 - Ulwick (*Jobs to Be Done*) — the customer's outcome statements are
   the right unit of success, not internal feature deltas.
 
-### Cluster 5 — Cost of Delay & Smallest Learnable Bet
+### Cluster 5 — Cost of Delay & Smallest Shippable Bet
 
-"MVP" is widely abused to mean "the smallest thing the team can build
-quickly". The discipline is the opposite: the leanest experiment that
-disambiguates the riskiest assumption.
+The discovery artifact (Phase 2) already did the *learning*. This
+cluster answers: given the artifact's evidence, what is the smallest
+*shippable* version, and what risks does shipping introduce that the
+artifact could not test?
 
 - Reinertsen (*The Principles of Product Development Flow*) — **cost of
   delay** quantifies what waiting costs; **queues** and **batch size**
   govern how fast a team learns; small batches are economically
   superior under uncertainty.
-- Ries (*The Lean Startup*) — the MVP is defined by the *learning goal*,
-  not the feature set.
+- Ries (*The Lean Startup*) — the canonical MVP framing assumed
+  building was expensive; with vibe coding, the MVP becomes the
+  smallest *shippable* unit, while Ries's original learning purpose
+  moves upstream into the discovery artifact.
 - Pichler (*Agile Product Management with Scrum*) — release plans and
   sprint goals are the operational unit of "smaller, sooner".
+
+The cluster's load-bearing decisions: what was validated by the
+artifact, what's on the ship-debt list (scale, security, retention >30
+days, network effects, compliance, billing, support, ops, edge-case
+data), who owns paying it down, and what's explicitly not shipping in
+v1.
 
 ### Cluster 6 — Pricing & Value Capture
 
@@ -178,16 +237,21 @@ requirements list that hides risk.
 The skill is structured as a gated interview:
 
 - **Phase 1** gates on a real Customer & Job and a real Bet (Clusters 1 and 2).
-- **Phase 2** gates on assumptions per risk (5/5), a kill criterion measured in *use*, and the pricing shape (Clusters 3, 4, and 6).
-- **Phase 3** gates on the smallest learnable bet (Cluster 5).
-- **Phases 4–6** draft, review (with explicit "use above everything" + pricing-not-cost-plus checks), and save.
+- **Phase 2** gates on a runnable discovery artifact with a *what surprised me* log of at least three items — the build-before-align principle in operating form.
+- **Phase 3** gates on assumptions per risk (5/5), each with the artifact-validated column filled, a kill criterion measured in *use*, and the pricing shape (Clusters 3, 4, and 6).
+- **Phase 4** gates on the smallest *shippable* bet, naming the artifact-validated value and the ship debt that shipping introduces (Cluster 5).
+- **Phases 5–7** draft, review (with explicit "use above everything", pricing-not-cost-plus, and ship-debt checks), and save.
 
-The "use above everything" meta-gate runs across every phase: success that
-isn't measured in unprompted use is treated as success-theatre.
+The "use above everything" meta-gate runs across every phase: success
+that isn't measured in unprompted use is treated as success-theatre.
+The "build before align, ship after learn" principle runs alongside it:
+a PRD whose Cluster 3 was filled without an artifact's evidence is
+being validated on vibes.
 
-The gates are the point. A PRD that is "polished" past empty clusters is
-worse than a PRD that names them as open. The whole skill is a refusal to
-help the user feel finished before the team is actually informed.
+The gates are the point. A PRD that is "polished" past empty clusters
+or an empty Phase 2 is worse than a PRD that names them as open. The
+whole skill is a refusal to help the user feel finished before the
+team is actually informed.
 
 ## Anti-patterns the skill is specifically designed to refuse
 
@@ -213,6 +277,18 @@ help the user feel finished before the team is actually informed.
 - "Support feature X" as a requirement — that's a Feature with no
   Function and no Outcome. The skill demands proof of viability and the
   first-order quantified result.
+- "We need an eng estimate first" — the skill flips it: the eng
+  estimate is for *shipping*, not for learning. Vibe-code an artifact
+  this afternoon to test the assumption.
+- "We need cross-functional alignment first" — alignment is downstream
+  of evidence. The skill refuses to draft alignment-shape artifacts
+  until a discovery artifact exists.
+- "Five users said they liked it, ship it" — five happy users do not
+  validate scale, security, compliance, or retention. The skill
+  demands ship-debt items with owners.
+- "Let's spec it first" — the spec emerges from the artifact. The
+  skill refuses to write a forward-spec without the artifact's
+  surprises.
 
 ## Bibliography
 
@@ -222,9 +298,11 @@ help the user feel finished before the team is actually informed.
 - Trieloff, Lars. *Eleven Pricing Aphorisms* (ProductCamp Berlin, 2014-09-13) and *Gain-Sharing Pricing Model* (Apple Notes, 2014-10-29).
 - Trieloff, Lars. *Performance Culture* (CMS Summit, 2025).
 - Nuescheler, David. *Helix Design Principles — "Use above everything / Uptime / Simple, fast, reliable, secure / Less is more"* (captured 2024-11-04).
+- Huesler, Cedric. *Build first, then align* (Slack, AEM PM thread, 2026-04-29). Operating principle: alignment artifacts (decks, sign-offs, SLC checklists) sit downstream of the discovery artifact's evidence, not upstream of it.
 
 ### Canonical bibliography
 
+- Karpathy, Andrej. *Vibe Coding* (X.com, 2025-02-02). The frame for treating coding agents as a discovery instrument: building becomes cheap, shipping remains expensive.
 - Cagan, Marty. *Inspired: How to Create Products Customers Love.*
 - Christensen, Clayton M., Taddy Hall, Karen Dillon, and David S. Duncan. *Competing Against Luck.*
 - Christensen, Clayton M. *The Innovator's Dilemma.*

--- a/skills/pm-prd/references/insights.md
+++ b/skills/pm-prd/references/insights.md
@@ -1,0 +1,150 @@
+# Insights & Synthesis
+
+This skill is built on the conviction that a PRD is a forcing function for
+decisions, not a polished artifact. It is informed by recurring patterns
+across the canonical product-management bookshelf.
+
+The synthesis below explains *why* the skill is structured around five
+decision clusters, and credits the frameworks each cluster draws from.
+
+## The five decision clusters and where they come from
+
+### Cluster 1 — Customer & Job
+
+The most consistent failure mode in product work is naming a "user"
+abstractly and a "feature" concretely. The fix is to invert the order:
+name the *moment of struggle* concretely, and let the feature follow.
+
+- Christensen (*Competing Against Luck*) — customers don't buy products;
+  they hire them to make progress in specific circumstances.
+- Ulwick (*Jobs to Be Done: Theory to Practice*) — the customer's job has
+  functional, emotional, and social dimensions, and is measured by
+  *desired outcomes* the customer can articulate.
+- Moesta (*Demand-Side Sales 101*) — purchases are caused by four forces
+  (push of the situation, pull of the new, anxiety of the new, habit of
+  the present) and a specific trigger event.
+- Cagan (*Inspired*) — discovery is the work of distinguishing the right
+  problem from the right solution; "users want this" is not a problem
+  statement.
+- Jiwa (*Meaningful*) — the customer's *worldview* matters more than the
+  product feature set.
+
+### Cluster 2 — The Bet
+
+A PRD is, fundamentally, a wager about a market. The wager has to be made
+explicit or the team is gambling without knowing it.
+
+- Rumelt (*Good Strategy / Bad Strategy* and *The Crux*) — the kernel of
+  strategy is **diagnosis, guiding policy, coherent action**, with the
+  *crux* being the keystone constraint that, if relaxed, makes the rest
+  tractable. Most "strategy" documents skip the diagnosis.
+- Cagan (*Inspired*) — opportunity assessment forces the questions:
+  exactly what problem, for whom, how big, how to measure, what
+  alternatives, why us, how to market, what's critical, recommendation.
+- McGrath (*Product Strategy for High Technology Companies*) — the
+  market window and platform position determine which bets are even
+  available.
+- Reeves (*Building Products for the Enterprise*) — in B2B, the bet
+  also includes who buys, who deploys, who operates, and who renews.
+- Neumeier (*ZAG*) — the onliness statement: who, where, why, when —
+  and why no one else.
+
+### Cluster 3 — Assumptions, Hypotheses & Risks
+
+The core cognitive move of modern product work is making leaps of faith
+*visible* and *falsifiable* before committing engineering resources.
+
+- Cagan (*Inspired*) — every product faces four risks: **value risk**
+  (will customers buy or use this?), **usability risk** (can users figure
+  it out?), **feasibility risk** (can engineering build it?), and
+  **business viability risk** (does it work for sales, marketing,
+  finance, legal, support, partners?).
+- Ries (*The Lean Startup*) — **leap-of-faith assumptions** are
+  identified explicitly and tested with the cheapest experiment that
+  disambiguates them; **value hypothesis** vs **growth hypothesis** must
+  be distinguished.
+- Christensen (*The Innovator's Dilemma*) — incumbent assumptions about
+  who the customer is and what they value are exactly the assumptions
+  most likely to be wrong.
+
+### Cluster 4 — Success That Can Fail
+
+A success criterion that cannot fail is not a criterion. The kill
+criterion is the load-bearing element.
+
+- Olson (*The Product-Led Organization*) — the **aha moment** is the
+  observable user behavior that signals the job was actually done.
+  Without it, "engagement" is theatre.
+- Ries (*The Lean Startup*) — innovation accounting and the **pivot or
+  persevere** decision both require pre-committed metrics and pre-defined
+  thresholds.
+- Reeves (*Building Products for the Enterprise*) — rollout phases,
+  exit criteria, and rollback triggers turn one big bet into a sequence
+  of smaller, observable bets.
+- Ulwick (*Jobs to Be Done*) — the customer's outcome statements are
+  the right unit of success, not internal feature deltas.
+
+### Cluster 5 — Cost of Delay & Smallest Learnable Bet
+
+"MVP" is widely abused to mean "the smallest thing the team can build
+quickly". The discipline is the opposite: the leanest experiment that
+disambiguates the riskiest assumption.
+
+- Reinertsen (*The Principles of Product Development Flow*) — **cost of
+  delay** quantifies what waiting costs; **queues** and **batch size**
+  govern how fast a team learns; small batches are economically
+  superior under uncertainty.
+- Ries (*The Lean Startup*) — the MVP is defined by the *learning goal*,
+  not the feature set.
+- Pichler (*Agile Product Management with Scrum*) — release plans and
+  sprint goals are the operational unit of "smaller, sooner".
+
+## How the workflow operationalises this
+
+The skill is structured as a gated interview:
+
+- **Phase 1** gates on a real Customer & Job and a real Bet (Clusters 1 and 2).
+- **Phase 2** gates on assumptions per risk + a kill criterion (Clusters 3 and 4).
+- **Phase 3** gates on the smallest learnable bet (Cluster 5).
+- **Phases 4–6** draft, review, and save.
+
+The gates are the point. A PRD that is "polished" past empty clusters is
+worse than a PRD that names them as open. The whole skill is a refusal to
+help the user feel finished before the team is actually informed.
+
+## Anti-patterns the skill is specifically designed to refuse
+
+- "Just draft it" — the skill drafts, but every unverified claim is marked
+  as an assumption with an open invalidator. The user gets a draft *and*
+  the open questions, not a confidence-laundering exercise.
+- "Make it sound better" — wording is not the problem when the bet is
+  vague. The skill never re-words; it surfaces the underlying decision.
+- "Users want this feature" — the skill does not paraphrase the feature
+  into a problem statement. It asks the Cluster 1 questions until a real
+  moment of struggle exists.
+- "Improve retention" — the skill asks for the aha moment and the leading
+  indicator before any roadmap.
+- "We're confident" — the skill rephrases as a falsifiable claim with an
+  invalidator. "Confident" is not an assumption.
+
+## Bibliography
+
+- Cagan, Marty. *Inspired: How to Create Products Customers Love.*
+- Christensen, Clayton M., Taddy Hall, Karen Dillon, and David S. Duncan. *Competing Against Luck.*
+- Christensen, Clayton M. *The Innovator's Dilemma.*
+- Eyal, Nir. *Hooked.*
+- Horowitz, Ben. *The Hard Thing About Hard Things.*
+- Jiwa, Bernadette. *Meaningful.*
+- Lawley, Brian, and Pamela Schure. *42 Rules of Product Management.*
+- McGrath, Michael E. *Product Strategy for High Technology Companies.*
+- Moesta, Bob. *Demand-Side Sales 101.*
+- Neumeier, Marty. *ZAG.*
+- Olson, Todd. *The Product-Led Organization.*
+- Pichler, Roman. *Agile Product Management with Scrum.*
+- Pragmatic Marketing. *Strategic Role of Product Management.*
+- Reeves, Blair, and Benjamin Gaines. *Building Products for the Enterprise.*
+- Reinertsen, Donald G. *The Principles of Product Development Flow.*
+- Ries, Eric. *The Lean Startup.*
+- Rumelt, Richard P. *Good Strategy / Bad Strategy.*
+- Rumelt, Richard P. *The Crux.*
+- Ulwick, Anthony W. *Jobs to Be Done: Theory to Practice.*

--- a/skills/pm-prd/references/prd-template.md
+++ b/skills/pm-prd/references/prd-template.md
@@ -70,7 +70,7 @@ doing what, with what trigger, with what frustration.
 
 > Every claim has an invalidator and a cheapest test. Faith is not an assumption.
 
-For each of Cagan's four product risks, list at least one assumption.
+For each of the **five** product risks, list at least one assumption.
 
 ### Value risk — will customers buy or use this?
 
@@ -96,16 +96,31 @@ For each of Cagan's four product risks, list at least one assumption.
 |---|---|---|---|---|
 | B1 | | | | |
 
+### Adoption / Org-readiness risk — who has to change behavior post-launch?
+
+> Distinct from feasibility (eng can build) and viability (we can sell).
+> Names the procurement / sales / support / ops / partner / customer-side
+> behavior shift required for the bet to pay off. Technology alone does
+> not deliver outcomes; the cultural shift is usually the harder part.
+
+| # | Who must change behavior | What must change | Evidence they will | Invalidator | Enablement plan |
+|---|---|---|---|---|---|
+| A1 | | | | | |
+
 ---
 
 ## 4. Success That Can Fail
 
 > If there's no result that would cause us to abandon this work, the success
-> definition is unfalsifiable.
+> definition is unfalsifiable. **Use above everything**: success is measured
+> in unprompted use, not ship dates and not click-throughs on our own
+> notifications.
 
-**Aha moment** — the observable user behavior that signals the job was done.
+**Aha moment** — the observable user behavior that signals the job was done, performed *on the customer's own initiative*.
 
-**Primary outcome metric** — exactly one.
+**"Shipped but unused" check** — if this shipped exactly as written but no customer used it without being prompted by us, would we still call it a win? If yes, redo this section. (The answer should be no.)
+
+**Primary outcome metric** — exactly one. Must measure use, not ship.
 
 **Guardrail metrics** — must not regress.
 
@@ -176,22 +191,28 @@ revenue, learning, or optionality?
 
 ---
 
-## 7. Requirements
+## 7. Requirements (FFOB)
 
 > Listed *after* the bet, the customer, and the assumptions — because
 > requirements are a consequence of those, not the headline.
+>
+> Each requirement is structured as **Feature → Function → Outcome →
+> Benefits**. Skipping the Function column collapses to FAB and lets
+> "advantage" become a watered-down benefit; skipping the Outcome column
+> collapses to FFB and hides the first-order quantifiable result. Both
+> columns are load-bearing.
 
 ### Must-have (MVP blockers)
 
-| # | Requirement | Acceptance criterion | Tied to assumption |
-|---|---|---|---|
-| R1 | | | |
+| # | Feature | Function (proof of viability) | Outcome (first-order, quantified) | Benefits (higher-order, plural) | Acceptance | Tied to assumption |
+|---|---|---|---|---|---|---|
+| R1 | [short customer-facing name] | [demo / diagram / screenshot / 1-line technical proof] | [measurable result, e.g. "page loads ≤ 200 ms"] | [stack of higher-order desirables, e.g. better SEO → more organic traffic → more revenue] | [verifier] | [V1 / U1 / F1 / B1 / A1] |
 
 ### Should-have (v1.1+)
 
-| # | Requirement | Rationale for deferral |
-|---|---|---|
-| S1 | | |
+| # | Feature | Function | Outcome | Rationale for deferral |
+|---|---|---|---|---|
+| S1 | | | | |
 
 ### Won't-have (explicit out of scope)
 
@@ -199,7 +220,49 @@ revenue, learning, or optionality?
 
 ---
 
-## 8. Go-to-Market
+## 8. Pricing & Value Capture
+
+> Pricing is a decision cluster, not a footnote in business viability.
+> Cost-plus and competition-minus are explicitly disqualified. Force the
+> hard choices early; pricing without hard choices is a wish-list.
+
+**Price-to-value statement** — one sentence: "[customer] pays [amount / structure] because they get [quantified outcome from section 7] worth [value]."
+
+**Willingness-to-pay shape**
+
+| Segment | What they hire this to do | Willingness to pay (signal) | Where it breaks |
+|---|---|---|---|
+| | | | |
+
+**Hard choices**
+
+- Which segment are we deliberately *not* serving at this price, and why?
+- Which feature(s) we could charge for separately, but won't, and why?
+- Where is the point of diminishing returns — and is the price set there?
+
+**Pricing model** — choose and justify
+
+- [ ] Per-seat / per-user
+- [ ] Per-usage / metered (define the unit and why it tracks customer value)
+- [ ] Tiered (define the *self-segmenting* feature gate, not just feature count)
+- [ ] Flat / subscription
+- [ ] Outcome / gain-sharing — *only if* this is an established solution and the data is already in the system. Define the upside split and the floor.
+- [ ] Other: [specify]
+
+**Disqualified by default**
+
+- ❌ Cost-plus (price = cost × markup)
+- ❌ Competition-minus (price = competitor price - δ)
+- ❌ "Freemium" without a defined paid-upgrade trigger
+
+**Open pricing questions**
+
+| # | Question | Owner | Due |
+|---|---|---|---|
+
+---
+
+## 9. Go-to-Market
 
 ### Target segment
 

--- a/skills/pm-prd/references/prd-template.md
+++ b/skills/pm-prd/references/prd-template.md
@@ -66,35 +66,75 @@ doing what, with what trigger, with what frustration.
 
 ---
 
-## 3. Assumptions, Hypotheses & Risks
+## 3. Discovery Artifact
 
-> Every claim has an invalidator and a cheapest test. Faith is not an assumption.
+> Building is cheap; shipping is expensive. The artifact is a *discovery
+> instrument*, not the product. The act of building it surfaces
+> assumptions the PM could not articulate alone, and gives section 4 a
+> validation column instead of a wish-list.
+
+**Artifact** — link to the runnable thing (URL, repo, binary, recorded concierge run).
+
+**Form** — vibe-coded prototype / concierge / wizard-of-oz / landing page / sales pitch / other.
+
+**Built with** — coding agent or method (Cursor / Claude Code / Replit / v0 / Bolt / Lovable / Windsurf / hand-coded / non-code).
+
+**Time to build** — [hours / days].
+
+**Audience** — who saw it (3–5 real customers, or hardest internal critic). Names where possible.
+
+**What we expected they'd do** — one paragraph.
+
+**What surprised us** — minimum three items. If nothing surprised, the artifact wasn't probing the right edge.
+
+| # | What we expected | What actually happened | Implication for the bet |
+|---|---|---|---|
+| S1 | | | |
+| S2 | | | |
+| S3 | | | |
+
+**Assumptions the artifact validated** — list claim IDs from section 4.
+
+**Assumptions the artifact refuted or weakened** — list claim IDs from section 4.
+
+**Assumptions the artifact could not test** — list claim IDs that fall in the *what vibe coding cannot test* set (section 6).
+
+---
+
+## 4. Assumptions, Hypotheses & Risks
+
+> Every claim has an invalidator and a cheapest test. Faith is not an
+> assumption. The **Artifact-validated?** column links each claim back to
+> the discovery artifact (section 3): *Y* (the artifact tested it and the
+> claim held), *N* (the artifact tested it and refuted it), *partial*
+> (the artifact tested some of it), or *not testable* (the claim sits
+> in the *what vibe coding cannot test* set — see section 6).
 
 For each of the **five** product risks, list at least one assumption.
 
 ### Value risk — will customers buy or use this?
 
-| # | Claim | Evidence today | Invalidator | Cheapest test |
-|---|---|---|---|---|
-| V1 | [falsifiable claim] | [what we know] | [what would prove it wrong] | [experiment runnable before code] |
+| # | Claim | Evidence today | Invalidator | Cheapest test | Artifact-validated? |
+|---|---|---|---|---|---|
+| V1 | [falsifiable claim] | [what we know] | [what would prove it wrong] | [experiment runnable before code] | [Y / N / partial / not testable] |
 
 ### Usability risk — can users figure out how to use it?
 
-| # | Claim | Evidence today | Invalidator | Cheapest test |
-|---|---|---|---|---|
-| U1 | | | | |
+| # | Claim | Evidence today | Invalidator | Cheapest test | Artifact-validated? |
+|---|---|---|---|---|---|
+| U1 | | | | | |
 
 ### Feasibility risk — can our engineers build this with the time, skills, and tech we have?
 
-| # | Claim | Evidence today | Invalidator | Cheapest test |
-|---|---|---|---|---|
-| F1 | | | | |
+| # | Claim | Evidence today | Invalidator | Cheapest test | Artifact-validated? |
+|---|---|---|---|---|---|
+| F1 | | | | | |
 
 ### Business viability risk — does this work for sales, marketing, finance, legal, partners, support?
 
-| # | Claim | Evidence today | Invalidator | Cheapest test |
-|---|---|---|---|---|
-| B1 | | | | |
+| # | Claim | Evidence today | Invalidator | Cheapest test | Artifact-validated? |
+|---|---|---|---|---|---|
+| B1 | | | | | |
 
 ### Adoption / Org-readiness risk — who has to change behavior post-launch?
 
@@ -103,13 +143,13 @@ For each of the **five** product risks, list at least one assumption.
 > behavior shift required for the bet to pay off. Technology alone does
 > not deliver outcomes; the cultural shift is usually the harder part.
 
-| # | Who must change behavior | What must change | Evidence they will | Invalidator | Enablement plan |
-|---|---|---|---|---|---|
-| A1 | | | | | |
+| # | Who must change behavior | What must change | Evidence they will | Invalidator | Enablement plan | Artifact-validated? |
+|---|---|---|---|---|---|---|
+| A1 | | | | | | |
 
 ---
 
-## 4. Success That Can Fail
+## 5. Success That Can Fail
 
 > If there's no result that would cause us to abandon this work, the success
 > definition is unfalsifiable. **Use above everything**: success is measured
@@ -138,32 +178,45 @@ For each of the **five** product risks, list at least one assumption.
 
 ---
 
-## 5. The Smallest Learnable Bet (MVP)
+## 6. The Smallest Shippable Bet
 
-> The smallest experiment that disambiguates the riskiest assumption — not
-> the smallest buildable thing.
+> The discovery artifact (section 3) already did the *learning*. This
+> section answers: given the artifact's evidence, what's the smallest
+> *shippable* version, and what new risks does shipping introduce that
+> the artifact did not test?
 
-**Riskiest assumption** — name it (refer to a row in section 3).
+**Validated value to ship** — the assumption(s) the artifact validated, and the value those validations capture (refer to artifact-validated rows in section 4).
 
-**Why an MVP and not a prototype** — or vice versa. What form (build,
-prototype, concierge, wizard-of-oz, landing page, sales pitch) actually tests
-the assumption fastest?
+**Smallest shippable scope** — 2 to 3 sentences. The minimum that captures the validated value at ship-quality. Not the artifact in production; not the artifact plus everything else.
 
-**MVP definition** — 2 to 3 sentences describing the minimum viable scope.
+> **What vibe coding cannot test**: scale (concurrent users, p95 latency
+> under load), security (attack surface, secrets handling, auth bypass),
+> long-term retention (>30 days), network effects (cold-start dynamics),
+> compliance / regulatory, edge-case data, ops observability, billing /
+> refunds, support load. A working artifact validated by five happy
+> users does not validate any of these. Treat them as **ship debt** to
+> pay before going live, not as validated.
 
-**What the MVP tests, exactly** — the falsifiable claim it resolves.
+**Ship debt** — the work the artifact did *not* do that must be paid before launch (or accepted as known risk).
 
-**What we are explicitly NOT building in v1**
+| # | Ship-debt item | Why it must be paid (or accepted) | Owner | Due |
+|---|---|---|---|---|
+| SD1 | [scale / security / retention / compliance / billing / support / observability / other] | | | |
+| SD2 | | | | |
+| SD3 | | | | |
+
+**What we are explicitly NOT shipping in v1**
 
 - [Excluded item] — [why now is not the time]
 - [Excluded item] — [why now is not the time]
 
-**Cost of delay** — what does waiting another quarter cost us in customers,
-revenue, learning, or optionality?
+**Cost of delay** — what does waiting another quarter cost us in customers, revenue, learning, or optionality?
+
+**Rollback path** — how we pull back if the ship-debt items reveal unexpected risk in production.
 
 ---
 
-## 6. Roadmap
+## 7. Roadmap
 
 > Phases, not dates. Each phase has an entry point, exit criteria, and a
 > rollback trigger.
@@ -191,7 +244,7 @@ revenue, learning, or optionality?
 
 ---
 
-## 7. Requirements (FFOB)
+## 8. Requirements (FFOB)
 
 > Listed *after* the bet, the customer, and the assumptions — because
 > requirements are a consequence of those, not the headline.
@@ -206,7 +259,7 @@ revenue, learning, or optionality?
 
 | # | Feature | Function (proof of viability) | Outcome (first-order, quantified) | Benefits (higher-order, plural) | Acceptance | Tied to assumption |
 |---|---|---|---|---|---|---|
-| R1 | [short customer-facing name] | [demo / diagram / screenshot / 1-line technical proof] | [measurable result, e.g. "page loads ≤ 200 ms"] | [stack of higher-order desirables, e.g. better SEO → more organic traffic → more revenue] | [verifier] | [V1 / U1 / F1 / B1 / A1] |
+| R1 | [short customer-facing name] | [link to discovery artifact / demo / diagram / 1-line technical proof] | [measurable result, e.g. "page loads ≤ 200 ms"] | [stack of higher-order desirables, e.g. better SEO → more organic traffic → more revenue] | [verifier] | [V1 / U1 / F1 / B1 / A1] |
 
 ### Should-have (v1.1+)
 
@@ -220,13 +273,13 @@ revenue, learning, or optionality?
 
 ---
 
-## 8. Pricing & Value Capture
+## 9. Pricing & Value Capture
 
 > Pricing is a decision cluster, not a footnote in business viability.
 > Cost-plus and competition-minus are explicitly disqualified. Force the
 > hard choices early; pricing without hard choices is a wish-list.
 
-**Price-to-value statement** — one sentence: "[customer] pays [amount / structure] because they get [quantified outcome from section 7] worth [value]."
+**Price-to-value statement** — one sentence: "[customer] pays [amount / structure] because they get [quantified outcome from section 8] worth [value]."
 
 **Willingness-to-pay shape**
 
@@ -262,7 +315,7 @@ revenue, learning, or optionality?
 
 ---
 
-## 9. Go-to-Market
+## 10. Go-to-Market
 
 ### Target segment
 

--- a/skills/pm-prd/references/prd-template.md
+++ b/skills/pm-prd/references/prd-template.md
@@ -1,0 +1,257 @@
+# [Product / Feature Name] — PRD
+
+**Version**: 1.0
+**Status**: DRAFT
+**Author**: [Name]
+**Last Updated**: [Date]
+**Stakeholders**: [Names & roles]
+
+> Section order is intentional: the bet, the customer, and the assumptions
+> come *before* the feature list. Mark unresolved cells `OPEN QUESTION`
+> rather than fabricating answers.
+
+---
+
+## 1. The Bet
+
+> The diagnosis, the crux, the opportunity, and why now.
+
+**Diagnosis** — one paragraph. What is actually going on in this market or
+workflow? What is the underlying knot, not the symptom?
+
+**Crux** — one sentence. Of the things that make this hard, which single
+constraint, if relaxed, unlocks the rest?
+
+**Opportunity size** — populate concretely:
+
+| Dimension | Value | Source |
+|---|---|---|
+| Segment size | [N customers / users] | |
+| Frequency of the job | [per day / week / year] | |
+| Willingness to pay or switch | [signal] | |
+| Cost of the workaround today | [time / money / effort] | |
+
+**Why us, why now** — one paragraph. What is our unfair advantage, and what
+window are we acting inside?
+
+**Out of scope for this PRD** — what this PRD explicitly does NOT address.
+
+---
+
+## 2. The Customer in Context
+
+> A real human in a real moment, not a persona slide.
+
+**Moment of struggle** — a one-paragraph story. Who, when, where, while
+doing what, with what trigger, with what frustration.
+
+**The job they're hiring this product to do**
+
+- Functional progress: [what they're trying to accomplish]
+- Emotional progress: [how they want to feel]
+- Social progress: [how they want to be perceived]
+
+**Forces of progress**
+
+| Force | Description |
+|---|---|
+| Push of the situation | What about today is unacceptable? |
+| Pull of the new | What is appealing about a different solution? |
+| Anxiety of the new | What worries them about switching? |
+| Habit of the present | What is comfortable about the status quo? |
+
+**Workaround today** — what are they doing now? Cobbling together what?
+
+**How they measure success** — in their own words, not ours.
+
+---
+
+## 3. Assumptions, Hypotheses & Risks
+
+> Every claim has an invalidator and a cheapest test. Faith is not an assumption.
+
+For each of Cagan's four product risks, list at least one assumption.
+
+### Value risk — will customers buy or use this?
+
+| # | Claim | Evidence today | Invalidator | Cheapest test |
+|---|---|---|---|---|
+| V1 | [falsifiable claim] | [what we know] | [what would prove it wrong] | [experiment runnable before code] |
+
+### Usability risk — can users figure out how to use it?
+
+| # | Claim | Evidence today | Invalidator | Cheapest test |
+|---|---|---|---|---|
+| U1 | | | | |
+
+### Feasibility risk — can our engineers build this with the time, skills, and tech we have?
+
+| # | Claim | Evidence today | Invalidator | Cheapest test |
+|---|---|---|---|---|
+| F1 | | | | |
+
+### Business viability risk — does this work for sales, marketing, finance, legal, partners, support?
+
+| # | Claim | Evidence today | Invalidator | Cheapest test |
+|---|---|---|---|---|
+| B1 | | | | |
+
+---
+
+## 4. Success That Can Fail
+
+> If there's no result that would cause us to abandon this work, the success
+> definition is unfalsifiable.
+
+**Aha moment** — the observable user behavior that signals the job was done.
+
+**Primary outcome metric** — exactly one.
+
+**Guardrail metrics** — must not regress.
+
+**30 / 60 / 90-day signals**
+
+| Timeframe | Metric | Target | What it tells us |
+|---|---|---|---|
+| 30 days | | | |
+| 60 days | | | |
+| 90 days | | | |
+
+**Kill criterion** — *mandatory*. The data that would cause us to pull this back.
+
+**Rollback plan** — how we pull back, and what we tell affected customers.
+
+---
+
+## 5. The Smallest Learnable Bet (MVP)
+
+> The smallest experiment that disambiguates the riskiest assumption — not
+> the smallest buildable thing.
+
+**Riskiest assumption** — name it (refer to a row in section 3).
+
+**Why an MVP and not a prototype** — or vice versa. What form (build,
+prototype, concierge, wizard-of-oz, landing page, sales pitch) actually tests
+the assumption fastest?
+
+**MVP definition** — 2 to 3 sentences describing the minimum viable scope.
+
+**What the MVP tests, exactly** — the falsifiable claim it resolves.
+
+**What we are explicitly NOT building in v1**
+
+- [Excluded item] — [why now is not the time]
+- [Excluded item] — [why now is not the time]
+
+**Cost of delay** — what does waiting another quarter cost us in customers,
+revenue, learning, or optionality?
+
+---
+
+## 6. Roadmap
+
+> Phases, not dates. Each phase has an entry point, exit criteria, and a
+> rollback trigger.
+
+### Phase 1 — Validate
+
+**Scope**: [what's included]
+**Target users**: [internal / closed beta / N customers]
+**Exit criteria**: [the assumption that must be confirmed before Phase 2]
+**Rollback trigger**: [data that would cause us to pull back]
+
+### Phase 2 — Expand
+
+**Scope**: [what's included; what we learned from Phase 1]
+**Target users**: [feature flag %, segment]
+**Exit criteria**: [what must be true to move to Phase 3]
+**Rollback trigger**: [data that would cause us to pull back]
+
+### Phase 3 — Scale
+
+**Scope**: [polish, integrations, GA readiness]
+**Target users**: [full GA]
+**Exit criteria**: [GA launch criteria]
+**Rollback trigger**: [data that would cause us to pull back post-GA]
+
+---
+
+## 7. Requirements
+
+> Listed *after* the bet, the customer, and the assumptions — because
+> requirements are a consequence of those, not the headline.
+
+### Must-have (MVP blockers)
+
+| # | Requirement | Acceptance criterion | Tied to assumption |
+|---|---|---|---|
+| R1 | | | |
+
+### Should-have (v1.1+)
+
+| # | Requirement | Rationale for deferral |
+|---|---|---|
+| S1 | | |
+
+### Won't-have (explicit out of scope)
+
+- [Capability] — [why not now]
+
+---
+
+## 8. Go-to-Market
+
+### Target segment
+
+> Who are the first 10 customers or users? Describe by problem and
+> circumstance, not demographics.
+
+### Channel
+
+How does the segment find out?
+
+- [ ] In-product (in-app, onboarding flow)
+- [ ] Sales-led (AE outreach, demo)
+- [ ] Content (blog, SEO, social)
+- [ ] Partner-led
+- [ ] Other: [specify]
+
+### Message
+
+One sentence: what problem this solves, for whom, and what's now possible.
+
+*"[Product / feature] helps [user in circumstance] [solve problem] so they
+can [achieve outcome]."*
+
+### Launch motion
+
+- [ ] Internal dogfood → closed beta → GA
+- [ ] Big-bang public launch
+- [ ] Soft launch (no announcement)
+- [ ] Partner / co-marketing launch
+
+**Beta plan**: who's in beta, how they're selected, feedback mechanism.
+
+### Launch success metrics
+
+| Timeframe | Metric | Target |
+|---|---|---|
+| 30 days | | |
+| 60 days | | |
+| 90 days | | |
+
+---
+
+## Appendix
+
+### Open questions
+
+| # | Question | Owner | Due | Blocks which decision |
+|---|---|---|---|---|
+| Q1 | | | | |
+
+### Change log
+
+| Version | Date | Author | Changes |
+|---|---|---|---|
+| 1.0 | [Date] | [Name] | Initial draft |


### PR DESCRIPTION
Rewrites the `pm-prd` skill so the PRD is treated as a **forcing function for decisions**, not a polished artifact. The skill now interviews the PM until the bet is real, and refuses to draft until each of five decision clusters has provisional answers — drawing on the recurring patterns across the canonical product-management bookshelf.

Supersedes #57. Same skill name (`pm-prd`); different shape.

## What changes

- **`SKILL.md`** — replaces the five-pillar template-fill workflow with a 3-phase gated interview:
  1. Frame the bet (Customer & Job + Diagnosis & Crux)
  2. Surface assumptions per risk + define a *mandatory* kill criterion
  3. Define the smallest learnable bet (the experiment that disambiguates the riskiest assumption)
- Adds explicit **anti-polishing guardrails**. The skill refuses to paraphrase "users want this" into a problem statement, refuses to "make it sound better", and when asked to "just draft it" produces a draft whose first visible section is the open questions, with every unverified claim marked as an assumption.
- **`references/prd-template.md`** — restructured so The Bet, The Customer in Context, Assumptions & Risks, and Success That Can Fail (with kill criterion + rollback) come *before* the requirements list. Assumption tables have evidence / invalidator / cheapest-test columns. Roadmap phases have explicit rollback triggers.
- **`references/decision-forcing-questions.md`** *(new)* — paraphrased question banks organized by the five decision clusters, plus a "when the PM is stuck" quick reference. All questions are grouped and paraphrased; nothing is verbatim.
- **`references/insights.md`** *(new)* — synthesis and bibliography crediting the underlying frameworks.

## The five decision clusters

1. **Customer & Job** — moment of struggle, trigger, forces of progress, workaround, customer-stated outcomes.
2. **The Bet** — diagnosis, crux, opportunity size, why-us-why-now, coherent action.
3. **Assumptions, Hypotheses & Risks** — Cagan's four risks (value, usability, feasibility, business viability), each with falsifiable claim + evidence + invalidator + cheapest test.
4. **Success That Can Fail** — aha moment, primary metric, guardrails, **kill criterion**, 30/60/90-day signals, rollback plan.
5. **Cost of Delay & Smallest Learnable Bet** — what waiting costs, the leanest experiment that disambiguates the riskiest assumption, explicit deferrals.

## Frameworks credited

Cagan (*Inspired*), Christensen (*Competing Against Luck*; *The Innovator's Dilemma*), Ulwick (*Jobs to Be Done: Theory to Practice*), Moesta (*Demand-Side Sales 101*), Rumelt (*Good Strategy / Bad Strategy*; *The Crux*), Ries (*The Lean Startup*), Reinertsen (*Principles of Product Development Flow*), Olson (*The Product-Led Organization*), Reeves (*Building Products for the Enterprise*), Pichler (*Agile Product Management with Scrum*), McGrath (*Product Strategy for High Technology Companies*), Eyal (*Hooked*), Jiwa (*Meaningful*), Neumeier (*ZAG*), Horowitz (*The Hard Thing About Hard Things*), Lawley (*42 Rules of Product Management*), Pragmatic Marketing (*Strategic Role of Product Management*).

Full bibliography is in `skills/pm-prd/references/insights.md` and `references/decision-forcing-questions.md`.

## Why a new PR rather than commits on #57

The rewrite changes the operating principle of the skill (from "fill the template" to "gate on decision quality"), the file layout (adds two reference files), and the workflow (3-phase gated interview with explicit refusal patterns). It is cleanest to land it as a single coherent change, with #57 closeable on merge.

Original draft of the skill was contributed by **Shweta** (@dshweta091). This PR keeps the same skill name and same intent ("help PMs write a useful PRD") but reshapes it around decision-forcing questions surfaced from the broader literature.
