### PR TITLE
feat: declare rail icons for sprinkles

### DIFF
--- a/skills/llm-wiki/llm-wiki.shtml
+++ b/skills/llm-wiki/llm-wiki.shtml
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>LLM Wiki</title>
+<link rel="icon" href="book-open" />
 <style>
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/skills/presentations/templates/presentation.shtml
+++ b/skills/presentations/templates/presentation.shtml
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Presentation</title>
+  <link rel="icon" href="presentation" />
 
   <!-- reveal.js core CSS -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5/dist/reset.css">

--- a/skills/slicc-demo/slicc-demo.shtml
+++ b/skills/slicc-demo/slicc-demo.shtml
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>SLICC — An AI agent that lives in your browser</title>
+  <link rel="icon" href="ice-cream-cone" />
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/skills/strudel-music/sprinkle/strudel-music.shtml
+++ b/skills/strudel-music/sprinkle/strudel-music.shtml
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Strudel Music</title>
+  <link rel="icon" href="music" />
   <script src="https://unpkg.com/@strudel/web@1.3.0" onerror="document.getElementById('statusText').textContent='Failed to load Strudel library from unpkg';document.getElementById('statusText').classList.add('error-text');window.__strudelLoadFailed=true;"></script>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }


### PR DESCRIPTION
## Summary

Adopt the new SLICC per-sprinkle rail-icon hook ([ai-ecoverse/slicc#547](https://github.com/ai-ecoverse/slicc/pull/547)) so each sprinkle in this repo gets its own glyph in the sidebar instead of all four falling back to the same Sparkles default.

## Picks

| Sprinkle | Lucide name | Why |
|---|---|---|
| `strudel-music` | `music` | live-coded music — matches Strudel's purpose |
| `llm-wiki` | `book-open` | LLM-generated wiki content |
| `slicc-demo` | `ice-cream-cone` | leans into SLICC's ice-cream vocab (cone, scoop, lick, float) |
| `presentations` | `presentation` | reveal.js slide deck |

## What this does

The sprinkle renderer in SLICC reads `<link rel="icon">` from the `.shtml`'s `<head>` and renders the matching glyph in the rail. The `href` accepts:

1. a **Lucide kebab-case name** (used here, ~1500 icons)
2. a **VFS path** to an SVG (e.g. `/shared/sprinkles/foo/icon.svg`)
3. an **inline `<svg>` or `data:image/svg+xml;...` URL** for one-offs

If the spec is missing or unresolvable the rail falls back to the generic Sparkles glyph, so this is purely additive — older SLICC builds that don't yet recognize the hook simply ignore it.

## Verification

The SLICC PR has end-to-end live verification covering each path. Locally I confirmed all four chosen names exist in the Lucide registry. No behavioural changes to the sprinkles themselves; only one line of `<head>` markup added per sprinkle.
