### PR TITLE
fix(github): add issue create subcommand + document oauth-token auth

### DIFF
--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -30,8 +30,6 @@ git config github.token <YOUR_PAT>     # persisted across shells
 export GITHUB_TOKEN=<YOUR_PAT>          # session-scoped
 ```
 
-**AI attribution** — when running as an AI agent (`CLAUDECODE`, `CURSOR_AGENT`, etc.), mutating operations (`pr create/merge/comment/edit/close/review`, `issue create/edit/close/comment`, `vars set`, `release create/upload/delete`, `notifications read`) auto-trigger a device-flow auth via `as-a-bot-worker` so the action is attributed to the human user, not a bot account. The first such call prints a verification URL + code to stderr; the resulting token is cached at `/.cache/ai-aligned-gh/token`. Run `gh.jsh auth` to inspect status.
-
 **Repo defaults** — if you omit `owner/repo`, the script infers it from the current directory's `git remote get-url origin`. Pass it explicitly to override.
 
 ## Running the script

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -18,11 +18,19 @@ allowed_tools:
 
 ## Setup
 
-**Authentication** — store your PAT in git config:
+**Authentication** — preferred: use SLICC's OAuth provider:
 ```bash
-git config github.token <YOUR_PAT>
+export GITHUB_TOKEN=$(oauth-token github)
 ```
-Or set `GITHUB_TOKEN` as an environment variable. The token is read automatically on every invocation.
+This works out of the box for SLICC agents — no manual PAT needed. Run `oauth-token github` once interactively if not yet authorized.
+
+Alternatives (in precedence order: git config wins, then env var):
+```bash
+git config github.token <YOUR_PAT>     # persisted across shells
+export GITHUB_TOKEN=<YOUR_PAT>          # session-scoped
+```
+
+**AI attribution** — when running as an AI agent (`CLAUDECODE`, `CURSOR_AGENT`, etc.), mutating operations (`pr create/merge/comment/edit/close/review`, `issue create/edit/close/comment`, `vars set`, `release create/upload/delete`, `notifications read`) auto-trigger a device-flow auth via `as-a-bot-worker` so the action is attributed to the human user, not a bot account. The first such call prints a verification URL + code to stderr; the resulting token is cached at `/.cache/ai-aligned-gh/token`. Run `gh.jsh auth` to inspect status.
 
 **Repo defaults** — if you omit `owner/repo`, the script infers it from the current directory's `git remote get-url origin`. Pass it explicitly to override.
 
@@ -91,6 +99,15 @@ gh.jsh issue view 123
 gh.jsh issue view 123 owner/repo
 ```
 Shows title, author, URL, labels, body preview.
+
+**Create an issue**
+```bash
+gh.jsh issue create "Title" "Body text"
+gh.jsh issue create "Title" "Body text" --label=bug
+gh.jsh issue create "Title" "Body text" --label=bug --label=triage owner/repo
+gh.jsh issue create "Title" "Body text" --labels=bug,triage owner/repo
+```
+Returns the new issue number and URL. `--label=` may be repeated; `--labels=` accepts a comma-separated list. Title and body are required positional args; pass `""` for an empty body.
 
 ---
 

--- a/skills/github/scripts/gh.jsh
+++ b/skills/github/scripts/gh.jsh
@@ -361,6 +361,33 @@ async function issueList(args) {
   console.log(table(rows, [6, 62]));
 }
 
+// ─── issue create ────────────────────────────────────────────────────────────
+
+async function issueCreate(args) {
+  const labels = [];
+  const positional = [];
+  for (const a of args) {
+    if (a.startsWith('--label=')) labels.push(a.slice(8));
+    else if (a.startsWith('--labels=')) labels.push(...a.slice(9).split(',').map(s => s.trim()).filter(Boolean));
+    else positional.push(a);
+  }
+  if (!positional[0]) die('issue create: title required');
+  if (positional[1] === undefined) die('issue create: body required');
+  const [title, body] = positional;
+  const repo = await resolveRepo(positional[2]);
+
+  const payload = { title, body };
+  if (labels.length) payload.labels = labels;
+
+  try {
+    const res = await api(`/repos/${repo}/issues`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+    console.log(sym('success') + ' Created issue ' + C.cyan('#' + res.number) + ' — ' + res.html_url);
+  } catch (e) { fail('issue create', e); }
+}
+
 // ─── issue view ──────────────────────────────────────────────────────────────
 
 async function issueView(args) {
@@ -858,6 +885,7 @@ function showHelp() {
   console.log('  ' + C.cyan('pr checkout') + '   <num> [repo]                 Print checkout commands');
   console.log('  ' + C.cyan('issue list') + '    [repo]                       List open issues');
   console.log('  ' + C.cyan('issue view') + '    <num> [repo]                 View issue details');
+  console.log('  ' + C.cyan('issue create') + '  <title> <body> [--label=L]... [repo]  Create a new issue');
   console.log('  ' + C.cyan('repo view') + '     [repo]                       Show repository info');
   console.log('  ' + C.cyan('run list') + '      [repo]                       List recent workflow runs');
   console.log('  ' + C.cyan('run view') + '      <run_id> [repo]              View run details and jobs');
@@ -869,8 +897,9 @@ function showHelp() {
   console.log('  ' + C.cyan('notifications read') + '  [--repo=r]              Mark notifications as read');
   console.log('  ' + C.cyan('monday') + '            [--limit N] [--date Nd]    Monday protocol inbox (JSON)\n');
   console.log(C.bold('AUTH'));
-  console.log('  git config github.token <PAT>');
-  console.log('  — or: export GITHUB_TOKEN=<PAT>\n');
+  console.log('  export GITHUB_TOKEN=$(oauth-token github)   # preferred for SLICC agents');
+  console.log('  git config github.token <PAT>               # persistent PAT');
+  console.log('  export GITHUB_TOKEN=<PAT>                   # session PAT\n');
   console.log(C.bold('REPO'));
   console.log('  Defaults to current git remote origin. Pass owner/repo to override.');
 }
@@ -892,7 +921,7 @@ if (cmd === 'monday') { await mondayGh(argv.slice(2)); process.exit(0); }
 
 const dispatch = {
   pr:      { list: () => prList(rest),      view: () => prView(rest),    merge: () => prMerge(rest), comment: () => prComment(rest), checkout: () => prCheckout(rest) },
-  issue:   { list: () => issueList(rest),   view: () => issueView(rest) },
+  issue:   { list: () => issueList(rest),   view: () => issueView(rest), create: () => issueCreate(rest) },
   repo:    { view: () => repoView(rest) },
   run:     { list: () => runList(rest),     view: () => runView(rest) },
   release: { list: () => releaseList(rest) },

--- a/skills/github/scripts/gh.jsh
+++ b/skills/github/scripts/gh.jsh
@@ -364,20 +364,24 @@ async function issueList(args) {
 // ─── issue create ────────────────────────────────────────────────────────────
 
 async function issueCreate(args) {
-  const labels = [];
+  const usage = 'usage: gh issue create <title> <body> [--label=L]... [--labels=a,b] [repo]';
+  const labelSet = new Set();
   const positional = [];
   for (const a of args) {
-    if (a.startsWith('--label=')) labels.push(a.slice(8));
-    else if (a.startsWith('--labels=')) labels.push(...a.slice(9).split(',').map(s => s.trim()).filter(Boolean));
-    else positional.push(a);
+    if (a.startsWith('--label=')) {
+      const v = a.slice(8).trim();
+      if (v) labelSet.add(v);
+    } else if (a.startsWith('--labels=')) {
+      for (const v of a.slice(9).split(',').map(s => s.trim()).filter(Boolean)) labelSet.add(v);
+    } else positional.push(a);
   }
-  if (!positional[0]) die('issue create: title required');
-  if (positional[1] === undefined) die('issue create: body required');
+  if (!positional[0]) die('issue create: title required\n' + usage);
+  if (positional[1] === undefined) die('issue create: body required\n' + usage);
   const [title, body] = positional;
   const repo = await resolveRepo(positional[2]);
 
   const payload = { title, body };
-  if (labels.length) payload.labels = labels;
+  if (labelSet.size) payload.labels = [...labelSet];
 
   try {
     const res = await api(`/repos/${repo}/issues`, {
@@ -885,7 +889,7 @@ function showHelp() {
   console.log('  ' + C.cyan('pr checkout') + '   <num> [repo]                 Print checkout commands');
   console.log('  ' + C.cyan('issue list') + '    [repo]                       List open issues');
   console.log('  ' + C.cyan('issue view') + '    <num> [repo]                 View issue details');
-  console.log('  ' + C.cyan('issue create') + '  <title> <body> [--label=L]... [repo]  Create a new issue');
+  console.log('  ' + C.cyan('issue create') + '  <title> <body> [--label=L]... [--labels=a,b] [repo]  Create issue');
   console.log('  ' + C.cyan('repo view') + '     [repo]                       Show repository info');
   console.log('  ' + C.cyan('run list') + '      [repo]                       List recent workflow runs');
   console.log('  ' + C.cyan('run view') + '      <run_id> [repo]              View run details and jobs');


### PR DESCRIPTION
## Summary
- Adds `gh.jsh issue create <title> <body> [--label=L]... [--labels=a,b] [repo]` so agents can file issues without falling back to raw curl. Returns the new issue number and URL.
- Documents `oauth-token github` as the preferred auth path for SLICC agents in `SKILL.md` (alongside the existing PAT options) and surfaces it in `--help`.
- Documents the existing AI-attribution device flow that gates mutating ops, so agents discover it instead of going around it.

Closes #61.

## Test plan
- [ ] `gh.jsh --help` shows the new `issue create` line and updated AUTH block
- [ ] `gh.jsh issue create "Test title" "Test body" --label=bug ai-ecoverse/skills` creates an issue and prints `#N — URL`
- [ ] `gh.jsh issue create "T" "B"` (no repo) infers repo from `git remote get-url origin`
- [ ] Missing title or body errors out with a usage hint
- [ ] `--labels=a,b` and repeated `--label=a --label=b` both attach multiple labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)