### PR TITLE
fix(presentations): wire stardust + bespoke effects layer (closes #62)

### DIFF
--- a/skills/presentations/SKILL.md
+++ b/skills/presentations/SKILL.md
@@ -1,82 +1,44 @@
 ---
 name: presentations
-description: Create interactive reveal.js presentations as sprinkles, with bespoke per-brand visual design via stardust
+description: Create reveal.js slide decks as standalone HTML, with brand-aware theming and bespoke visual effects. Use when the user asks for slides, a slide deck, a slideshow, an HTML presentation, a pitch deck, conference talk, keynote, lightning talk, or "make a deck about X". Handles content discovery, narrative shape, theme generation (via the stardust design system when present), per-slide SVG/CSS/3D effects, export, and live edits.
 allowed-tools: bash
 ---
 
 # Presentations
 
-Create reveal.js slide decks as interactive SLICC sprinkles. Output is bespoke — never a templated preset. The skill leans on the **stardust** design system (when present) for distinctive, brand-aware visual direction; falls back to anchor moods otherwise. Every deck ships with the bespoke effects layer: SVG filters, CSS shader patterns, 3D animation. No bland AI-default look, ever.
+Output is bespoke, never templated. Slides render as a SLICC *sprinkle* — a standalone `.shtml` panel the harness opens and live-edits via the lick bridge. Brand-aware theming via Adobe's stardust design system when present (`references/stardust-setup.md`); anchor-mood fallback otherwise. The bespoke effects layer (SVG filters, CSS shaders, 3D animations) is mandatory in either mode.
 
-**Trigger phrases:** "create a presentation", "make slides", "build a deck", "presentation about X", "slide deck", "make a pitch deck"
+## Phase 0 — Stardust gate
 
-## Phase 0 — Stardust gate (run before discovery)
-
-Before generating anything, check for stardust artifacts. Stardust is the design system that drives bespoke per-brand visual direction. Without it, presentations risk looking templated.
-
-### 0.1 — Detect existing stardust output
-
-Look for these files at the project root, in priority order:
+Before discovery, check for stardust artifacts (drives brand-specific theming). Full detection + install detail in `references/stardust-setup.md`.
 
 ```bash
-test -f DESIGN.json   # impeccable/stardust target tokens (preferred)
-test -f DESIGN.md     # impeccable/stardust target design system
-test -f stardust/direction.md  # stardust direction trace
+test -f DESIGN.json && echo "stardust present"
 ```
 
-If `DESIGN.json` exists at the project root: **skip install prompts, go straight to Phase 2 with stardust-driven theme generation** (see `style-guide.md` § Stardust integration). Mention briefly to the user: "Found stardust DESIGN.json — generating theme from your brand tokens."
+- **`DESIGN.json` exists** → skip install, go to Phase 1. Mention "Found stardust DESIGN.json — generating theme from your brand tokens."
+- **stardust skill installed but no DESIGN.json** → ask "run `$stardust extract <url>` first, or skip to anchor-mood mode?"
+- **neither** → offer install via upskill / gh upskill / npx skills / Claude Code plugin marketplace (see `references/stardust-setup.md` for exact commands and `pbakaus/impeccable` dependency). If declined, proceed with anchor-mood mode — effects layer is still mandatory.
 
-### 0.2 — Detect installed stardust skill
+## Phase 1 — Content & narrative discovery
 
-If no DESIGN.json exists, check whether the stardust *skill* is installed:
+Conversational. Skip questions the user already answered.
 
-```bash
-# Common skill install paths the SLICC/Claude Code harness uses
-ls .claude/skills/stardust/SKILL.md  ~/.claude/skills/stardust/SKILL.md \
-   .agents/skills/stardust/SKILL.md  .cursor/skills/stardust/SKILL.md \
-   plugins/stardust/skills/stardust/SKILL.md 2>/dev/null
-```
-
-If installed: tell the user "stardust is installed — want me to run `$stardust extract <url>` first to capture brand surface, or proceed with anchor-mood themes?" and act on the answer. Stardust extract → direct → DESIGN.json gives the strongest result; skipping it just means anchor-mood mode.
-
-### 0.3 — Offer to install stardust
-
-If stardust is not installed AND no DESIGN.json exists, ask the user if they'd like to install it. Present these four install methods (pick whichever matches their harness):
-
-| Method | Command | When |
-|--------|---------|------|
-| **Claude Code plugin (built-in)** | `/plugin marketplace add adobe/skills` then `/plugin install stardust@adobe-skills` | Running inside Claude Code. User runs the slash commands themselves. |
-| **upskill (SLICC native)** | `upskill adobe/skills --skill stardust` | SLICC harness with the `upskill` CLI installed. |
-| **gh upskill (extension)** | `gh upskill adobe/skills --skill stardust` | User has `trieloff/gh-upskill` gh extension installed. |
-| **npx skills (Vercel)** | `npx skills add adobe/skills --skill stardust` | Generic — works anywhere npx runs. |
-
-Phrase the offer concisely. Example:
-
-> "Want me to install stardust first? It's Adobe's design system for brand-aware visual direction — without it, presentations fall back to anchor moods (still distinctive, but not specific to your brand). Install options:
->
-> 1. **Claude Code (built-in):** run `/plugin marketplace add adobe/skills` then `/plugin install stardust@adobe-skills`
-> 2. **upskill:** `upskill adobe/skills --skill stardust`
-> 3. **gh upskill:** `gh upskill adobe/skills --skill stardust`
-> 4. **npx skills:** `npx skills add adobe/skills --skill stardust`
->
-> Or skip and use anchor-mood mode."
-
-If the user picks 2, 3, or 4, run the command via bash. If they pick 1, print the slash commands for them to run (skills can't invoke slash commands). If they decline, proceed with anchor-mood mode — still applies the bespoke effects layer.
-
-Stardust itself depends on **impeccable** (`pbakaus/impeccable`). If you install stardust, also offer to install impeccable the same way. Without impeccable, stardust will refuse to run and the user will hit a wall on first invocation. After install, stardust normally needs `$stardust extract <url>` and `$stardust direct` before DESIGN.json appears — surface that step explicitly.
-
-## Phase 1 — Content Discovery
-
-Gather requirements through quick questions. Skip questions the user already answered:
-
-1. **Purpose** — pitch, teaching, conference talk, internal update, workshop
+1. **Purpose** — pitch, teaching, conference talk, internal update, workshop, retrospective, post-mortem
 2. **Length** — 5–10 slides, 10–20, 20+
 3. **Content readiness** — ready content, or just a topic?
-4. **Brand context** — only if stardust is NOT in play: "any brand or URL this should evoke?" (a yes opens the door to running stardust)
+4. **Narrative shape** — pick from `references/storytelling.md`. Default by purpose:
+   - Keynote, founder story, mission talk, education → **Hero's Journey** (Campbell)
+   - Pitch, persuasion, vision talk, change initiative → **Sparkline / contrast** (Duarte)
+   - Retrospective, post-mortem, lessons-learned → **Man-in-Hole** (Vonnegut)
+   - Product launch, success story → **Cinderella** (Vonnegut)
+   - Wake-up call, pre-mortem, risk talk → **From Bad to Worse** (Vonnegut)
+   - Technical deep-dive with no narrative arc → no shape, just structure
+5. **Brand context** (only if no stardust) — "any brand or URL this should evoke?" (a yes opens the door to running stardust)
 
-Keep discovery conversational. If the user gives a clear brief ("10-slide pitch deck about our Q3 results"), skip redundant questions.
+If the user gives a clear brief ("10-slide pitch deck about our Q3 results"), pick the shape from purpose without asking.
 
-## Phase 2 — Style Discovery
+## Phase 2 — Style discovery
 
 Read the style guide:
 
@@ -84,54 +46,37 @@ Read the style guide:
 read_file /workspace/skills/presentations/style-guide.md
 ```
 
-### When stardust artifacts exist (DESIGN.json at project root)
+- **Stardust mode** — generate theme CSS dynamically from `DESIGN.json` per `style-guide.md` § *Stardust integration*. Show ONE preview slide.
+- **Anchor-mood mode** — pick from `style-guide.md` § *Anchor moods* (8 starting points). Show 1–2 sample title slides as inline shtml cards. Let the user pick.
 
-Generate theme CSS dynamically from `DESIGN.json` tokens. The `style-guide.md` § *Stardust integration* section is the spec — follow it strictly:
+Either way, layer the bespoke effects (SVG filters, CSS shaders, 3D animations) per `style-guide.md` § *Bespoke effects layer*.
 
-- Map `colors.<role>` → `--r-background-color`, `--r-main-color`, `--r-heading-color`, `--r-accent-color`
-- Map `typography.<headingRole>.fontFamily` + `.fontSize` → `--r-heading-font`, heading scale
-- Map `typography.<bodyRole>.fontFamily` → `--r-main-font`
-- Pull `extensions.divergence.font_deck` for the @import URL
-- Honor `extensions.divergence.seed.ground_family` — it dictates whether the deck is dark, cream, saturated, etc.
-- Layer the **bespoke effects** (SVG filters, shaders, 3D) keyed to the seed's `craft` tradition (letterpress → ink-bleed displacement; Riso → off-register dual-color; terrazzo → speckled radial; folded-paper → fold shadows).
-
-Show ONE preview slide as an inline shtml card so the user can see the brand-derived theme. No "pick a preset" question — there is no preset.
-
-### When no stardust artifacts (anchor-mood mode)
-
-Pick an **anchor mood** from `style-guide.md` § *Anchor moods*. There are 8, and each is a *starting point*, not a finished design. Mandatory: layer the bespoke effects on top. Show 1–2 sample title slides as inline shtml cards with different moods. Let the user pick or ask for adjustments.
-
-### Hard rules — no matter the mode
-
-- **No bland output.** If a draft slide looks like a reveal.js default with nicer fonts, it has failed. Discard and retry.
-- **No banned fonts.** Inter, Roboto, Arial, Helvetica, Open Sans, system-ui as primary heading or body face. Period.
-- **No safe palettes.** No "navy + accent blue + white." No corporate gray-on-white. No generic gradient-on-white hero.
-- **Effects layer is mandatory.** Every deck applies at least one SVG filter primitive AND one of {3D entrance, animated mask/clip, mix-blend layer, scanline/grain overlay} per the rules in `style-guide.md` § *Bespoke effects layer*.
-
-## Phase 3 — Create the Presentation
+## Phase 3 — Create the presentation
 
 ### Scoop workflow
 
 One scoop per presentation. The scoop owns the sprinkle and stays alive for edits.
 
-**Creating:**
 ```
 scoop_scoop("quarterly-review")
 feed_scoop("quarterly-review", "You own the sprinkle 'quarterly-review'. Your job:
 1. Read style guide: read_file /workspace/skills/presentations/style-guide.md
 2. Read brand tokens if present: read_file DESIGN.json (skip if missing)
-3. Create the .shtml file at /shared/sprinkles/quarterly-review/quarterly-review.shtml using the template from /workspace/skills/presentations/templates/presentation.shtml
-4. Run: sprinkle open quarterly-review
-5. Push initial content: sprinkle send quarterly-review '<slide-data-json>'
-6. Stay alive — wait for lick events. Do NOT exit while the sprinkle is open.")
+3. Read narrative reference: read_file /workspace/skills/presentations/references/storytelling.md
+4. Compose slides against the chosen narrative shape.
+5. Write the .shtml file at /shared/sprinkles/quarterly-review/quarterly-review.shtml using the template from /workspace/skills/presentations/templates/presentation.shtml
+6. Verify: test -f /shared/sprinkles/quarterly-review/quarterly-review.shtml — abort if missing.
+7. Run: sprinkle open quarterly-review — confirm it reports open before pushing.
+8. Push initial content: sprinkle send quarterly-review '<slide-data-json>'
+9. Stay alive — wait for lick events. Do NOT exit while the sprinkle is open.")
 ```
 
-**The scoop must:**
-- Write the `.shtml` to `/shared/sprinkles/<name>/<name>.shtml`
-- Open it with `sprinkle open <name>`
-- Push slide content via `sprinkle send <name> '<json>'`
-- Listen for lick events and respond
-- **Never exit** while the sprinkle is open
+### Validation checkpoints (mandatory)
+
+- **After writing the .shtml**: `test -f <path>` — abort and re-write if missing.
+- **After `sprinkle open`**: confirm the call returned without error before sending data. If open fails, surface the error to the user — don't retry blindly.
+- **After `sprinkle send`**: if the harness reports a JSON parse error, validate the JSON locally (`echo '<json>' | jq .`) before re-sending.
+- **On theme change**: verify `themeCSS` is non-empty before pushing the update — an empty themeCSS triggers the dark/light fallback.
 
 ### Reveal.js CDN
 
@@ -148,12 +93,12 @@ Push slide content via `sprinkle send <name> '<json>'`:
 ```json
 {
   "slides": [
-    {"type": "title", "title": "...", "subtitle": "...", "background": "#hex", "effects": ["aurora-bg", "displaced-heading"]},
-    {"type": "section", "title": "...", "subtitle": "...", "effects": ["3d-flip-in"]},
-    {"type": "content", "title": "...", "bullets": ["..."], "notes": "speaker notes", "effects": ["mix-blend-headings"]},
-    {"type": "code", "title": "...", "code": "...", "language": "js", "effects": ["scanlines"]},
-    {"type": "quote", "quote": "...", "attribution": "...", "background": "#hex", "effects": ["chromatic-aberration"]},
-    {"type": "image", "title": "...", "src": "url-or-description", "alt": "...", "effects": ["holographic"]}
+    {"type": "title", "title": "...", "subtitle": "...", "background": "#hex", "effects": ["effect-aurora-bg", "effect-displaced-heading"]},
+    {"type": "section", "title": "...", "subtitle": "...", "effects": ["effect-3d-flip-in"]},
+    {"type": "content", "title": "...", "bullets": ["..."], "notes": "speaker notes", "effects": ["effect-mix-blend-headings"]},
+    {"type": "code", "title": "...", "code": "...", "language": "js", "effects": ["effect-scanlines"]},
+    {"type": "quote", "quote": "...", "attribution": "...", "background": "#hex", "effects": ["effect-chromatic-aberration"]},
+    {"type": "image", "title": "...", "src": "url-or-description", "alt": "...", "effects": ["effect-holographic"]}
   ],
   "theme": "stardust-derived",
   "themeCSS": "@import url(...); :root { ... } /* full theme CSS */",
@@ -161,20 +106,20 @@ Push slide content via `sprinkle send <name> '<json>'`:
 }
 ```
 
-The `effects` array is per-slide — values are CSS class hooks the template applies. See `style-guide.md` § *Effects vocabulary* for the full list.
+`effects` is per-slide — values are CSS class hooks the template applies. Renderer validates against `/^effect-[a-z0-9-]+$/`. Full vocabulary in `style-guide.md` § *Effects vocabulary*.
 
 Send the full slides array on every update — the sprinkle replaces all content on each push.
 
-## Handling Lick Events
+## Lick events
 
-The sprinkle emits lick events via `slicc.lick({action, data})`. Handle these:
+The sprinkle emits `slicc.lick({action, data})`. Handle:
 
 | Action | Data | Response |
 |--------|------|----------|
 | `edit-slide` | `{index, content}` | Ask user what to change, regenerate that slide, push full deck |
 | `add-slide` | `{afterIndex}` | Generate new slide, insert, push full deck |
 | `delete-slide` | `{index}` | Remove slide, push full deck |
-| `change-theme` | `{theme}` | Update theme in data — regenerate from DESIGN.json (or pick a different anchor mood), push full deck |
+| `change-theme` | `{theme}` | Regenerate from DESIGN.json or pick a different anchor mood, push full deck |
 | `export-html` | `{}` | Write standalone HTML to VFS, tell user the path |
 
 **Modifying via cone:**
@@ -182,25 +127,33 @@ The sprinkle emits lick events via `slicc.lick({action, data})`. Handle these:
 feed_scoop("quarterly-review", "Lick event on YOUR sprinkle: Action: 'edit-slide', data: {index: 2, instruction: 'Make it more concise'}. Update slide 2 and push the full deck.")
 ```
 
-## Content Density Limits
-
-Each slide type has strict content limits. Overfull slides look terrible at any viewport size — and the bespoke effects amplify that. Sparse beats clever every time.
+## Content density limits
 
 | Slide Type | Max Content |
-|-----------|-------------|
+|---|---|
 | **Title** | 1 heading + 1 subtitle |
 | **Content** | 1 heading + 4–6 bullets OR 2 short paragraphs |
 | **Code** | 1 heading + 8–10 lines of code |
 | **Quote** | 1 quote (max 3 lines) + attribution |
 | **Image** | 1 heading + 1 image |
 
-If content exceeds these limits, split into multiple slides.
+If content exceeds these limits, split into multiple slides. Sparse beats clever.
 
-## Design Principles (enforce on every slide)
+## Hard rules (single source of truth)
+
+These are the only rules the skill enforces. The style guide elaborates; this list governs.
 
 1. **Bespoke over preset.** Stardust drives uniqueness when present. Anchor moods are starting positions, not finished designs.
-2. **Distinctive typography.** Banned: Inter, Roboto, Arial, Helvetica, Open Sans, system fonts. Use a stardust-derived font deck or pull from `style-guide.md` § *Font decks*.
-3. **Bold color choices.** Dark with vibrant accents, or striking monochrome, or saturated ground. Never default blue-on-white. Cream-family grounds only when the brand category genuinely warrants it (printing/publishing/paper goods).
-4. **Effects with purpose.** SVG filters, shaders, 3D animations are mandatory but must serve the slide's narrative. The effect tells you something about the brand or the moment — never decoration for its own sake.
-5. **Viewport fitting.** Reveal.js handles scale, but keep content sparse enough that effects breathe.
-6. **No AI tells.** Triplet-cadence headlines, "atelier"-style editorial vocabulary on non-editorial brands, stat-callout bars, generic-2026-SaaS hero silhouettes — all banned per stardust's divergence toolkit. See `style-guide.md` § *Anti-tells*.
+2. **Distinctive typography.** Banned as primary heading or body face: Inter, Roboto, Arial, Helvetica, Open Sans, system-ui. Use a stardust-derived font deck or one from `style-guide.md` § *Font decks*.
+3. **Bold color.** Dark with vibrant accents, striking monochrome, or saturated ground. Never default blue-on-white. Cream-family grounds (HSL-L 80–97, R−B ≥ 5, S < 40%) only when the brand category is literally printing/publishing/paper goods.
+4. **Effects layer is mandatory.** Every deck applies at least one SVG-filter or shader background AND one of {3D entrance, animated mask/clip, mix-blend layer, scanline/grain overlay} per `style-guide.md` § *Bespoke effects layer*.
+5. **Narrative shape is mandatory** (except for technical-reference decks). Pick one from `references/storytelling.md` in Phase 1; compose slides to match its arc.
+6. **No AI tells.** No triplet-cadence headlines beyond one per deck. No "atelier"/"the journal"/"dispatches" editorial vocabulary on non-editorial brands. No stat-callout bars, generic-2026-SaaS hero silhouettes, fabricated stats or named-person quotes. Full anti-tells list in `style-guide.md` § *Anti-tells*.
+7. **No effects on the last slide.** Land softly — the audience is scanning for the takeaway, not admiring shaders.
+
+## References
+
+- `references/stardust-setup.md` — stardust detection, install methods, impeccable dependency
+- `references/storytelling.md` — narrative shapes (Campbell, Duarte, Vonnegut), shape selection matrix, anti-patterns
+- `style-guide.md` — stardust token mapping, anchor moods, effects vocabulary, anti-tells, density limits
+- `templates/presentation.shtml` — the sprinkle template with inline SVG filter library and effect classes

--- a/skills/presentations/SKILL.md
+++ b/skills/presentations/SKILL.md
@@ -1,35 +1,112 @@
 ---
 name: presentations
-description: Create interactive reveal.js presentations as sprinkles
+description: Create interactive reveal.js presentations as sprinkles, with bespoke per-brand visual design via stardust
 allowed-tools: bash
 ---
 
 # Presentations
 
-Create reveal.js slide decks as interactive SLICC sprinkles. The user asks for a presentation, you build it as a sprinkle panel where slides can be navigated, edited, and refined through the lick bridge.
+Create reveal.js slide decks as interactive SLICC sprinkles. Output is bespoke — never a templated preset. The skill leans on the **stardust** design system (when present) for distinctive, brand-aware visual direction; falls back to anchor moods otherwise. Every deck ships with the bespoke effects layer: SVG filters, CSS shader patterns, 3D animation. No bland AI-default look, ever.
 
 **Trigger phrases:** "create a presentation", "make slides", "build a deck", "presentation about X", "slide deck", "make a pitch deck"
 
+## Phase 0 — Stardust gate (run before discovery)
+
+Before generating anything, check for stardust artifacts. Stardust is the design system that drives bespoke per-brand visual direction. Without it, presentations risk looking templated.
+
+### 0.1 — Detect existing stardust output
+
+Look for these files at the project root, in priority order:
+
+```bash
+test -f DESIGN.json   # impeccable/stardust target tokens (preferred)
+test -f DESIGN.md     # impeccable/stardust target design system
+test -f stardust/direction.md  # stardust direction trace
+```
+
+If `DESIGN.json` exists at the project root: **skip install prompts, go straight to Phase 2 with stardust-driven theme generation** (see `style-guide.md` § Stardust integration). Mention briefly to the user: "Found stardust DESIGN.json — generating theme from your brand tokens."
+
+### 0.2 — Detect installed stardust skill
+
+If no DESIGN.json exists, check whether the stardust *skill* is installed:
+
+```bash
+# Common skill install paths the SLICC/Claude Code harness uses
+ls .claude/skills/stardust/SKILL.md  ~/.claude/skills/stardust/SKILL.md \
+   .agents/skills/stardust/SKILL.md  .cursor/skills/stardust/SKILL.md \
+   plugins/stardust/skills/stardust/SKILL.md 2>/dev/null
+```
+
+If installed: tell the user "stardust is installed — want me to run `$stardust extract <url>` first to capture brand surface, or proceed with anchor-mood themes?" and act on the answer. Stardust extract → direct → DESIGN.json gives the strongest result; skipping it just means anchor-mood mode.
+
+### 0.3 — Offer to install stardust
+
+If stardust is not installed AND no DESIGN.json exists, ask the user if they'd like to install it. Present these four install methods (pick whichever matches their harness):
+
+| Method | Command | When |
+|--------|---------|------|
+| **Claude Code plugin (built-in)** | `/plugin marketplace add adobe/skills` then `/plugin install stardust@adobe-skills` | Running inside Claude Code. User runs the slash commands themselves. |
+| **upskill (SLICC native)** | `upskill adobe/skills --skill stardust` | SLICC harness with the `upskill` CLI installed. |
+| **gh upskill (extension)** | `gh upskill adobe/skills --skill stardust` | User has `trieloff/gh-upskill` gh extension installed. |
+| **npx skills (Vercel)** | `npx skills add adobe/skills --skill stardust` | Generic — works anywhere npx runs. |
+
+Phrase the offer concisely. Example:
+
+> "Want me to install stardust first? It's Adobe's design system for brand-aware visual direction — without it, presentations fall back to anchor moods (still distinctive, but not specific to your brand). Install options:
+>
+> 1. **Claude Code (built-in):** run `/plugin marketplace add adobe/skills` then `/plugin install stardust@adobe-skills`
+> 2. **upskill:** `upskill adobe/skills --skill stardust`
+> 3. **gh upskill:** `gh upskill adobe/skills --skill stardust`
+> 4. **npx skills:** `npx skills add adobe/skills --skill stardust`
+>
+> Or skip and use anchor-mood mode."
+
+If the user picks 2, 3, or 4, run the command via bash. If they pick 1, print the slash commands for them to run (skills can't invoke slash commands). If they decline, proceed with anchor-mood mode — still applies the bespoke effects layer.
+
+Stardust itself depends on **impeccable** (`pbakaus/impeccable`). If you install stardust, also offer to install impeccable the same way. Without impeccable, stardust will refuse to run and the user will hit a wall on first invocation. After install, stardust normally needs `$stardust extract <url>` and `$stardust direct` before DESIGN.json appears — surface that step explicitly.
+
 ## Phase 1 — Content Discovery
 
-Before generating anything, gather requirements through quick questions:
+Gather requirements through quick questions. Skip questions the user already answered:
 
-1. **Purpose** — "What's this for?" (pitch, teaching, conference talk, internal update, workshop)
-2. **Length** — "How long?" (5–10 slides, 10–20, 20+)
-3. **Content readiness** — "Do you have content ready, or just a topic?"
-4. **Style** — Show 1–2 sample slides as inline shtml cards with different themes, let user pick
+1. **Purpose** — pitch, teaching, conference talk, internal update, workshop
+2. **Length** — 5–10 slides, 10–20, 20+
+3. **Content readiness** — ready content, or just a topic?
+4. **Brand context** — only if stardust is NOT in play: "any brand or URL this should evoke?" (a yes opens the door to running stardust)
 
 Keep discovery conversational. If the user gives a clear brief ("10-slide pitch deck about our Q3 results"), skip redundant questions.
 
 ## Phase 2 — Style Discovery
 
-Read the style guide for available themes:
+Read the style guide:
 
 ```bash
 read_file /workspace/skills/presentations/style-guide.md
 ```
 
-Generate 1–2 sample title slides as **inline shtml cards** showing different themes. Each card should be a small preview (single slide, not a full deck). Let the user pick a theme or ask for adjustments before generating the full deck.
+### When stardust artifacts exist (DESIGN.json at project root)
+
+Generate theme CSS dynamically from `DESIGN.json` tokens. The `style-guide.md` § *Stardust integration* section is the spec — follow it strictly:
+
+- Map `colors.<role>` → `--r-background-color`, `--r-main-color`, `--r-heading-color`, `--r-accent-color`
+- Map `typography.<headingRole>.fontFamily` + `.fontSize` → `--r-heading-font`, heading scale
+- Map `typography.<bodyRole>.fontFamily` → `--r-main-font`
+- Pull `extensions.divergence.font_deck` for the @import URL
+- Honor `extensions.divergence.seed.ground_family` — it dictates whether the deck is dark, cream, saturated, etc.
+- Layer the **bespoke effects** (SVG filters, shaders, 3D) keyed to the seed's `craft` tradition (letterpress → ink-bleed displacement; Riso → off-register dual-color; terrazzo → speckled radial; folded-paper → fold shadows).
+
+Show ONE preview slide as an inline shtml card so the user can see the brand-derived theme. No "pick a preset" question — there is no preset.
+
+### When no stardust artifacts (anchor-mood mode)
+
+Pick an **anchor mood** from `style-guide.md` § *Anchor moods*. There are 8, and each is a *starting point*, not a finished design. Mandatory: layer the bespoke effects on top. Show 1–2 sample title slides as inline shtml cards with different moods. Let the user pick or ask for adjustments.
+
+### Hard rules — no matter the mode
+
+- **No bland output.** If a draft slide looks like a reveal.js default with nicer fonts, it has failed. Discard and retry.
+- **No banned fonts.** Inter, Roboto, Arial, Helvetica, Open Sans, system-ui as primary heading or body face. Period.
+- **No safe palettes.** No "navy + accent blue + white." No corporate gray-on-white. No generic gradient-on-white hero.
+- **Effects layer is mandatory.** Every deck applies at least one SVG filter primitive AND one of {3D entrance, animated mask/clip, mix-blend layer, scanline/grain overlay} per the rules in `style-guide.md` § *Bespoke effects layer*.
 
 ## Phase 3 — Create the Presentation
 
@@ -42,10 +119,11 @@ One scoop per presentation. The scoop owns the sprinkle and stays alive for edit
 scoop_scoop("quarterly-review")
 feed_scoop("quarterly-review", "You own the sprinkle 'quarterly-review'. Your job:
 1. Read style guide: read_file /workspace/skills/presentations/style-guide.md
-2. Create the .shtml file at /shared/sprinkles/quarterly-review/quarterly-review.shtml using the template from /workspace/skills/presentations/templates/presentation.shtml
-3. Run: sprinkle open quarterly-review
-4. Push initial content: sprinkle send quarterly-review '<slide-data-json>'
-5. Stay alive — wait for lick events. Do NOT exit while the sprinkle is open.")
+2. Read brand tokens if present: read_file DESIGN.json (skip if missing)
+3. Create the .shtml file at /shared/sprinkles/quarterly-review/quarterly-review.shtml using the template from /workspace/skills/presentations/templates/presentation.shtml
+4. Run: sprinkle open quarterly-review
+5. Push initial content: sprinkle send quarterly-review '<slide-data-json>'
+6. Stay alive — wait for lick events. Do NOT exit while the sprinkle is open.")
 ```
 
 **The scoop must:**
@@ -70,17 +148,20 @@ Push slide content via `sprinkle send <name> '<json>'`:
 ```json
 {
   "slides": [
-    {"type": "title", "title": "...", "subtitle": "...", "background": "#hex"},
-    {"type": "section", "title": "...", "subtitle": "..."},
-    {"type": "content", "title": "...", "bullets": ["..."], "notes": "speaker notes"},
-    {"type": "code", "title": "...", "code": "...", "language": "js"},
-    {"type": "quote", "quote": "...", "attribution": "...", "background": "#hex"},
-    {"type": "image", "title": "...", "src": "url-or-description", "alt": "..."}
+    {"type": "title", "title": "...", "subtitle": "...", "background": "#hex", "effects": ["aurora-bg", "displaced-heading"]},
+    {"type": "section", "title": "...", "subtitle": "...", "effects": ["3d-flip-in"]},
+    {"type": "content", "title": "...", "bullets": ["..."], "notes": "speaker notes", "effects": ["mix-blend-headings"]},
+    {"type": "code", "title": "...", "code": "...", "language": "js", "effects": ["scanlines"]},
+    {"type": "quote", "quote": "...", "attribution": "...", "background": "#hex", "effects": ["chromatic-aberration"]},
+    {"type": "image", "title": "...", "src": "url-or-description", "alt": "...", "effects": ["holographic"]}
   ],
-  "theme": "midnight-aurora",
+  "theme": "stardust-derived",
+  "themeCSS": "@import url(...); :root { ... } /* full theme CSS */",
   "transition": "slide"
 }
 ```
+
+The `effects` array is per-slide — values are CSS class hooks the template applies. See `style-guide.md` § *Effects vocabulary* for the full list.
 
 Send the full slides array on every update — the sprinkle replaces all content on each push.
 
@@ -93,7 +174,7 @@ The sprinkle emits lick events via `slicc.lick({action, data})`. Handle these:
 | `edit-slide` | `{index, content}` | Ask user what to change, regenerate that slide, push full deck |
 | `add-slide` | `{afterIndex}` | Generate new slide, insert, push full deck |
 | `delete-slide` | `{index}` | Remove slide, push full deck |
-| `change-theme` | `{theme}` | Update theme in data, push full deck |
+| `change-theme` | `{theme}` | Update theme in data — regenerate from DESIGN.json (or pick a different anchor mood), push full deck |
 | `export-html` | `{}` | Write standalone HTML to VFS, tell user the path |
 
 **Modifying via cone:**
@@ -103,7 +184,7 @@ feed_scoop("quarterly-review", "Lick event on YOUR sprinkle: Action: 'edit-slide
 
 ## Content Density Limits
 
-Each slide type has strict content limits. Overfull slides look terrible at any viewport size.
+Each slide type has strict content limits. Overfull slides look terrible at any viewport size — and the bespoke effects amplify that. Sparse beats clever every time.
 
 | Slide Type | Max Content |
 |-----------|-------------|
@@ -115,11 +196,11 @@ Each slide type has strict content limits. Overfull slides look terrible at any 
 
 If content exceeds these limits, split into multiple slides.
 
-## Design Principles
+## Design Principles (enforce on every slide)
 
-- **No generic AI aesthetics** — avoid safe, bland palettes and default fonts
-- **Distinctive typography** — not Inter, not Arial, not system fonts. Use bold typographic choices via Google Fonts or CDN
-- **Bold color choices** — dark backgrounds with vibrant accents, or striking monochrome. Never default blue-on-white
-- **Purposeful animations** — fragments and transitions should serve the narrative, not decorate
-- **Viewport fitting** — reveal.js handles this, but keep content sparse enough that it looks good at any size
-
+1. **Bespoke over preset.** Stardust drives uniqueness when present. Anchor moods are starting positions, not finished designs.
+2. **Distinctive typography.** Banned: Inter, Roboto, Arial, Helvetica, Open Sans, system fonts. Use a stardust-derived font deck or pull from `style-guide.md` § *Font decks*.
+3. **Bold color choices.** Dark with vibrant accents, or striking monochrome, or saturated ground. Never default blue-on-white. Cream-family grounds only when the brand category genuinely warrants it (printing/publishing/paper goods).
+4. **Effects with purpose.** SVG filters, shaders, 3D animations are mandatory but must serve the slide's narrative. The effect tells you something about the brand or the moment — never decoration for its own sake.
+5. **Viewport fitting.** Reveal.js handles scale, but keep content sparse enough that effects breathe.
+6. **No AI tells.** Triplet-cadence headlines, "atelier"-style editorial vocabulary on non-editorial brands, stat-callout bars, generic-2026-SaaS hero silhouettes — all banned per stardust's divergence toolkit. See `style-guide.md` § *Anti-tells*.

--- a/skills/presentations/SKILL.md
+++ b/skills/presentations/SKILL.md
@@ -25,18 +25,22 @@ test -f DESIGN.json && echo "stardust present"
 Conversational. Skip questions the user already answered.
 
 1. **Purpose** — pitch, teaching, conference talk, internal update, workshop, retrospective, post-mortem
-2. **Length** — 5–10 slides, 10–20, 20+
-3. **Content readiness** — ready content, or just a topic?
-4. **Narrative shape** — pick from `references/storytelling.md`. Default by purpose:
+2. **Mode** — pick one:
+   - **traditional** — paced sequence of slides (default). User advances manually.
+   - **zoom** — big-picture-first; an overview slide names regions and each subsequent slide zooms into one. Uses vertical sub-slides under a `zoom-overview` parent.
+   - **rapid** — Lessig-style. 100 slides, ≤20 sec each, single word or sentence per slide. Auto-advances. Most slides should be `big-word` type. Ban bullet lists.
+3. **Length** — 5–10 slides, 10–20, 20+ (rapid implies 50+; warn if user pairs rapid with <30 slides)
+4. **Content readiness** — ready content, or just a topic?
+5. **Narrative shape** — pick from `references/storytelling.md`. Default by purpose:
    - Keynote, founder story, mission talk, education → **Hero's Journey** (Campbell)
    - Pitch, persuasion, vision talk, change initiative → **Sparkline / contrast** (Duarte)
    - Retrospective, post-mortem, lessons-learned → **Man-in-Hole** (Vonnegut)
    - Product launch, success story → **Cinderella** (Vonnegut)
    - Wake-up call, pre-mortem, risk talk → **From Bad to Worse** (Vonnegut)
    - Technical deep-dive with no narrative arc → no shape, just structure
-5. **Brand context** (only if no stardust) — "any brand or URL this should evoke?" (a yes opens the door to running stardust)
+6. **Brand context** (only if no stardust) — "any brand or URL this should evoke?" (a yes opens the door to running stardust)
 
-If the user gives a clear brief ("10-slide pitch deck about our Q3 results"), pick the shape from purpose without asking.
+If the user gives a clear brief ("10-slide pitch deck about our Q3 results"), pick the shape and mode from purpose without asking.
 
 ## Phase 2 — Style discovery
 
@@ -88,27 +92,27 @@ No local dependencies needed.
 
 ## Data Contract
 
-Push slide content via `sprinkle send <name> '<json>'`:
+Push via `sprinkle send <name> '<json>'`. Top-level shape:
 
 ```json
 {
-  "slides": [
-    {"type": "title", "title": "...", "subtitle": "...", "background": "#hex", "effects": ["effect-aurora-bg", "effect-displaced-heading"]},
-    {"type": "section", "title": "...", "subtitle": "...", "effects": ["effect-3d-flip-in"]},
-    {"type": "content", "title": "...", "bullets": ["..."], "notes": "speaker notes", "effects": ["effect-mix-blend-headings"]},
-    {"type": "code", "title": "...", "code": "...", "language": "js", "effects": ["effect-scanlines"]},
-    {"type": "quote", "quote": "...", "attribution": "...", "background": "#hex", "effects": ["effect-chromatic-aberration"]},
-    {"type": "image", "title": "...", "src": "url-or-description", "alt": "...", "effects": ["effect-holographic"]}
-  ],
+  "mode": "traditional|zoom|rapid",
   "theme": "stardust-derived",
-  "themeCSS": "@import url(...); :root { ... } /* full theme CSS */",
-  "transition": "slide"
+  "themeCSS": "@import url(...); :root { ... }",
+  "transition": "slide|fade|convex|none",
+  "slides": [ /* ... */ ]
 }
 ```
 
-`effects` is per-slide — values are CSS class hooks the template applies. Renderer validates against `/^effect-[a-z0-9-]+$/`. Full vocabulary in `style-guide.md` § *Effects vocabulary*.
+Each slide is `{type, ...}`. The 16 types and their per-type fields are documented in `style-guide.md` § *Bespoke slide types* — `title`, `section`, `big-word`, `metric`, `comparison`, `process`, `timeline`, `definition`, `cards`, `diagram`, `quote`, `image`, `code`, `content`, `zoom-overview`, `zoom-detail`. Common per-slide fields:
 
-Send the full slides array on every update — the sprinkle replaces all content on each push.
+- `effects` — array of class hooks. Renderer validates `/^effect-[a-z0-9-]+$/`. See `style-guide.md` § *Effects vocabulary*.
+- `builds` — staged element reveals: `[{selector, stagger?, at?}]`. See `style-guide.md` § *Builds*.
+- `autoslide` — ms before auto-advance. Rapid mode defaults to 20000ms.
+- `background` — `"#hex"`, `"rgb(...)"`, or image URL.
+- `notes` — speaker notes.
+
+The full slides array replaces all content on every push.
 
 ## Lick events
 
@@ -129,15 +133,7 @@ feed_scoop("quarterly-review", "Lick event on YOUR sprinkle: Action: 'edit-slide
 
 ## Content density limits
 
-| Slide Type | Max Content |
-|---|---|
-| **Title** | 1 heading + 1 subtitle |
-| **Content** | 1 heading + 4–6 bullets OR 2 short paragraphs |
-| **Code** | 1 heading + 8–10 lines of code |
-| **Quote** | 1 quote (max 3 lines) + attribution |
-| **Image** | 1 heading + 1 image |
-
-If content exceeds these limits, split into multiple slides. Sparse beats clever.
+Sparse beats clever. Per-type maxima in `style-guide.md` § *Content Density Rules*. If content overflows, split into multiple slides — never shrink font size.
 
 ## Hard rules (single source of truth)
 
@@ -147,9 +143,18 @@ These are the only rules the skill enforces. The style guide elaborates; this li
 2. **Distinctive typography.** Banned as primary heading or body face: Inter, Roboto, Arial, Helvetica, Open Sans, system-ui. Use a stardust-derived font deck or one from `style-guide.md` § *Font decks*.
 3. **Bold color.** Dark with vibrant accents, striking monochrome, or saturated ground. Never default blue-on-white. Cream-family grounds (HSL-L 80–97, R−B ≥ 5, S < 40%) only when the brand category is literally printing/publishing/paper goods.
 4. **Effects layer is mandatory.** Every deck applies at least one SVG-filter or shader background AND one of {3D entrance, animated mask/clip, mix-blend layer, scanline/grain overlay} per `style-guide.md` § *Bespoke effects layer*.
-5. **Narrative shape is mandatory** (except for technical-reference decks). Pick one from `references/storytelling.md` in Phase 1; compose slides to match its arc.
-6. **No AI tells.** No triplet-cadence headlines beyond one per deck. No "atelier"/"the journal"/"dispatches" editorial vocabulary on non-editorial brands. No stat-callout bars, generic-2026-SaaS hero silhouettes, fabricated stats or named-person quotes. Full anti-tells list in `style-guide.md` § *Anti-tells*.
-7. **No effects on the last slide.** Land softly — the audience is scanning for the takeaway, not admiring shaders.
+5. **No bullet-list decks.** Bullet lists are one slide type among ~14, not the default. A deck where >40% of slides are `content` with bullets is wrong — replace bullet slides with `metric`, `comparison`, `process`, `timeline`, `definition`, `cards`, `diagram`, `big-word`, or `quote`. Full type catalog in `style-guide.md` § *Bespoke slide types*.
+6. **Builds, not paragraphs.** Slides with multiple ideas reveal them in stages via the `builds` array (or per-slide `effects: ["effect-slide-stack"]`), not as a wall of text.
+7. **Contrast guarantee.** Body text ≥4.5:1, large text ≥3:1 against the rendered background. The template auto-applies text-shadow plates over busy backgrounds (`effect-aurora-bg`, `effect-conic-bg`, `effect-speckled-bg`, `effect-blueprint-bg`); do not undo them. When using `effect-holographic` or `effect-chromatic-aberration` on a busy background, add `text-protect` to the heading container or pick a flat background.
+8. **Narrative shape is mandatory** (except for technical-reference decks). Pick one from `references/storytelling.md` in Phase 1; compose slides to match its arc.
+9. **No AI tells.** No triplet-cadence headlines beyond one per deck. No "atelier"/"the journal"/"dispatches" editorial vocabulary on non-editorial brands. No stat-callout bars, generic-2026-SaaS hero silhouettes, fabricated stats or named-person quotes. Full anti-tells list in `style-guide.md` § *Anti-tells*.
+10. **No effects on the last slide.** Land softly — the audience is scanning for the takeaway, not admiring shaders.
+
+### Mode-specific rules
+
+- **rapid** — bullet lists are banned. Each slide is `big-word`, `metric`, single-image, or one-sentence `content`. No effects with entrance animations >0.3s. Total slides 50+ (warn user otherwise).
+- **zoom** — every `zoom-detail` slide must reference a `regionId` that exists in the preceding `zoom-overview`. Use vertical sub-slides under reveal.js.
+- **traditional** — no special constraints beyond the global rules.
 
 ## References
 

--- a/skills/presentations/SKILL.md
+++ b/skills/presentations/SKILL.md
@@ -29,6 +29,7 @@ Conversational. Skip questions the user already answered.
    - **traditional** — paced sequence of slides (default). User advances manually.
    - **zoom** — big-picture-first; an overview slide names regions and each subsequent slide zooms into one. Uses vertical sub-slides under a `zoom-overview` parent.
    - **rapid** — Lessig-style. 100 slides, ≤20 sec each, single word or sentence per slide. Auto-advances. Most slides should be `big-word` type. Ban bullet lists.
+   - **scroll** — built-in reveal v5 scroll-doc view. Deck becomes a vertically-scrolling page. Best when sharing the URL after a talk. Adds a CSS-only progress bar at the top.
 3. **Length** — 5–10 slides, 10–20, 20+ (rapid implies 50+; warn if user pairs rapid with <30 slides)
 4. **Content readiness** — ready content, or just a topic?
 5. **Narrative shape** — pick from `references/storytelling.md`. Default by purpose:

--- a/skills/presentations/references/stardust-setup.md
+++ b/skills/presentations/references/stardust-setup.md
@@ -1,0 +1,60 @@
+# Stardust setup reference
+
+Stardust is Adobe's website-redesign skill. When run for a brand, it produces `DESIGN.md` and `DESIGN.json` at the project root carrying brand-specific tokens — palette role names, typography, spacing, divergence seed (decade × craft × register × ground-family), and a font deck. The presentations skill consumes those tokens to generate brand-native theme CSS.
+
+Source: <https://github.com/adobe/skills/tree/main/plugins/stardust>
+
+## Detection
+
+```bash
+test -f DESIGN.json   # preferred — token spec is here
+test -f DESIGN.md     # design system markdown
+test -f stardust/direction.md  # full reasoning trace (optional)
+```
+
+If `DESIGN.json` exists: skip install, generate theme dynamically (see `style-guide.md` § Stardust integration).
+
+If neither exists, also check whether the stardust skill itself is installed:
+
+```bash
+ls .claude/skills/stardust/SKILL.md \
+   ~/.claude/skills/stardust/SKILL.md \
+   .agents/skills/stardust/SKILL.md \
+   .cursor/skills/stardust/SKILL.md \
+   plugins/stardust/skills/stardust/SKILL.md 2>/dev/null
+```
+
+## Install methods
+
+Pick whichever matches the user's harness. Run the bash-based ones via the Bash tool; print the slash commands for the user to invoke themselves.
+
+| Method | Command | Notes |
+|--------|---------|-------|
+| Claude Code plugin (built-in) | `/plugin marketplace add adobe/skills` then `/plugin install stardust@adobe-skills` | User runs the slash commands. Skills can't invoke them. |
+| upskill (SLICC native) | `upskill adobe/skills --skill stardust` | Run via Bash. Standalone CLI. |
+| gh upskill (extension) | `gh upskill adobe/skills --skill stardust` | Run via Bash. Requires `trieloff/gh-upskill` gh extension. |
+| npx skills (Vercel) | `npx skills add adobe/skills --skill stardust` | Run via Bash. Generic, works anywhere npx runs. |
+
+## Impeccable dependency
+
+Stardust hard-depends on **impeccable** (`pbakaus/impeccable`). On install, also offer to install impeccable the same way:
+
+- `upskill pbakaus/impeccable --all`
+- `gh upskill pbakaus/impeccable --all`
+- `npx skills add pbakaus/impeccable --all`
+
+Without impeccable, stardust refuses to run on first invocation.
+
+## After install
+
+Stardust normally needs `$stardust extract <url>` then `$stardust direct` before `DESIGN.json` appears at the project root. Surface those steps to the user — they're not automatic.
+
+## Phrasing the offer
+
+Concise. Don't oversell. Example:
+
+> Want me to install stardust first? It generates brand-specific tokens that make presentations feel native to a brand, not pasted onto one. Without it, decks fall back to anchor-mood mode (still distinctive, just not specific to your brand).
+>
+> Install: `upskill adobe/skills --skill stardust` · `gh upskill adobe/skills --skill stardust` · `npx skills add adobe/skills --skill stardust` · or run `/plugin marketplace add adobe/skills` then `/plugin install stardust@adobe-skills` for Claude Code.
+>
+> Or skip — I'll use anchor-mood mode.

--- a/skills/presentations/references/storytelling.md
+++ b/skills/presentations/references/storytelling.md
@@ -1,0 +1,229 @@
+# Storytelling Frameworks for Presentation Design
+
+Reference for an LLM agent generating reveal.js slide decks. Three narrative shapes, when to use each, and how each beat maps to slide types. Consult this before drafting deck outlines.
+
+---
+
+## 1. Joseph Campbell — The Hero's Journey
+
+> "The cave you fear to enter holds the treasure you seek."
+
+The 17 stages of the monomyth collapse into 3 acts (Departure / Initiation / Return) and, for talks, into 8 practical beats. The hero is rarely the speaker — usually it's the audience, the customer, the company, or the idea.
+
+### The 8 beats, mapped to slide types
+
+| # | Beat | Act | One-line definition | Slide type | Example phrase |
+|---|------|-----|---------------------|------------|----------------|
+| 1 | Ordinary World | Departure | The status quo before the story starts; familiar, slightly stale. | Section divider or title slide with a single grounding image | "In 2019, our team was shipping one release a quarter." |
+| 2 | Call to Adventure | Departure | The disturbance — a problem, opportunity, or signal that won't go away. | Content slide with a sharp question or one statistic | "Then we got the email no founder wants to read." |
+| 3 | Refusal / Threshold | Departure | Why the journey looked impossible; the cost of starting. | Quote slide or a single-bullet content slide | "We didn't have the team. We didn't have the budget. We went anyway." |
+| 4 | Mentor | Initiation | The guide, framework, tool, or insight that made it tractable. | Quote slide (attributing the mentor) or a diagram of the framework | "An engineer on the team showed us a paper from 2017." |
+| 5 | Trials | Initiation | Three concrete obstacles, in escalating order. | A 3-up content slide or three short consecutive slides | "First the data was wrong. Then the model was wrong. Then we were wrong." |
+| 6 | Revelation | Initiation | The moment the worldview flips; the insight earned through trials. | Single full-bleed slide — image, quote, or one sentence | "The bug wasn't in the code. It was in the question." |
+| 7 | Transformation | Return | What the hero/audience/product became after the revelation. | Before/after content slide or a paired-image slide | "We stopped shipping features. We started shipping outcomes." |
+| 8 | Return with Elixir | Return | The gift the audience takes home — a principle, tool, or invitation. | Closing title slide with a single takeaway and a CTA | "Here's the playbook. Take it." |
+
+### When this shape fits
+
+- Keynotes (20+ minutes) where you have time to set scene, descend, return.
+- Founder stories, origin talks, mission framings.
+- Education and onboarding — the audience is the hero learning a craft.
+- Conference talks built around a single transformation.
+
+### When it overshoots
+
+- 5-minute status updates (no time for descent and return; just give the update).
+- Technical deep-dives where the audience wants depth, not arc.
+- Sales pitches with a concrete ask — Duarte's contrast model converts better.
+- Any talk where the speaker is tempted to cast themselves as the hero rather than the audience.
+
+---
+
+## 2. Nancy Duarte — The Sparkline / Resonate Model
+
+> "The contrast between what is and what could be is what creates the narrative gap."
+
+A great talk oscillates between **what is** (current reality) and **what could be** (the better future the audience could inhabit). Tension lives in the gap between them. The talk climbs through alternating contrast until it lands a **S.T.A.R. moment** (Something They'll Always Remember), then closes on **new bliss** — a vivid picture of the audience's life after they adopt the proposal.
+
+### Slide-sequence pattern
+
+| Position | Phase | Slide type |
+|----------|-------|------------|
+| 1 | Title — the call | Title slide naming the stakes |
+| 2 | What is #1 | Content slide: the painful current state, with one stat or anecdote |
+| 3 | What could be #1 | Vision slide: a future-tense headline, image-led |
+| 4 | What is #2 | Content slide: a deeper layer of the problem |
+| 5 | What could be #2 | Vision slide: a sharper picture of the upside |
+| 6 | (repeat as needed) | Alternate; each cycle should escalate |
+| 7 | S.T.A.R. moment | Full-bleed: one image, one phrase, one stat, or one demo |
+| 8 | Call to action | Content slide with a concrete, single ask |
+| 9 | New bliss | Closing slide painting the audience's post-adoption life |
+
+The cadence matters more than the count. Two cycles is enough for a 10-minute talk; four for a 30-minute one. Each "what is" slide should feel slightly heavier than the last; each "what could be" slightly more vivid.
+
+### The four S.T.A.R. variants
+
+| Variant | What it is | Example |
+|---------|-----------|---------|
+| Memorable dramatization | A live demo, prop, or staged moment | Pulling a working prototype out of a backpack mid-talk |
+| Repeatable sound bite | A short phrase engineered to be quoted | "Software is eating the world." |
+| Evocative visual | A single image that does the argument's work | A photograph of one user's handwritten note |
+| Shocking statistic | A number that reframes the room | "73% of the data we collect is never read by anyone." |
+
+Pick exactly one. Two S.T.A.R. moments cancel each other out.
+
+### When this shape fits
+
+- Pitches, fundraising, sales decks with an ask.
+- Persuasion and change-initiative talks (re-orgs, strategy shifts).
+- Vision and product-launch talks.
+- Any talk where the speaker needs the audience to *do* something on Monday.
+
+---
+
+## 3. Kurt Vonnegut — Shapes of Stories
+
+> "The shape of a story is at least as interesting as the shape of a pot."
+
+Vonnegut graphed stories on a fortune Y-axis (good fortune up, ill fortune down) against a time X-axis. Six shapes recur. For decks, the curve is the spine of the talk; section dividers sit at the inflection points.
+
+### Man in Hole — down then up
+
+```
+fortune
+  |    ___________
+  |   /
+  |  /
+  | /
+  |/_____
+  |     \    /
+  |      \__/
+  |________________ time
+```
+
+Suits post-mortems, incident reviews, lessons-learned talks, recovery stories, "we almost died and here's what we learned."
+
+### Boy Meets Girl — up, down, up
+
+```
+fortune
+  |     ___        ___
+  |    /   \      /
+  |   /     \    /
+  |  /       \  /
+  | /         \/
+  |________________ time
+```
+
+Suits customer testimonials, "romance with the product" stories, partnership announcements, anything with a near-loss and reconciliation.
+
+### Cinderella — rise, fall, rise to greater heights
+
+```
+fortune
+  |              _____
+  |             /
+  |     ___    /
+  |    /   \  /
+  |   /     \/
+  |  /
+  | /
+  |/_______________ time
+```
+
+Suits product launches, success stories, turnaround narratives, IPO talks. The most crowd-pleasing shape and therefore the most over-used.
+
+### From Bad to Worse — gradual decline
+
+```
+fortune
+  |\
+  | \___
+  |     \__
+  |        \___
+  |            \__
+  |               \
+  |________________ time
+```
+
+Suits warnings, pre-mortems, climate/security/risk talks, wake-up calls. Use sparingly — audiences resist 30 minutes of decline unless the close pivots to agency.
+
+### Which Way Is Up — ambiguous oscillation
+
+```
+fortune
+  |   _   _   _
+  |  / \_/ \_/ \
+  | /           \_
+  |/______________ time
+```
+
+Suits research talks, philosophical or exploratory pieces, Kafka-esque industry analyses, "it's complicated" updates. Honest but hard to land — pair with a strong closing frame.
+
+### Creation Story — steps up
+
+```
+fortune
+  |              ___
+  |          ___|
+  |      ___|
+  |  ___|
+  |_|______________ time
+```
+
+Suits roadmap talks, capability-building stories, "how we got here" company narratives, milestone reviews.
+
+---
+
+## 4. Picking the Right Shape
+
+Ask the user three questions in Phase 1 (content discovery): **Purpose? Audience? Time budget?** Then consult the matrix.
+
+| Purpose | Audience | Time | Recommended shape |
+|---------|----------|------|-------------------|
+| Persuade / get a concrete ask | External or executive | 5–15 min | Duarte sparkline |
+| Inspire / share a journey | Conference, broad | 20–45 min | Campbell hero's journey |
+| Retrospective / lessons learned | Internal team | 10–20 min | Vonnegut Man-in-Hole |
+| Launch / unveil success | Customers, press | 10–30 min | Vonnegut Cinderella |
+| Customer story / testimonial | Sales, marketing | 5–15 min | Vonnegut Boy-Meets-Girl |
+| Wake-up call / risk warning | Leadership, policy | 10–25 min | Vonnegut Bad-to-Worse + Duarte close |
+| Roadmap / capability review | Internal, investors | 15–30 min | Vonnegut Creation Story |
+| Status update | Internal | <10 min | None — just structured headers |
+| Technical deep-dive | Specialists | Any | None — use a logical, not narrative, structure |
+| Founder / mission talk | Mixed | 20+ min | Campbell |
+| Vision / strategy shift | Org-wide | 15–30 min | Duarte |
+
+If purpose is unclear, default to Duarte — contrast structure works for the widest range of business presentations and degrades gracefully.
+
+---
+
+## 5. Anti-Patterns in AI-Generated Decks
+
+Three slop patterns to detect and refuse.
+
+### (a) Hero's Journey Lite
+
+Every section divider is labeled with a Campbell stage ("The Call," "The Trials," "The Return") but the content underneath has no actual transformation — same tone, same register, no descent, no revelation.
+
+**Test from a draft deck:** read only the first sentence of each section. If you cannot identify which beat *changed* the protagonist, the labels are decoration. Strip them.
+
+### (b) Duarte Cosplay
+
+Every other slide alternates "current state" / "future state" headlines, regardless of whether the content actually contrasts. The structure becomes a tic; the audience stops feeling the gap because the gap is mechanical.
+
+**Test from a draft deck:** count consecutive "what is / what could be" pairs. More than three cycles without escalation, or any pair where the two slides could be swapped without changing the argument, indicates cosplay. Collapse adjacent pairs into one substantive contrast.
+
+### (c) Vonnegut Overlay
+
+A fortune curve is drawn or implied over content that doesn't actually rise or fall. The deck claims a Cinderella shape but every slide sits at the same emotional altitude.
+
+**Test from a draft deck:** rate the emotional valence of each section on a -3 to +3 scale. If the variance is under 2 points across the whole deck, there is no curve — remove the shape language and present the content as structured information.
+
+---
+
+## 6. Notes for the Agent
+
+- Pick one framework per deck. Mixing Campbell and Duarte produces mush.
+- The S.T.A.R. moment, the Revelation beat, and the inflection point of a Vonnegut curve are the same slide in different vocabularies — there should be exactly one per deck.
+- Section dividers in reveal.js are the natural home for act/phase transitions; use vertical slides for the beats inside an act.
+- If the user cannot articulate a transformation, a contrast, or a curve in one sentence, the deck does not need a narrative framework — it needs a clean outline.

--- a/skills/presentations/style-guide.md
+++ b/skills/presentations/style-guide.md
@@ -350,6 +350,7 @@ Every deck applies effects from this catalog via the per-slide `effects` array. 
 | `effect-conic-bg` | `@property --rot` 60deg/sec conic-gradient with 8 stops | light, gradient |
 | `effect-speckled-bg` | radial-gradient mosaic, pseudo-random distribution via box-shadow stack | light, terrazzo |
 | `effect-blueprint-bg` | feColorMatrix to cyan-on-blueprint + line-art `radial-gradient` overlay | dark |
+| `effect-shader-bg` | **WebGL background via Paper Shaders.** Set `data-shader="meshGradient\|dithering\|voronoi\|smokeRing\|metaballs\|neuroNoise\|grainGradient"` on the section. Optional `data-shader-config="<json>"` for `speed`, `scale`, custom `colors`. ~30 KB tree-shaken; loaded lazily. Replaces several CSS-only bg effects with one unified pipeline. | dark or light |
 
 #### Heading effects (apply to slide section, target h1/h2)
 
@@ -436,6 +437,7 @@ Bullet-list `content` slides are **one of fourteen types**, not the default. A d
 | `cards` | 2x2, 3x2, or 3x3 grid of mini-cards with icon + title + body. Feature list, principles, team. | `cards: { layout, items: [{ icon, title, description }] }` |
 | `diagram` | Agent-supplied SVG or HTML. Architecture, flow, map. | `diagram: "<svg>...</svg>"`, optional `caption` |
 | `chart` | **Live data viz.** Three engines: `mermaid` (flowcharts/sequence/state — default), `chartjs` (bar/line/donut), `plot` (Observable Plot grammar-of-graphics). Engine library is loaded lazily from CDN on first use; stardust accent/text colors auto-applied. | `engine: "mermaid"\|"chartjs"\|"plot"`, `chart: <string\|object>`, optional `caption` |
+| `code-magic` | **Token-level code morph (Shiki Magic Move).** Pass an array of successive code states; clicking advances to the next, with smooth FLIP between tokens. The audience sees a function refactor itself in real time. Lazy-loads Shiki + magic-move from CDN. | `steps: [string, string, ...]`, optional `language` (default `javascript`), optional `codeTheme` (default `github-dark-default`) |
 | `quote` | Single quote, max 3 lines. | `quote`, optional `attribution` |
 | `image` | Hero image + heading + optional caption. | `src`, `alt` |
 | `code` | Code block, 8–10 lines, syntax-highlighted. | `code`, `language` |
@@ -501,6 +503,45 @@ The `chart` type loads its rendering engine lazily from CDN on first use. Each e
 - Static structural diagram (flow, sequence, state, gantt) → mermaid.
 - Quick bar / line / donut with stardust theming → chartjs.
 - Anything statistical, faceted, or with multiple mark layers → plot.
+
+### The `code-magic` slide — token-level code morphs
+
+Shiki Magic Move animates between successive code states at the token level — function refactors play out as a smooth FLIP animation. Best for talks where you teach by transformation: refactoring, optimisation passes, or "before / after this change" code reveals.
+
+```json
+{
+  "type": "code-magic",
+  "title": "Extracting the helper",
+  "language": "typescript",
+  "steps": [
+    "function compute(items) {\n  return items.reduce((a, x) => a + x.price * x.qty, 0);\n}",
+    "function compute(items) {\n  return items.reduce((a, x) => a + lineTotal(x), 0);\n}\n\nfunction lineTotal(item) {\n  return item.price * item.qty;\n}",
+    "function compute(items) {\n  return items.reduce((a, x) => a + lineTotal(x), 0);\n}\n\nfunction lineTotal({ price, qty }) {\n  return price * qty;\n}"
+  ]
+}
+```
+
+Each click advances one step; clicking back walks the morph in reverse. Cap at 6 steps per slide — beyond that the audience loses the thread.
+
+### The `effect-shader-bg` — WebGL backgrounds
+
+Paper Shaders ([shaders.paper.design](https://shaders.paper.design/)) gives us seven WebGL backgrounds in ~30 KB: `meshGradient`, `dithering`, `voronoi`, `smokeRing`, `metaballs`, `neuroNoise`, `grainGradient`. Each is themed automatically from `--r-accent-color`, `--r-accent-secondary`, `--r-background-color`.
+
+Use the data-contract `shader` and `shaderConfig` fields together with `effect-shader-bg` in the `effects` array. The renderer copies them onto the section as `data-shader` and `data-shader-config`; mountShaderBg picks them up and inserts a full-bleed canvas behind the slide content.
+
+```json
+{
+  "type": "big-word",
+  "word": "FLOW",
+  "effects": ["effect-shader-bg"],
+  "shader": "meshGradient",
+  "shaderConfig": { "speed": 0.3, "scale": 1.2 }
+}
+```
+
+Works with any slide type — title, big-word, metric, quote, html. The `shaderConfig` is optional (sane defaults derived from stardust tokens). Available shaders: `meshGradient`, `dithering`, `voronoi`, `smokeRing`, `metaballs`, `neuroNoise`, `grainGradient`.
+
+Pair carefully with text effects: shader backgrounds are busy. The contrast-protection layer auto-applies text-shadow halos on h1/h2/p/li when `effect-shader-bg` is present, but for `effect-holographic` or `effect-chromatic-aberration` headings, also add `text-protect` class to the heading container.
 
 ### The `html` escape hatch — full power
 
@@ -780,6 +821,7 @@ Maximum content per slide type. **Never exceed these limits.**
 | `cards` | 1 heading + 4 cards (2×2) or 6 cards (3×2) or 9 cards (3×3) |
 | `diagram` | 1 heading + 1 diagram + optional caption |
 | `chart` | 1 heading + 1 chart (≤8 series, ≤20 categories before axis becomes unreadable) + optional caption |
+| `code-magic` | 2–6 steps (each ≤12 lines). Beyond 6 steps, the audience loses the thread; split into multiple slides. |
 | `content` | 1 heading + 4–6 bullets OR 2 short paragraphs |
 | `code` | 1 heading + 8–12 lines of code |
 | `quote` | 1 quote (max 3 lines) + attribution |

--- a/skills/presentations/style-guide.md
+++ b/skills/presentations/style-guide.md
@@ -435,6 +435,7 @@ Bullet-list `content` slides are **one of fourteen types**, not the default. A d
 | `definition` | Term + meaning, dictionary-entry style. Manifesto, glossary, "what we mean by X". | `definition: { term, pos?, pronunciation?, meanings: [...] }` |
 | `cards` | 2x2, 3x2, or 3x3 grid of mini-cards with icon + title + body. Feature list, principles, team. | `cards: { layout, items: [{ icon, title, description }] }` |
 | `diagram` | Agent-supplied SVG or HTML. Architecture, flow, map. | `diagram: "<svg>...</svg>"`, optional `caption` |
+| `chart` | **Live data viz.** Three engines: `mermaid` (flowcharts/sequence/state — default), `chartjs` (bar/line/donut), `plot` (Observable Plot grammar-of-graphics). Engine library is loaded lazily from CDN on first use; stardust accent/text colors auto-applied. | `engine: "mermaid"\|"chartjs"\|"plot"`, `chart: <string\|object>`, optional `caption` |
 | `quote` | Single quote, max 3 lines. | `quote`, optional `attribution` |
 | `image` | Hero image + heading + optional caption. | `src`, `alt` |
 | `code` | Code block, 8–10 lines, syntax-highlighted. | `code`, `language` |
@@ -445,6 +446,61 @@ Bullet-list `content` slides are **one of fourteen types**, not the default. A d
 | `zoom-detail` | Mode=zoom only. Sits as a vertical sub-slide under a `zoom-overview`. | `regionId` (links back), plus content of choice |
 
 **Picking rule of thumb**: if you reach for bullets, ask first whether the items are (a) a temporal sequence → `process` or `timeline`, (b) two opposing groups → `comparison`, (c) parallel categories → `cards`, (d) a definition → `definition`, (e) a single magnitude → `metric`. Bullets are the *fallback*.
+
+### The `chart` slide — live data viz
+
+The `chart` type loads its rendering engine lazily from CDN on first use. Each engine reads stardust's `--r-accent-color` and `--r-main-color` so charts theme themselves automatically.
+
+**Mermaid (default)** — for flowcharts, sequence diagrams, state machines, gantts, ERD, mindmaps. Pass the Mermaid source as a string:
+
+```json
+{
+  "type": "chart",
+  "title": "Pipeline",
+  "engine": "mermaid",
+  "chart": "graph LR\n  A[Capture] --> B[Diagnose]\n  B --> C[Patch]\n  C --> D[Ship]"
+}
+```
+
+**Chart.js** — for bar / line / donut / radar / scatter. Pass a Chart.js config object:
+
+```json
+{
+  "type": "chart",
+  "title": "Quarterly ARR",
+  "engine": "chartjs",
+  "chart": {
+    "type": "bar",
+    "data": {
+      "labels": ["Q1", "Q2", "Q3", "Q4"],
+      "datasets": [{ "label": "ARR ($M)", "data": [4.2, 6.8, 9.1, 12.4] }]
+    },
+    "options": { "responsive": true, "maintainAspectRatio": false }
+  }
+}
+```
+
+(Dataset color falls back to `--r-accent-color` when not supplied. Legend, tick, and axis colors default to `--r-main-color`.)
+
+**Observable Plot** — for grammar-of-graphics; richer than Chart.js for statistical viz. Pass a Plot spec:
+
+```json
+{
+  "type": "chart",
+  "engine": "plot",
+  "chart": {
+    "marks": [
+      { "type": "ruleY", "data": [0] },
+      { "type": "barY", "data": [{"k": "A", "v": 10}, {"k": "B", "v": 24}], "options": { "x": "k", "y": "v" } }
+    ]
+  }
+}
+```
+
+**When to pick which**:
+- Static structural diagram (flow, sequence, state, gantt) → mermaid.
+- Quick bar / line / donut with stardust theming → chartjs.
+- Anything statistical, faceted, or with multiple mark layers → plot.
 
 ### The `html` escape hatch — full power
 
@@ -723,6 +779,7 @@ Maximum content per slide type. **Never exceed these limits.**
 | `definition` | 1 term + 1–3 meanings + optional pronunciation/POS |
 | `cards` | 1 heading + 4 cards (2×2) or 6 cards (3×2) or 9 cards (3×3) |
 | `diagram` | 1 heading + 1 diagram + optional caption |
+| `chart` | 1 heading + 1 chart (≤8 series, ≤20 categories before axis becomes unreadable) + optional caption |
 | `content` | 1 heading + 4–6 bullets OR 2 short paragraphs |
 | `code` | 1 heading + 8–12 lines of code |
 | `quote` | 1 quote (max 3 lines) + attribution |

--- a/skills/presentations/style-guide.md
+++ b/skills/presentations/style-guide.md
@@ -440,6 +440,7 @@ Bullet-list `content` slides are **one of fourteen types**, not the default. A d
 | `code` | Code block, 8–10 lines, syntax-highlighted. | `code`, `language` |
 | `content` | Bulleted list. **Use sparingly** — most lists are better as `cards` or `process`. | `bullets`, optional `title`, optional `content` HTML |
 | `html` | **Full-power escape hatch** — agent-controlled HTML with no sanitizer. `<script>`, `<style>`, `<iframe>`, `on*=` handlers, animated SVG, custom canvas/WebGL, third-party widgets all work. Scripts are rehydrated post-render so they actually execute. For one-off interactive scenes, slide-scoped CSS, embedded demos, or anything the type catalog doesn't cover. | `html: "<style>...</style><script>...</script><div>...</div>"` |
+| `recap` | **Closing slide.** 3 takeaways + 1 CTA, two-column layout. End-screen for an async-shared deck. | `takeaways: [string, string, string]`, `cta: { label, text }` |
 | `zoom-overview` | Mode=zoom only. Names regions to zoom into; renders as labeled chips or supplied diagram. | `regions: [{ id, label }]` or `diagram` |
 | `zoom-detail` | Mode=zoom only. Sits as a vertical sub-slide under a `zoom-overview`. | `regionId` (links back), plus content of choice |
 
@@ -524,7 +525,7 @@ These are auto-suppressed in **rapid** mode (slides too short for animations to 
 
 ## Presentation modes
 
-Three modes; pick one per deck via the data contract's `mode` field.
+Four modes; pick one per deck via the data contract's `mode` field.
 
 ### traditional
 
@@ -562,6 +563,77 @@ section[type=section] (next chapter)
 - No build sequences. The audience sees the slide for 20 sec; staged reveals don't have time.
 
 **Voice in rapid mode**: terse. Each slide is a beat. The audience reads the slide in 2 seconds and listens to the speaker for the rest.
+
+### scroll — share-friendly scrolling deck
+
+Reveal.js v5's built-in `view: 'scroll'` mode. The deck becomes a vertically-scrolling document — each slide is a viewport-sized section. Best for decks shared as URLs after a talk, where the viewer wants to skim. Auto-adds a scroll-driven CSS-only progress bar at the top (no JS, uses `animation-timeline: scroll(root block)`).
+
+**Tips**:
+- Pair with the `recap` slide type at the end — async readers go straight there.
+- Effects layer still applies, but `effect-3d-flip-in`-style entrance animations don't fire in scroll view (no slide-change events).
+- Use `effect-snap-carousel` on `cards` slides for horizontal sub-flow within a section.
+
+---
+
+## View Transitions and cross-slide morphs
+
+The template auto-applies `view-transition-name` to key elements (h1 in title slides, h2 across slides, `.metric-value`, `.big-word`). On browsers that support the View Transitions API (Baseline since Oct 2025), the browser morphs same-named elements between slide changes — a metric value can morph in size and position into a big-word headline on the next slide, the deck headline persists as a slide changes, etc.
+
+### How to opt elements in
+
+Two ways:
+
+1. **Implicit** — use the slide types and the template handles it. h1 in `title-slide`/`section-slide` shares the `deck-headline` name across slides, so it morphs.
+
+2. **Explicit `data-vt-name`** — for custom morphs across non-matching types, add the same `data-vt-name="my-thing"` to two elements on adjacent slides:
+
+```json
+{ "type": "html", "html": "<svg data-vt-name='hero-shape'>...</svg>" },
+{ "type": "html", "html": "<svg data-vt-name='hero-shape'>...</svg>" }
+```
+
+The browser will morph the SVG between the two states.
+
+### The `data-id` auto-animate technique (reveal.js native)
+
+Separately from View Transitions, reveal.js's auto-animate matches by `data-id` across adjacent sections with `data-auto-animate`:
+
+```html
+<section data-auto-animate>
+  <h1 data-id="hero">Before</h1>
+  <p data-id="ratio" style="font-size: 30px;">10%</p>
+</section>
+<section data-auto-animate>
+  <h1 data-id="hero">After</h1>
+  <p data-id="ratio" style="font-size: 200px;">94%</p>
+</section>
+```
+
+Reveal animates every CSS property between the two `data-id="hero"` and `data-id="ratio"` pairs. Use this for: a number that grows, an icon that travels across the slide, a card that morphs into a chart. The two morphing techniques (View Transitions and auto-animate) compose: VT handles cross-slide morphs declaratively; auto-animate handles per-property tweens with explicit `data-id` matching.
+
+---
+
+## Anchor-positioned callouts
+
+For tooltips, footnotes, and term-definition asides on `definition` and `diagram` slides:
+
+```html
+<p>The <span class="anchor" id="zenith" style="--anchor: --zenith">zenith</span> is the highest point...</p>
+<aside class="callout" style="--anchor: --zenith">
+  Astronomy: the point on the celestial sphere directly above the observer.
+</aside>
+```
+
+CSS handles the rest — the callout positions below the anchor, flips above when it would overflow the viewport (`position-try-fallbacks: flip-block, flip-inline`).
+
+For click-to-reveal popovers, use the Popover API:
+
+```html
+<button popovertarget="def-zenith" class="anchor">zenith</button>
+<aside id="def-zenith" popover>
+  Astronomy: the point on the celestial sphere directly above the observer.
+</aside>
+```
 
 ---
 

--- a/skills/presentations/style-guide.md
+++ b/skills/presentations/style-guide.md
@@ -419,6 +419,147 @@ When the user specifies a mood, match to the closest anchor. When nothing is spe
 
 ---
 
+## Bespoke slide types
+
+Bullet-list `content` slides are **one of fourteen types**, not the default. A deck made of bullet slides is the bland-deck failure mode the skill exists to prevent. Pick the type that matches the *informational shape* of the slide.
+
+| Type | When to use | Required fields |
+|---|---|---|
+| `title` | Opening slide. One headline. | `title`, optional `subtitle` |
+| `section` | Act / chapter divider. Single bold headline, centered. | `title`, optional `subtitle` |
+| `big-word` | One word or short phrase fills the screen (clamp 64–220px). Default for rapid mode. | `word`, optional `accent` (substring), optional `subtitle` |
+| `metric` | Single huge number + label + optional delta. Replaces stat-callout bars. | `metric: { value, label, delta?, direction? }` |
+| `comparison` | Two columns separated by a vertical "VS". Then/now, us/them, problem/solution. | `comparison: { left, right, vs? }` where each side is `{ title, items?, content? }` |
+| `process` | Numbered horizontal steps with arrow connectors. Workflow, recipe, methodology. | `steps: [{ title, description }]` |
+| `timeline` | Vertical timeline with dated events. Roadmap, history, retrospective. | `events: [{ date, title, description }]` |
+| `definition` | Term + meaning, dictionary-entry style. Manifesto, glossary, "what we mean by X". | `definition: { term, pos?, pronunciation?, meanings: [...] }` |
+| `cards` | 2x2, 3x2, or 3x3 grid of mini-cards with icon + title + body. Feature list, principles, team. | `cards: { layout, items: [{ icon, title, description }] }` |
+| `diagram` | Agent-supplied SVG or HTML. Architecture, flow, map. | `diagram: "<svg>...</svg>"`, optional `caption` |
+| `quote` | Single quote, max 3 lines. | `quote`, optional `attribution` |
+| `image` | Hero image + heading + optional caption. | `src`, `alt` |
+| `code` | Code block, 8–10 lines, syntax-highlighted. | `code`, `language` |
+| `content` | Bulleted list. **Use sparingly** — most lists are better as `cards` or `process`. | `bullets`, optional `title`, optional `content` HTML |
+| `zoom-overview` | Mode=zoom only. Names regions to zoom into; renders as labeled chips or supplied diagram. | `regions: [{ id, label }]` or `diagram` |
+| `zoom-detail` | Mode=zoom only. Sits as a vertical sub-slide under a `zoom-overview`. | `regionId` (links back), plus content of choice |
+
+**Picking rule of thumb**: if you reach for bullets, ask first whether the items are (a) a temporal sequence → `process` or `timeline`, (b) two opposing groups → `comparison`, (c) parallel categories → `cards`, (d) a definition → `definition`, (e) a single magnitude → `metric`. Bullets are the *fallback*.
+
+---
+
+## Builds (staged element reveals)
+
+Beyond reveal.js fragments, slides take a `builds` array that maps CSS selectors to staged reveals. The renderer adds `class="fragment"` and `data-fragment-index` to matched children.
+
+```json
+"builds": [
+  { "selector": ".card", "stagger": true },        // each card reveals one after the next
+  { "selector": "h3", "at": 1 },                    // h3 reveals at fragment index 1
+  { "selector": ".timeline-event", "stagger": true }
+]
+```
+
+**Allowed selectors**: any CSS selector, but stick to class names and tag names; complex selectors get fragile across renders.
+
+**Stagger vs at**: `stagger: true` indexes matches 0, 1, 2, … so each one steps in. `at: <n>` reveals the matched elements at a specific fragment index — useful when multiple staged reveals should fire together.
+
+**When to use**:
+- `cards` — almost always stagger, so the audience absorbs each one.
+- `process`, `timeline` — stagger to match the temporal narrative.
+- `metric` — never. The number lands in one moment.
+- `quote` — never. A quote arrives whole or not at all.
+- `big-word` — never. The point of `big-word` is the impact of one beat.
+
+**Mini-animations** (CSS classes the agent can add to children for richer entrance):
+
+| Class | Effect |
+|---|---|
+| `typewriter` | Types text out character by character on slide entry. Use on `<span>` inside a heading. |
+| `counter-up` | Animates a number from 0 to its `data-target` value over 1.2s. Use `data-format="int"` for integers, `data-suffix="%"` for units. |
+| `draw-line` | Animates an SVG path's `stroke-dashoffset` to 0 — line draws itself. Use on a `<line>` or `<path>` inside a `diagram`. |
+| `flip-card` | Element flips in 3D on entrance. Use on a `cards` child. |
+| `[data-from="left\|right\|top\|bottom"]` | Element slides in from that direction on entrance. Use sparingly. |
+
+These are auto-suppressed in **rapid** mode (slides too short for animations to land).
+
+---
+
+## Presentation modes
+
+Three modes; pick one per deck via the data contract's `mode` field.
+
+### traditional
+
+Default. Manual advance. All slide types, all effects, all builds available.
+
+### zoom — big picture first, then zoom into parts
+
+A `zoom-overview` slide names regions of a larger whole; each subsequent vertical sub-slide is a `zoom-detail` that drills into one region. The detail slide entry runs an `effect-zoom-blur`-like animation by default.
+
+**Composition pattern**:
+```
+section[type=zoom-overview] (regions: north, south, east, west)
+  ↓ vertical
+  section[type=zoom-detail, regionId=north]
+  section[type=zoom-detail, regionId=south]
+  section[type=zoom-detail, regionId=east]
+  section[type=zoom-detail, regionId=west]
+section[type=section] (next chapter)
+```
+
+**Tips**:
+- Provide a `diagram` on the overview so regions sit in a real spatial layout — not just a chip list.
+- Each detail's `regionId` must match an overview region. Renderer uses this to apply the zoom transition.
+- Cap at 5 regions per overview. More than 5 and the audience loses track.
+
+### rapid — Lessig-style, ≤20 sec/slide
+
+100 slides, single word or sentence per slide. Auto-advances. Effects and entrance animations are suppressed (too short to land).
+
+**Hard rules in rapid mode**:
+- Each slide ≤20 sec auto-advance (default 20000ms; per-slide override allowed).
+- Slide types: `big-word` (default), `metric`, `image`, single-sentence `content`. **Bullets banned.**
+- Total slide count: 50+ minimum (warn the user otherwise — sub-50 isn't really rapid).
+- No `effect-aurora-bg` / `effect-conic-bg` (too slow). Static backgrounds only.
+- No build sequences. The audience sees the slide for 20 sec; staged reveals don't have time.
+
+**Voice in rapid mode**: terse. Each slide is a beat. The audience reads the slide in 2 seconds and listens to the speaker for the rest.
+
+---
+
+## Contrast guarantees
+
+Dark backgrounds with bespoke effects can wreck contrast. The template ships an **automatic protection layer** that you must respect:
+
+### Auto-applied (don't undo)
+
+The template adds text-shadow halos to headings and body text on slides carrying any of: `effect-aurora-bg`, `effect-conic-bg`, `effect-speckled-bg`, `effect-blueprint-bg`. The shadow is tinted to the background color so headings stay readable as the conic gradient passes underneath.
+
+### Heading effects + busy backgrounds
+
+Two heading effects degrade contrast on busy bgs:
+
+- **`effect-holographic`** — text fill is a moving gradient, low contrast against patterned grounds. Combine only with flat backgrounds (`#hex` background only) or pair with `text-protect` on the heading.
+- **`effect-chromatic-aberration`** — the text-shadow stack at red/cyan offsets reduces effective contrast. Template forces the heading core to white when this effect is on. Don't override.
+
+### The `text-protect` utility
+
+Add the `text-protect` class to any element sitting over a busy region. It renders a soft radial darken behind the element keyed to `--r-background-color`.
+
+```html
+<h1 class="text-protect">Statement that needs to be readable</h1>
+```
+
+Use sparingly — overuse = visual noise.
+
+### Hard contrast minimums
+
+- Body text: ≥4.5:1 against rendered background (WCAG AA)
+- Large text (≥24px): ≥3:1
+- The 8 anchor moods all pass these; the bespoke-effects layer is what threatens them.
+- When in doubt, drop the effect rather than the readability.
+
+---
+
 ## Anti-tells (banned moves)
 
 Per stardust's divergence toolkit. These are the assistant's recurring defaults — banned outright on this skill except with a **brand-specific written justification** (the kind that wouldn't transfer to another brand unchanged).
@@ -445,6 +586,12 @@ Per stardust's divergence toolkit. These are the assistant's recurring defaults 
 **Fabricated content:**
 - Invented stats, addresses, named-customer logos, named-person quotes, dollar amounts, percentages, dates that don't appear in the user's brief or in stardust's `current/pages/<slug>.json`. Use `data-placeholder="true"` with a visible signature treatment instead.
 
+**Bland-deck patterns:**
+- **Bullet-list deck** — more than 40% of slides are `content` type with bullets. Test from draft: `(count(slides[type='content' and bullets]) / total) > 0.4` is the failure. Replace bullet slides with `metric`, `comparison`, `process`, `timeline`, `cards`, `definition`, or `big-word` per the informational shape.
+- **Title-then-bullets-then-title** — every non-title slide is `<h2>` + `<ul>`. Even when the bullet count is reasonable, the *rhythm* is dead. At least every third content-bearing slide should be a non-bullet type.
+- **Wall-of-text content slide** — bullets that are full sentences with sub-clauses. Bullets are sentence fragments. If a bullet has >12 words, split the slide or move to `quote` / `definition`.
+- **No builds** — multi-element slides (cards, process, timeline) without a `builds` array. The audience sees everything at once and tunes out. Stagger them.
+
 If a draft hits any of these, rewrite. "Feels right for the brand" is not a justification.
 
 ---
@@ -455,15 +602,22 @@ Maximum content per slide type. **Never exceed these limits.**
 
 | Slide Type | Maximum Content |
 |---|---|
-| Title slide | 1 heading + 1 subtitle + optional tagline |
-| Content slide | 1 heading + 4–6 bullet points OR 1 heading + 2 short paragraphs |
-| Feature grid | 1 heading + 4–6 cards (2×2 or 2×3 layout) |
-| Code slide | 1 heading + 8–12 lines of code |
-| Quote slide | 1 quote (max 3 lines) + attribution |
-| Image slide | 1 heading + 1 image + optional caption |
-| Section divider | 1 large heading + optional subtitle |
-| Comparison | 1 heading + 2 columns with 3–4 points each |
-| Stats / metrics | 1 heading + 3–4 large numbers with labels (avoid; this is the stat-callout anti-tell) |
+| `title` | 1 heading + 1 subtitle + optional tagline |
+| `section` | 1 large heading + optional subtitle |
+| `big-word` | 1 word OR 1 short phrase (≤6 words). Optional 1-line subtitle. |
+| `metric` | 1 number + 1 label + optional delta. Never two metrics on one slide. |
+| `comparison` | 1 heading + 2 columns × 3–4 points each |
+| `process` | 1 heading + 3–5 steps (4 is the sweet spot) |
+| `timeline` | 1 heading + 4–6 events (more = fragment with builds) |
+| `definition` | 1 term + 1–3 meanings + optional pronunciation/POS |
+| `cards` | 1 heading + 4 cards (2×2) or 6 cards (3×2) or 9 cards (3×3) |
+| `diagram` | 1 heading + 1 diagram + optional caption |
+| `content` | 1 heading + 4–6 bullets OR 2 short paragraphs |
+| `code` | 1 heading + 8–12 lines of code |
+| `quote` | 1 quote (max 3 lines) + attribution |
+| `image` | 1 heading + 1 image + optional caption |
+| `zoom-overview` | 1 heading + 3–5 regions |
+| `zoom-detail` | Same as the underlying type it carries |
 
 If content overflows, **split into multiple slides** — never shrink font size. Bullet points are sentence fragments, not paragraphs. Code blocks show the essential 8–12 lines, not full files. One idea per slide.
 

--- a/skills/presentations/style-guide.md
+++ b/skills/presentations/style-guide.md
@@ -439,10 +439,49 @@ Bullet-list `content` slides are **one of fourteen types**, not the default. A d
 | `image` | Hero image + heading + optional caption. | `src`, `alt` |
 | `code` | Code block, 8–10 lines, syntax-highlighted. | `code`, `language` |
 | `content` | Bulleted list. **Use sparingly** — most lists are better as `cards` or `process`. | `bullets`, optional `title`, optional `content` HTML |
+| `html` | **Full-power escape hatch** — agent-controlled HTML with no sanitizer. `<script>`, `<style>`, `<iframe>`, `on*=` handlers, animated SVG, custom canvas/WebGL, third-party widgets all work. Scripts are rehydrated post-render so they actually execute. For one-off interactive scenes, slide-scoped CSS, embedded demos, or anything the type catalog doesn't cover. | `html: "<style>...</style><script>...</script><div>...</div>"` |
 | `zoom-overview` | Mode=zoom only. Names regions to zoom into; renders as labeled chips or supplied diagram. | `regions: [{ id, label }]` or `diagram` |
 | `zoom-detail` | Mode=zoom only. Sits as a vertical sub-slide under a `zoom-overview`. | `regionId` (links back), plus content of choice |
 
 **Picking rule of thumb**: if you reach for bullets, ask first whether the items are (a) a temporal sequence → `process` or `timeline`, (b) two opposing groups → `comparison`, (c) parallel categories → `cards`, (d) a definition → `definition`, (e) a single magnitude → `metric`. Bullets are the *fallback*.
+
+### The `html` escape hatch — full power
+
+The `html` slide type passes the agent's HTML through verbatim — no sanitizer. `<script>`, `<style>`, `<iframe>`, animated SVG, canvas/WebGL, third-party CDN widgets all work. Scripts are rehydrated after innerHTML insertion so they execute.
+
+**Use when** the type catalog doesn't fit:
+- Interactive demos (a working calculator, a live data visualization, a tiny game)
+- Slide-scoped CSS that needs `@keyframes` or pseudo-element artistry beyond the effects layer
+- Embedded third-party widgets (CodePen, Observable, GitHub gists, video players)
+- Custom canvas/WebGL scenes
+- Multi-step animated sequences with their own JS state machine
+
+**Example — slide-scoped CSS animation:**
+
+```json
+{
+  "type": "html",
+  "effects": ["effect-aurora-bg"],
+  "html": "<style>.orbit{position:relative;width:60vmin;height:60vmin;margin:auto;animation:spin 24s linear infinite}.orbit .planet{position:absolute;inset:0;animation:orbit 12s linear infinite}.orbit .planet b{display:block;width:2vmin;height:2vmin;border-radius:50%;background:var(--r-accent-color);transform:translate(28vmin,0)}@keyframes spin{to{transform:rotate(360deg)}}@keyframes orbit{to{transform:rotate(-360deg)}}</style><div class='orbit'><div class='planet'><b></b></div></div>"
+}
+```
+
+**Example — embedded interactive (script tag rehydrates):**
+
+```json
+{
+  "type": "html",
+  "html": "<div id='counter' style='font-size:30vmin;text-align:center;font-family:var(--r-heading-font)'>0</div><script>let n=0;setInterval(()=>{n++;document.getElementById('counter').textContent=n},100)</script>"
+}
+```
+
+**Trust model.** The deck is agent-authored. Scripts run with the privileges of the sprinkle iframe. Don't put untrusted user input into the `html` field — the agent is the trusted authority.
+
+**Constraints**:
+- Inline `<style>` is slide-scoped *by convention* — wrap rules in a unique class so they don't bleed into other slides.
+- Inline `<script>` runs on slide load (when innerHTML is set + rehydrated). It does NOT re-run on slide re-show. If you need per-show side effects, listen for `slidechanged` from the parent.
+- The `effects` array still works — you can layer the bespoke effects on top of an `html` slide.
+- The `builds` array still works — pass selectors that match elements inside your HTML for staged reveals.
 
 ---
 
@@ -618,6 +657,7 @@ Maximum content per slide type. **Never exceed these limits.**
 | `image` | 1 heading + 1 image + optional caption |
 | `zoom-overview` | 1 heading + 3–5 regions |
 | `zoom-detail` | Same as the underlying type it carries |
+| `html` | Agent's responsibility — no enforced limit, but the *one idea per slide* rule still applies |
 
 If content overflows, **split into multiple slides** — never shrink font size. Bullet points are sentence fragments, not paragraphs. Code blocks show the essential 8–12 lines, not full files. One idea per slide.
 

--- a/skills/presentations/style-guide.md
+++ b/skills/presentations/style-guide.md
@@ -2,30 +2,160 @@
 
 Reference for creating reveal.js presentations. Read this before generating any slide deck.
 
+This guide is structured in three layers:
+
+1. **Stardust integration** — when `DESIGN.json` exists, pull tokens dynamically. This is the preferred path.
+2. **Anchor moods** — eight starting positions for when stardust is not in play. Each one is a *starting point*, not a finished design.
+3. **Bespoke effects layer** — SVG filters, CSS shader patterns, 3D animations. Mandatory on every deck regardless of mode.
+
+Plus: anti-tells, content density rules, and the data contract for the per-slide `effects` array.
+
 ---
 
 ## Design Principles
 
-1. **No AI slop** — No generic gradients-on-white, no "corporate futurism," no stock-art energy
-2. **No overused fonts** — Never use Inter, Roboto, Arial, Helvetica, Open Sans, or system fonts
-3. **Bold choices** — Every theme must feel like a human designer made it with intention
-4. **Typography first** — Font pairing drives the mood more than color
-5. **Restraint** — One accent color used purposefully beats a rainbow
-6. **Contrast matters** — Text must always be effortlessly readable
+1. **No AI slop** — no generic gradients-on-white, no "corporate futurism," no stock-art energy
+2. **No banned fonts** — never use Inter, Roboto, Arial, Helvetica, Open Sans, or system fonts as primary heading/body
+3. **Bold choices** — every deck must feel like a human designer made it with intention
+4. **Typography first** — font pairing drives the mood more than color
+5. **Restraint with effects** — one effect per slide, used purposefully. Three competing effects = chaos
+6. **Contrast matters** — text must always be effortlessly readable. WCAG AA minimum (4.5:1 body, 3:1 large)
 
 ---
 
-## Theme Presets
+## Stardust integration (preferred mode)
 
-### 1. Midnight Aurora
+When `DESIGN.json` exists at the project root, **generate the theme dynamically** rather than picking a preset. Stardust's `DESIGN.json` carries the resolved brand tokens for the target site/brand; the presentation should use them so the deck feels native to the brand, not pasted into it.
 
-**Mood**: Deep, dramatic, cinematic. For keynotes, product launches, high-stakes pitches.
+### Reading DESIGN.json
 
-**Fonts**: Heading: `Space Grotesk` (700) · Body: `Source Serif 4` (400, 400i)
+Key paths to extract:
+
+| DESIGN.json path | Reveal.js token | Notes |
+|---|---|---|
+| `colors.<background-role>.hex` | `--r-background-color` | The brand's ground (often non-cream — respect `extensions.divergence.seed.ground_family`) |
+| `colors.<text-primary-role>.hex` | `--r-main-color` | Body text |
+| `colors.<heading-role>.hex` | `--r-heading-color` | Heading. Often = `--r-main-color` for cohesion. |
+| `colors.<accent-role>.hex` | `--r-accent-color` | Pop. Used for `strong`, link, code, callout |
+| `colors.<accent-secondary-role>.hex` | `--r-accent-secondary` | Optional second accent |
+| `typography.<headingRole>.fontFamily` | `--r-heading-font` | Brand-native role name like `display-archivist`, `Pomodoro Slab`, etc. |
+| `typography.<bodyRole>.fontFamily` | `--r-main-font` | Body face |
+| `typography.<headingRole>.fontWeight` | `--r-heading-font-weight` | Weight number, e.g. 700 |
+| `typography.<bodyRole>.lineHeight` | line-height on `.reveal` | Body line height |
+| `extensions.divergence.font_deck` | @import URL list | Map deck name → Google Fonts URL list (table below) |
+| `extensions.divergence.seed.craft` | effects layer keying | Letterpress → ink-bleed; Riso → off-register; folded-paper → fold shadows |
+| `extensions.divergence.seed.ground_family` | overall mood key | `dark`, `cream`, `stark-white`, `pale-gray`, `saturated`, `monochrome-tint` |
+| `extensions.divergence.seed.decade` | type idiom | 1970s → magazine slab; 1990s → rough early-web; 2025-now → current editorial |
+
+### Font deck → Google Fonts URLs
+
+| Deck | @import URL |
+|---|---|
+| `editorial-archival` | `https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,700;1,700&family=Big+Shoulders+Stencil+Display:wght@700&family=JetBrains+Mono:wght@500;700&display=swap` |
+| `tactile-humanist` | `https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;800&family=Geist+Mono:wght@400;500&display=swap` |
+| `retro-italian` | `https://fonts.googleapis.com/css2?family=Alfa+Slab+One&family=Yeseva+One&family=VT323&display=swap` |
+| `zine-maximalist` | `https://fonts.googleapis.com/css2?family=Homemade+Apple&family=Special+Elite&family=Abril+Fatface&family=Bungee+Shade&family=DM+Serif+Display&display=swap` |
+| `swiss-modernist` | `https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;700;900&family=Iosevka:wght@400;700&display=swap` |
+| `bauhaus-functional` | `https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&family=Martian+Mono:wght@400;600&family=Roboto+Slab:wght@400;700&display=swap` |
+| `serif-luxury` | `https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=IBM+Plex+Sans:wght@400;500&display=swap` |
+| `bureaucratic` | `https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:wght@400;700&family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans+Condensed:wght@400;700&display=swap` |
+| `broadcast` | `https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;700&family=Courier+Prime:wght@400;700&family=Georgia&display=swap` |
+| `handmade-signwriter` | `https://fonts.googleapis.com/css2?family=Rubik+Wet+Paint&family=Libre+Caslon+Text:ital,wght@0,400;1,400&family=Syne+Mono&display=swap` |
+
+### Craft → effects-layer key
+
+The seed's `craft` tradition keys the dominant effect on the deck. Pick one effect class per craft and apply it via the `effects` array on slides where it serves narrative.
+
+| Craft seed | Dominant effect class | What it does |
+|---|---|---|
+| Letterpress | `effect-ink-bleed` | feTurbulence + feDisplacementMap, low scale (0.5) — kiss-impression headline |
+| Riso print | `effect-misregister` | Dual-color heading offset 2–3px with mix-blend-mode multiply |
+| Embossed leather | `effect-emboss` | feSpecularLighting + feComposite — lit chunky heading |
+| Woodblock poster | `effect-grain-knockout` | feTurbulence at scale 4, baseFrequency 0.9, used as alpha mask on heading |
+| Terrazzo | `effect-speckled-bg` | Animated radial-gradient mosaic on background |
+| Enamel sign | `effect-glossy-stroke` | text-stroke + feSpecularLighting + drop-shadow accent |
+| Ceramic transfer | `effect-decal-edge` | clip-path with slight irregularity + drop-shadow |
+| Cross-stitch sampler | `effect-grid-overlay` | repeating-linear-gradient grid mask |
+| Technical illustration | `effect-blueprint` | feColorMatrix to cyan-on-blueprint + line-art borders |
+| Field guide | `effect-marginalia` | small italic captions in margins, dotted leader lines |
+| Map engraving | `effect-contour` | layered text-shadows simulating engraved relief |
+| Tailor's pattern paper | `effect-pattern-stitch` | dashed-border outlines, perforation marks |
+| Wood-veneer marquetry | `effect-veneer` | feDisplacementMap with woodgrain turbulence |
+| Folded-paper ephemera | `effect-fold-shadow` | clip-path triangles + linear-gradient shadow simulating creases |
+| Neon bending | `effect-neon-glow` | filter: drop-shadow stack at 4 levels (glow + bleed) |
+| Photogram | `effect-silhouette` | feColorMatrix to high-contrast B&W + feGaussianBlur halo |
+| Plaster cast | `effect-plaster-relief` | feSpecularLighting + low-saturation tone |
+| Mosaic tile | `effect-tessellate` | clip-path + grid mask pattern |
+
+### Ground family → effect intensity
+
+The `ground_family` seed determines effect intensity AND color choice for shaders:
+
+- `dark` — full intensity. Glows, neon bleeds, chromatic aberration, scanlines all welcome.
+- `cream` — restrained. Ink-bleed and grain only. No glow. (Note: cream grounds are rare per stardust's enforcement; only justified for printing/paper-goods brands.)
+- `stark-white` — high contrast. Sharp shadows, no glow, hard-edged shaders only.
+- `pale-gray` — medium contrast. Grain and texture welcome, no glow.
+- `saturated` — the brand's accent color is the ground. Effects must use the contrast complement, not deepen the same hue.
+- `monochrome-tint` — low saturation tinted neutral. Subtle grain, soft shadows, restrained motion.
+
+### Worked example: stardust-derived theme CSS
+
+Given DESIGN.json with: `ground_family: dark`, `craft: Riso print`, `font_deck: tactile-humanist`, palette roles {`Vault: #0d0d12`, `Bone: #f4f1e8`, `Pomodoro: #d83a2a`, `Verdigris: #2ea693`}:
 
 ```css
-@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;800&family=Geist+Mono:wght@400;500&display=swap');
 
+:root {
+  /* Vault */    --r-background-color: #0d0d12;
+  /* Bone */     --r-main-color:       #f4f1e8;
+  /* Bone */     --r-heading-color:    #f4f1e8;
+  /* Pomodoro */ --r-accent-color:     #d83a2a;
+  /* Verdigris */--r-accent-secondary: #2ea693;
+  --r-heading-font: 'Plus Jakarta Sans', sans-serif;
+  --r-heading-font-weight: 800;
+  --r-main-font: 'Plus Jakarta Sans', sans-serif;
+  --r-mono-font: 'Geist Mono', monospace;
+  --r-heading-text-transform: none;
+}
+.reveal { background: var(--r-background-color); }
+.reveal h1, .reveal h2 { color: var(--r-heading-color); }
+.reveal strong, .reveal b { color: var(--r-accent-color); }
+.reveal a { color: var(--r-accent-secondary); }
+
+/* Riso misregister effect — dual-color heading */
+.reveal .effect-misregister h1,
+.reveal .effect-misregister h2 {
+  position: relative;
+  color: var(--r-heading-color);
+}
+.reveal .effect-misregister h1::before,
+.reveal .effect-misregister h2::before {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  color: var(--r-accent-color);
+  transform: translate(2px, -2px);
+  mix-blend-mode: screen;
+  z-index: -1;
+}
+```
+
+Note the brand-native role-name comments above each token. Stardust's role-naming rule (Pomodoro, Vault, Verdigris) carries through to the comments — never strip them.
+
+---
+
+## Anchor moods (fallback mode)
+
+When stardust is not in play, pick from these eight anchor moods. Each is a *starting point*: layer the bespoke effects on top, push beyond the baseline.
+
+### 1. Midnight Aurora · cinematic, dramatic, keynote
+
+**Fonts**: Heading `Space Grotesk` (700) · Body `Source Serif 4` (400, 400i) · Mono `JetBrains Mono`
+
+**Default effect**: `effect-aurora-bg` (animated conic-gradient + feGaussianBlur), `effect-displaced-heading` (subtle feTurbulence on h1)
+
+```css
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&family=JetBrains+Mono:wght@500&display=swap');
 :root {
   --r-background-color: #0b1120;
   --r-main-color: #c8d6e5;
@@ -35,30 +165,20 @@ Reference for creating reveal.js presentations. Read this before generating any 
   --r-heading-font: 'Space Grotesk', sans-serif;
   --r-main-font: 'Source Serif 4', serif;
   --r-heading-font-weight: 700;
-  --r-heading-text-transform: none;
 }
 .reveal { background: radial-gradient(ellipse at 30% 80%, #0f1f3d 0%, #0b1120 70%); }
-.reveal h1, .reveal h2 { color: var(--r-heading-color); }
-.reveal strong, .reveal b { color: var(--r-accent-color); }
-.reveal a { color: var(--r-accent-secondary); }
-.reveal code { background: #152238; color: var(--r-accent-color); padding: 0.1em 0.3em; border-radius: 3px; }
-.reveal pre code { background: #0d1a2d; border-left: 3px solid var(--r-accent-color); }
-.reveal blockquote { border-left: 4px solid var(--r-accent-secondary); color: #8fa5c0; }
 ```
 
 **Transition**: `fade` · **Code theme**: `atom-one-dark`
 
----
+### 2. Paper & Ink · warm, editorial, literary
 
-### 2. Paper & Ink
+**Fonts**: Heading `Playfair Display` (700, 700i) · Body `Libre Baskerville` (400, 400i)
 
-**Mood**: Warm, editorial, literary. For academic talks, essays, storytelling.
-
-**Fonts**: Heading: `Playfair Display` (700, 700i) · Body: `Libre Baskerville` (400, 400i)
+**Default effect**: `effect-ink-bleed` on display headings, `effect-grain-overlay` on backgrounds
 
 ```css
 @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;1,700&family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&display=swap');
-
 :root {
   --r-background-color: #f5f0e8;
   --r-main-color: #2c2416;
@@ -67,32 +187,20 @@ Reference for creating reveal.js presentations. Read this before generating any 
   --r-accent-secondary: #3d6b5e;
   --r-heading-font: 'Playfair Display', serif;
   --r-main-font: 'Libre Baskerville', serif;
-  --r-heading-font-weight: 700;
-  --r-heading-text-transform: none;
 }
 .reveal { background: #f5f0e8; }
-.reveal h1, .reveal h2 { color: var(--r-heading-color); letter-spacing: -0.02em; }
-.reveal h1 { font-style: italic; }
-.reveal strong { color: var(--r-accent-color); }
-.reveal a { color: var(--r-accent-secondary); text-decoration: underline; }
-.reveal code { background: #e8e0d4; color: var(--r-accent-color); padding: 0.1em 0.3em; border-radius: 2px; }
-.reveal pre code { background: #2c2416; color: #f5f0e8; border: none; }
-.reveal blockquote { border-left: 3px solid var(--r-accent-color); font-style: italic; color: #5a4e3c; }
 ```
 
-**Transition**: `slide` · **Code theme**: `github-light` (inline), `monokai` (blocks)
+**Transition**: `slide` · **Code theme**: `monokai` (blocks)
 
----
+### 3. Electric Signal · high-energy, technical, cutting-edge
 
-### 3. Electric Signal
+**Fonts**: Heading `JetBrains Mono` (700) · Body `DM Sans`
 
-**Mood**: High-energy, technical, cutting-edge. For developer talks, tech demos, launch events.
-
-**Fonts**: Heading: `JetBrains Mono` (700) · Body: `DM Sans` (400, 500)
+**Default effect**: `effect-chromatic-aberration` on h1 (RGB-split text-shadow), `effect-grid-bg` (40px subtle grid)
 
 ```css
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@500;700&family=DM+Sans:wght@400;500;700&display=swap');
-
 :root {
   --r-background-color: #0a0a0f;
   --r-main-color: #b0b8c8;
@@ -101,33 +209,22 @@ Reference for creating reveal.js presentations. Read this before generating any 
   --r-accent-secondary: #00d4aa;
   --r-heading-font: 'JetBrains Mono', monospace;
   --r-main-font: 'DM Sans', sans-serif;
-  --r-heading-font-weight: 700;
   --r-heading-text-transform: uppercase;
   --r-heading-letter-spacing: 0.08em;
 }
 .reveal { background: #0a0a0f; }
-.reveal h1, .reveal h2 { color: var(--r-heading-color); font-size: 1.8em; }
-.reveal strong { color: var(--r-accent-color); }
-.reveal a { color: var(--r-accent-secondary); }
-.reveal code { background: #1a1a2e; color: var(--r-accent-color); font-family: 'JetBrains Mono', monospace; padding: 0.1em 0.3em; }
-.reveal pre code { background: #12121f; border: 1px solid #2a2a3e; }
-.reveal blockquote { border-left: 3px solid var(--r-accent-color); color: #7a8298; }
-.reveal .slide-number { color: var(--r-accent-secondary); }
 ```
 
 **Transition**: `none` · **Code theme**: `dracula`
 
----
+### 4. Dune · organic, grounded, warm
 
-### 4. Dune
+**Fonts**: Heading `Fraunces` (700) · Body `Outfit` (300, 400)
 
-**Mood**: Organic, grounded, warm. For sustainability, nature, culture, design talks.
-
-**Fonts**: Heading: `Fraunces` (700) · Body: `Outfit` (300, 400)
+**Default effect**: `effect-emboss` on headings, `effect-grain-overlay` low-intensity
 
 ```css
 @import url('https://fonts.googleapis.com/css2?family=Fraunces:wght@700;900&family=Outfit:wght@300;400;600&display=swap');
-
 :root {
   --r-background-color: #f2ebe0;
   --r-main-color: #3d3228;
@@ -136,31 +233,20 @@ Reference for creating reveal.js presentations. Read this before generating any 
   --r-accent-secondary: #4a7c6f;
   --r-heading-font: 'Fraunces', serif;
   --r-main-font: 'Outfit', sans-serif;
-  --r-heading-font-weight: 700;
-  --r-heading-text-transform: none;
 }
 .reveal { background: linear-gradient(170deg, #f2ebe0 0%, #e8ddd0 100%); }
-.reveal h1, .reveal h2 { color: var(--r-heading-color); }
-.reveal strong { color: var(--r-accent-color); }
-.reveal a { color: var(--r-accent-secondary); }
-.reveal code { background: #e0d5c4; color: var(--r-accent-color); padding: 0.1em 0.3em; border-radius: 3px; }
-.reveal pre code { background: #2a1f14; color: #f2ebe0; border-left: 3px solid var(--r-accent-color); }
-.reveal blockquote { border-left: 4px solid var(--r-accent-color); color: #6b5d4e; }
 ```
 
 **Transition**: `slide` · **Code theme**: `nord`
 
----
+### 5. Phosphor · retro-terminal, nostalgic, hacker
 
-### 5. Phosphor
+**Fonts**: Heading `IBM Plex Mono` (600) · Body `IBM Plex Mono` (400, 400i)
 
-**Mood**: Retro-terminal, nostalgic, hacker. For security talks, CLI demos, retro computing.
-
-**Fonts**: Heading: `IBM Plex Mono` (600) · Body: `IBM Plex Mono` (400, 400i)
+**Default effect**: `effect-scanlines` (built into mood), `effect-neon-glow` on h1, `effect-crt-warp` on `.reveal`
 
 ```css
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,600;1,400&display=swap');
-
 :root {
   --r-background-color: #0c1014;
   --r-main-color: #33cc66;
@@ -169,33 +255,22 @@ Reference for creating reveal.js presentations. Read this before generating any 
   --r-accent-secondary: #33cc66;
   --r-heading-font: 'IBM Plex Mono', monospace;
   --r-main-font: 'IBM Plex Mono', monospace;
-  --r-heading-font-weight: 600;
-  --r-heading-text-transform: none;
 }
 .reveal { background: #0c1014; }
 .reveal::after { content: ''; position: fixed; inset: 0; background: repeating-linear-gradient(transparent, transparent 2px, rgba(0,0,0,0.15) 2px, rgba(0,0,0,0.15) 4px); pointer-events: none; z-index: 9999; }
 .reveal h1, .reveal h2 { color: var(--r-heading-color); text-shadow: 0 0 8px rgba(68,238,119,0.3); }
-.reveal strong { color: var(--r-accent-color); }
-.reveal a { color: var(--r-accent-color); }
-.reveal code { background: transparent; color: var(--r-accent-color); }
-.reveal pre code { background: #0a0e12; border: 1px solid #1a3a1a; color: var(--r-main-color); }
-.reveal blockquote { border-left: 2px solid var(--r-accent-color); color: #228844; }
-.reveal .slide-number { font-family: 'IBM Plex Mono', monospace; color: #228844; }
 ```
 
 **Transition**: `none` · **Code theme**: `monokai`
 
----
+### 6. Nordic Frost · clean, airy, minimal
 
-### 6. Nordic Frost
+**Fonts**: Heading `Manrope` (700, 800) · Body `Karla` (400, 400i)
 
-**Mood**: Clean, airy, minimal. For product design, UX talks, corporate strategy.
-
-**Fonts**: Heading: `Manrope` (700, 800) · Body: `Karla` (400, 400i)
+**Default effect**: `effect-mix-blend-headings` (difference blend on h1 over secondary band), `effect-soft-shadow-card`
 
 ```css
 @import url('https://fonts.googleapis.com/css2?family=Manrope:wght@700;800&family=Karla:ital,wght@0,400;0,500;1,400&display=swap');
-
 :root {
   --r-background-color: #f8fafb;
   --r-main-color: #2d3748;
@@ -205,31 +280,20 @@ Reference for creating reveal.js presentations. Read this before generating any 
   --r-heading-font: 'Manrope', sans-serif;
   --r-main-font: 'Karla', sans-serif;
   --r-heading-font-weight: 800;
-  --r-heading-text-transform: none;
 }
 .reveal { background: #f8fafb; }
-.reveal h1, .reveal h2 { color: var(--r-heading-color); letter-spacing: -0.03em; }
-.reveal strong { color: var(--r-accent-color); }
-.reveal a { color: var(--r-accent-color); text-decoration: none; border-bottom: 2px solid var(--r-accent-secondary); }
-.reveal code { background: #edf2f7; color: #6b21a8; padding: 0.15em 0.35em; border-radius: 4px; font-size: 0.85em; }
-.reveal pre code { background: #1e293b; color: #e2e8f0; border-radius: 8px; }
-.reveal blockquote { border-left: 4px solid var(--r-accent-color); background: #eef4ff; padding: 0.5em 1em; border-radius: 0 6px 6px 0; }
-.reveal ul li::marker { color: var(--r-accent-color); }
 ```
 
-**Transition**: `slide` · **Code theme**: `github-light` (inline), `one-dark` (blocks)
+**Transition**: `slide` · **Code theme**: `one-dark`
 
----
+### 7. Oxide · bold, high-contrast, industrial
 
-### 7. Oxide
+**Fonts**: Heading `Archivo Black` · Body `Work Sans`
 
-**Mood**: Bold, high-contrast, industrial. For data science, infra, systems engineering.
-
-**Fonts**: Heading: `Archivo Black` (400) · Body: `Work Sans` (400, 500)
+**Default effect**: `effect-3d-flip-in` on title slides, `effect-hard-stroke` on headings
 
 ```css
 @import url('https://fonts.googleapis.com/css2?family=Archivo+Black&family=Work+Sans:wght@400;500;600&display=swap');
-
 :root {
   --r-background-color: #18181b;
   --r-main-color: #d4d4d8;
@@ -238,33 +302,21 @@ Reference for creating reveal.js presentations. Read this before generating any 
   --r-accent-secondary: #06b6d4;
   --r-heading-font: 'Archivo Black', sans-serif;
   --r-main-font: 'Work Sans', sans-serif;
-  --r-heading-font-weight: 400;
   --r-heading-text-transform: uppercase;
-  --r-heading-letter-spacing: 0.04em;
 }
 .reveal { background: #18181b; }
-.reveal h1 { font-size: 2.2em; line-height: 1.1; color: var(--r-accent-color); }
-.reveal h2 { color: var(--r-heading-color); }
-.reveal strong { color: var(--r-accent-color); }
-.reveal a { color: var(--r-accent-secondary); }
-.reveal code { background: #27272a; color: var(--r-accent-color); font-size: 0.85em; padding: 0.1em 0.3em; border-radius: 3px; }
-.reveal pre code { background: #09090b; border: 1px solid #3f3f46; }
-.reveal blockquote { border-left: 4px solid var(--r-accent-color); color: #a1a1aa; }
 ```
 
 **Transition**: `fade` · **Code theme**: `vitesse-dark`
 
----
+### 8. Rose Quartz · soft, modern, approachable
 
-### 8. Rose Quartz
+**Fonts**: Heading `Sora` (600, 700) · Body `Nunito`
 
-**Mood**: Soft, modern, approachable. For workshops, education, creative briefs, community talks.
-
-**Fonts**: Heading: `Sora` (600, 700) · Body: `Nunito` (400, 400i)
+**Default effect**: `effect-conic-bg` (slow conic-gradient @property animation), `effect-holographic` on h1
 
 ```css
 @import url('https://fonts.googleapis.com/css2?family=Sora:wght@600;700&family=Nunito:ital,wght@0,400;0,600;1,400&display=swap');
-
 :root {
   --r-background-color: #fef7f7;
   --r-main-color: #3d2c3e;
@@ -273,30 +325,87 @@ Reference for creating reveal.js presentations. Read this before generating any 
   --r-accent-secondary: #7c3aed;
   --r-heading-font: 'Sora', sans-serif;
   --r-main-font: 'Nunito', sans-serif;
-  --r-heading-font-weight: 700;
-  --r-heading-text-transform: none;
 }
 .reveal { background: linear-gradient(135deg, #fef7f7 0%, #f5eef8 50%, #eef0fb 100%); }
-.reveal h1, .reveal h2 { color: var(--r-heading-color); }
-.reveal strong { color: var(--r-accent-color); }
-.reveal a { color: var(--r-accent-secondary); }
-.reveal code { background: #f0e4f0; color: var(--r-accent-color); padding: 0.1em 0.3em; border-radius: 6px; }
-.reveal pre code { background: #2a1a2c; color: #f0e4f0; border-radius: 8px; }
-.reveal blockquote { border-left: 4px solid var(--r-accent-secondary); background: rgba(124,58,237,0.05); padding: 0.5em 1em; border-radius: 0 8px 8px 0; }
-.reveal ul li::marker { color: var(--r-accent-color); }
 ```
 
-**Transition**: `convex` · **Code theme**: `github-light` (inline), `panda` (blocks)
-
+**Transition**: `convex` · **Code theme**: `panda`
 
 ---
 
-## Mood → Theme Mapping
+## Bespoke effects layer (mandatory)
 
-Pick the theme based on the presentation's emotional register:
+Every deck applies effects from this catalog via the per-slide `effects` array. Effects are CSS classes the template applies to the slide's `<section>`. Reuse the inline SVG filter library defined in the template — don't redefine filters per deck.
 
-| Mood / Context | Theme |
-|---------------|-------|
+### Effects vocabulary
+
+#### Background effects (apply to slide section)
+
+| Class | What it does | Mode |
+|---|---|---|
+| `effect-aurora-bg` | Animated conic-gradient (45s rotation) + feGaussianBlur halo. Uses `--r-accent-color` and `--r-accent-secondary`. | dark |
+| `effect-grid-bg` | 40px repeating-linear-gradient grid at 0.04 alpha | dark, mono |
+| `effect-grain-overlay` | feTurbulence baseFrequency 0.65 as alpha mask, opacity 0.08 | any |
+| `effect-scanlines` | repeating-linear-gradient horizontal lines at 4px stride | dark only |
+| `effect-conic-bg` | `@property --rot` 60deg/sec conic-gradient with 8 stops | light, gradient |
+| `effect-speckled-bg` | radial-gradient mosaic, pseudo-random distribution via box-shadow stack | light, terrazzo |
+| `effect-blueprint-bg` | feColorMatrix to cyan-on-blueprint + line-art `radial-gradient` overlay | dark |
+
+#### Heading effects (apply to slide section, target h1/h2)
+
+| Class | What it does | Mode |
+|---|---|---|
+| `effect-displaced-heading` | feTurbulence + feDisplacementMap (scale 1.5) on h1 | any |
+| `effect-chromatic-aberration` | text-shadow stack: red −2px, cyan +2px on h1 | dark |
+| `effect-misregister` | Riso-style dual-color offset heading via ::before with mix-blend-screen | dark, mono |
+| `effect-ink-bleed` | feTurbulence + feDisplacementMap (scale 0.5) — kiss impression | light, paper |
+| `effect-emboss` | feSpecularLighting + feComposite — lit relief heading | any |
+| `effect-glossy-stroke` | text-stroke + drop-shadow accent ring | any |
+| `effect-neon-glow` | drop-shadow stack at 4 levels (close glow + far bleed) using `--r-accent-color` | dark |
+| `effect-holographic` | conic-gradient text fill via background-clip + animation | light, gradient |
+| `effect-hard-stroke` | text-stroke 2px + offset hard drop-shadow | any |
+
+#### Slide-level effects (entrance / transform)
+
+| Class | What it does | When |
+|---|---|---|
+| `effect-3d-flip-in` | rotateY(60deg) → 0 on slide entry, 0.6s | title, section |
+| `effect-3d-tilt-in` | rotateX(20deg) translateZ(-100px) → 0, 0.5s | title |
+| `effect-zoom-blur` | scale(1.5) + filter:blur(20px) → 1, 0.7s | dramatic reveal |
+| `effect-slide-stack` | child elements slide in from below at 80ms stagger | content slides |
+| `effect-mix-blend-headings` | h1 gets mix-blend-mode: difference over a colored band ::before | content |
+
+#### Per-element decorations
+
+| Class | What it does | Apply to |
+|---|---|---|
+| `effect-fold-shadow` | clip-path triangle + linear-gradient shadow on container | sections, blockquote |
+| `effect-pattern-stitch` | dashed-border around block elements | callouts |
+| `effect-marginalia` | small italic captions positioned absolute in margins | optional |
+| `effect-decal-edge` | irregular clip-path + drop-shadow | images, cards |
+
+### Effect composition rules
+
+1. **One background effect per slide.** Don't stack `effect-aurora-bg` with `effect-conic-bg` — pick one. They fight.
+2. **One heading effect per slide.** `effect-misregister` and `effect-chromatic-aberration` are the same idea expressed differently — don't stack.
+3. **Slide-level entrance + heading effect = OK.** They run at different times.
+4. **Skip effects on text-dense content slides.** A 6-bullet content slide doesn't need `effect-zoom-blur` — readability wins. Reserve dramatic effects for title and section slides.
+5. **Skip ALL effects on the last slide.** Land softly. The audience is scanning for the takeaway, not admiring shaders.
+
+### How effects are wired
+
+The template (`templates/presentation.shtml`) ships an inline `<svg>` defs block with named filters: `#filter-displace-soft`, `#filter-displace-strong`, `#filter-emboss`, `#filter-grain`, `#filter-glow`, `#filter-blueprint`, `#filter-photogram`, `#filter-veneer`. CSS classes reference these via `filter: url(#filter-displace-soft)`.
+
+The data contract's `effects` array on each slide becomes a space-joined `class=""` on the rendered `<section>`. The template's CSS contains the rules for every `.effect-*` class.
+
+---
+
+## Mood → Anchor mapping (fallback only)
+
+Pick the anchor mood based on the deck's emotional register when stardust is not in play:
+
+| Mood / Context | Anchor |
+|---|---|
 | Cinematic, dramatic, keynote | **Midnight Aurora** |
 | Academic, literary, storytelling | **Paper & Ink** |
 | Technical, developer-focused, high-energy | **Electric Signal** |
@@ -306,7 +415,37 @@ Pick the theme based on the presentation's emotional register:
 | Infrastructure, systems, data-heavy | **Oxide** |
 | Friendly, educational, workshop | **Rose Quartz** |
 
-**When the user specifies a mood**, match to the closest theme. When they specify a theme name, use it directly. When neither is specified, default to **Midnight Aurora** for dark or **Nordic Frost** for light.
+When the user specifies a mood, match to the closest anchor. When nothing is specified, default to **Midnight Aurora** for dark or **Nordic Frost** for light. Whichever you pick, the effects layer is still mandatory.
+
+---
+
+## Anti-tells (banned moves)
+
+Per stardust's divergence toolkit. These are the assistant's recurring defaults — banned outright on this skill except with a **brand-specific written justification** (the kind that wouldn't transfer to another brand unchanged).
+
+**Visual:**
+- Cream-family page ground (any color where HSL-L is 80–97, R−B ≥ 5, S < 40%) — banned unless the brand's category is literally printing/publishing/paper-goods.
+- 45° hazard stripes (yellow + ink, two-tone alternation).
+- Hard non-blur drop shadow on display headings (offset 6–14px) without a craft justification.
+- Rotated circular stamps with perimeter text.
+- Stat-callout bar (3–4 large numbers + all-caps labels in a horizontal trust strip).
+- Generic-2026-SaaS hero silhouette — oversized clamp() sans + two-button CTA pair + sticky top-nav.
+- Hero text on photographic background without ≥0.4 contrast scrim.
+
+**Type:**
+- Stencil display (Big Shoulders Stencil) used for non-archival/industrial brands.
+- UPPERCASE condensed sans as primary display register without justification.
+- Italic expressive serif single-word accents (Fraunces italic, etc.) used as a visual gimmick.
+
+**Voice / copy:**
+- Triplet-cadence headlines: "Same press. Same shop. Same eight years." — at most ONE per deck.
+- Editorial vocabulary on non-editorial brands: "atelier", "the journal", "dispatches", "manifesto", "field guide" applied to product/services/B2B/healthcare.
+- Quartermaster/curator/examiner register as default voice.
+
+**Fabricated content:**
+- Invented stats, addresses, named-customer logos, named-person quotes, dollar amounts, percentages, dates that don't appear in the user's brief or in stardust's `current/pages/<slug>.json`. Use `data-placeholder="true"` with a visible signature treatment instead.
+
+If a draft hits any of these, rewrite. "Feels right for the brand" is not a justification.
 
 ---
 
@@ -315,7 +454,7 @@ Pick the theme based on the presentation's emotional register:
 Maximum content per slide type. **Never exceed these limits.**
 
 | Slide Type | Maximum Content |
-|-----------|----------------|
+|---|---|
 | Title slide | 1 heading + 1 subtitle + optional tagline |
 | Content slide | 1 heading + 4–6 bullet points OR 1 heading + 2 short paragraphs |
 | Feature grid | 1 heading + 4–6 cards (2×2 or 2×3 layout) |
@@ -324,13 +463,9 @@ Maximum content per slide type. **Never exceed these limits.**
 | Image slide | 1 heading + 1 image + optional caption |
 | Section divider | 1 large heading + optional subtitle |
 | Comparison | 1 heading + 2 columns with 3–4 points each |
-| Stats / metrics | 1 heading + 3–4 large numbers with labels |
+| Stats / metrics | 1 heading + 3–4 large numbers with labels (avoid; this is the stat-callout anti-tell) |
 
-**Rules**:
-- If content overflows, **split into multiple slides** — never shrink font size
-- Bullet points should be sentence fragments, not paragraphs
-- Code blocks should show the essential 8–12 lines, not full files
-- One idea per slide. If you're tempted to say "also," it's a new slide
+If content overflows, **split into multiple slides** — never shrink font size. Bullet points are sentence fragments, not paragraphs. Code blocks show the essential 8–12 lines, not full files. One idea per slide.
 
 ---
 
@@ -338,46 +473,38 @@ Maximum content per slide type. **Never exceed these limits.**
 
 ### Transitions (between slides)
 
-| Theme | Default Transition | Rationale |
-|-------|-------------------|-----------|
-| Midnight Aurora | `fade` | Cinematic dissolve matches the mood |
-| Paper & Ink | `slide` | Page-turning feel |
-| Electric Signal | `none` | Instant cuts feel technical and fast |
-| Dune | `slide` | Natural, physical movement |
-| Phosphor | `none` | Terminal screens don't transition |
-| Nordic Frost | `slide` | Clean, predictable |
-| Oxide | `fade` | Dramatic reveals |
-| Rose Quartz | `convex` | Playful, dimensional |
+Mood defaults from the anchor moods table above. Stardust mode: pick `fade` for `dark` ground, `slide` for `cream`/`stark-white`/`pale-gray`, `convex` for `monochrome-tint`, `none` for retro/terminal registers, `fade` for `saturated`.
 
 ### Fragments (within slides)
 
-Use fragments sparingly. Rules:
+Use sparingly. Rules:
 
-1. **Bullet lists**: Reveal one at a time ONLY for suspense/punchlines. Default: show all at once
-2. **Feature grids**: Never fragment — show the full grid immediately
-3. **Code blocks**: Never fragment — code needs full context
-4. **Quotes**: Never fragment
-5. **Images**: Fade-in is acceptable for dramatic reveal
-6. **Stats/metrics**: Can fragment to build narrative ("We went from X → Y → Z")
+1. **Bullet lists**: reveal one at a time ONLY for suspense/punchlines. Default: show all at once.
+2. **Feature grids**: never fragment.
+3. **Code blocks**: never fragment — code needs full context.
+4. **Quotes**: never fragment.
+5. **Images**: fade-in is acceptable for dramatic reveal.
+6. **Stats**: can fragment to build narrative ("X → Y → Z").
 
-**Fragment styles** by theme family:
-- Dark themes (Aurora, Signal, Phosphor, Oxide): `fade-up` or `fade-in`
-- Light themes (Paper, Dune, Frost, Rose): `fade-in` only — no directional movement
+**Fragment styles:**
+- Dark grounds: `fade-up` or `fade-in`
+- Light grounds: `fade-in` only — no directional movement
 
 ### Timing
 
 - Never auto-advance slides
 - Fragment animation duration: 0.3s (fast) to 0.5s (dramatic)
-- Avoid animation on the first and last slides
+- Effect-layer entrance animations 0.5s–0.7s; cap at 0.7s to keep pacing
+- Skip effect entrances on the first and last slides
 
 ---
 
 ## Code Syntax Highlighting
 
-Each theme specifies a recommended highlight.js theme. Summary:
+Per anchor / stardust mode:
 
-| Theme | Inline Code Style | Block Code Theme |
-|-------|-------------------|-----------------|
+| Mode | Inline Code Style | Block Code Theme |
+|---|---|---|
 | Midnight Aurora | Teal on dark blue | `atom-one-dark` |
 | Paper & Ink | Burgundy on parchment | `monokai` (blocks only) |
 | Electric Signal | Pink on near-black | `dracula` |
@@ -386,8 +513,11 @@ Each theme specifies a recommended highlight.js theme. Summary:
 | Nordic Frost | Purple on light gray | `one-dark` |
 | Oxide | Orange on dark zinc | `vitesse-dark` |
 | Rose Quartz | Rose on lavender | `panda` |
+| Stardust dark ground | Accent-color on bg layer | `atom-one-dark` or `vitesse-dark` |
+| Stardust light ground | Accent-color on bg layer-1 | `github-light` or `nord` |
+| Stardust saturated | Inverted (light on accent) | `monokai` |
 
-**Rules**:
+**Rules:**
 - Always wrap code in `<pre><code>` with a language class
 - Use `data-trim` and `data-noescape` on code blocks
 - Tab size: 2 spaces
@@ -396,23 +526,12 @@ Each theme specifies a recommended highlight.js theme. Summary:
 
 ---
 
-## Background Effects
+## Background Effects (legacy, see Bespoke effects layer above for the canonical list)
 
-Subtle background treatments per theme. Apply to `.reveal` or individual slides.
+The 8 anchor moods carry default backgrounds (radial gradient, flat near-black, scanline overlay, etc.). The effects-layer classes above are *additions* on top of the mood baseline — they are not replacements for the mood's background. Don't apply two background effects to the same slide.
 
-| Theme | Background Effect |
-|-------|------------------|
-| Midnight Aurora | Radial gradient from deep navy center, optional subtle star-field dots |
-| Paper & Ink | Flat cream. Optional: faint paper texture via CSS noise |
-| Electric Signal | Flat near-black. Optional: subtle grid pattern (`background-size: 40px 40px`) |
-| Dune | Gentle warm gradient (cream → sand) |
-| Phosphor | Flat black + CRT scanline overlay (built into theme CSS) |
-| Nordic Frost | Flat cool white. Optional: very faint blue tint on section dividers |
-| Oxide | Flat dark zinc. Optional: diagonal hatching on section dividers |
-| Rose Quartz | Soft multi-stop gradient (pink → lavender → blue-white) |
-
-**Rules**:
-- Never use background images on content slides (they fight with text)
-- Background effects should be barely noticeable — atmosphere, not decoration
-- Section divider slides can have slightly stronger background treatment
+**Rules:**
+- Never use background images on content slides (they fight with text and any heading effect)
+- Background effects should be barely noticeable as decoration — atmosphere, not foreground
+- Section divider slides can carry stronger background treatment
 - Title slides can use a unique background variant from the same palette

--- a/skills/presentations/templates/presentation.shtml
+++ b/skills/presentations/templates/presentation.shtml
@@ -547,7 +547,9 @@
     .reveal .effect-speckled-bg h1,
     .reveal .effect-speckled-bg h2,
     .reveal .effect-blueprint-bg h1,
-    .reveal .effect-blueprint-bg h2 {
+    .reveal .effect-blueprint-bg h2,
+    .reveal .effect-shader-bg h1,
+    .reveal .effect-shader-bg h2 {
       text-shadow:
         0 0 14px var(--r-background-color),
         0 0 28px var(--r-background-color);
@@ -558,7 +560,9 @@
     .reveal .effect-conic-bg p,
     .reveal .effect-conic-bg li,
     .reveal .effect-speckled-bg p,
-    .reveal .effect-speckled-bg li {
+    .reveal .effect-speckled-bg li,
+    .reveal .effect-shader-bg p,
+    .reveal .effect-shader-bg li {
       text-shadow:
         0 0 8px var(--r-background-color),
         0 0 16px var(--r-background-color);
@@ -890,6 +894,47 @@
        no padding, no auto title. */
     .reveal .slides section.html-slide {
       text-align: initial;
+    }
+
+    /* effect-shader-bg — Paper Shaders WebGL backgrounds.
+       Set effect-shader-bg on the section and data-shader="meshGradient
+       |dithering|voronoi|smokeRing|metaballs|neuroNoise|grainGradient" on
+       the section. The runtime mounts a full-bleed canvas behind the slide
+       content, themed from stardust tokens. Replaces several CSS-only bg
+       effects with a unified WebGL pipeline (~30KB tree-shaken). */
+    .reveal .slides section.effect-shader-bg {
+      position: relative;
+      isolation: isolate;
+      overflow: hidden;
+    }
+    .reveal .slides section.effect-shader-bg > .shader-canvas {
+      position: absolute;
+      inset: 0;
+      z-index: -1;
+      pointer-events: none;
+    }
+
+    /* code-magic — Shiki Magic Move slide variant. Token-level FLIP
+       between successive code states. The slide carries a steps array;
+       reveal fragments advance from one state to the next. */
+    .reveal .slides section.code-magic-slide {
+      text-align: left;
+    }
+    .reveal .slides section.code-magic-slide .magic-stage {
+      font-family: var(--r-mono-font, var(--r-main-font));
+      font-size: 0.7em;
+      line-height: 1.5;
+      background: color-mix(in oklab, var(--r-background-color) 80%, black);
+      border-radius: 6px;
+      padding: 0.8em 1em;
+      max-width: 92%;
+      margin: 1em auto;
+      overflow: hidden;
+      position: relative;
+    }
+    .reveal .slides section.code-magic-slide .magic-loading {
+      opacity: 0.5;
+      font-style: italic;
     }
 
     /* chart — live charts via Mermaid (default), Chart.js, or Observable Plot.
@@ -1398,7 +1443,8 @@
    *       "type": "title" | "content" | "code" | "quote" | "image" | "section"
    *             | "big-word" | "metric" | "comparison" | "process"
    *             | "timeline" | "definition" | "cards" | "diagram"
-   *             | "chart"  | "zoom-overview" | "zoom-detail" | "recap" | "html",
+   *             | "chart"  | "code-magic" | "zoom-overview" | "zoom-detail"
+   *             | "recap"  | "html",
    *
    *       // Common fields:
    *       "title": "Slide Title",
@@ -1429,6 +1475,13 @@
    *       "caption": "...",                                              // diagram caption
    *       "engine": "mermaid" | "chartjs" | "plot",                      // chart — engine choice (default: mermaid)
    *       "chart": "graph TD; A-->B" | { type: "bar", data: {...} },    // chart — string for mermaid, object for chartjs/plot
+   *       "steps": ["const x = 1", "const x = 1\\nconst y = x + 1"],    // code-magic — successive code states; click advances step
+   *       "language": "javascript",                                      // code-magic / code — Shiki lang id
+   *       "codeTheme": "github-dark-default",                            // code-magic — Shiki theme id
+   *       "shader": "meshGradient",                                      // effect-shader-bg — Paper Shaders name
+   *                  // (meshGradient | dithering | voronoi | smokeRing
+   *                  //  | metaballs | neuroNoise | grainGradient)
+   *       "shaderConfig": { "speed": 0.4, "scale": 1.2 },                // optional per-shader options
    *       "regions": [ { "id": "north", "label": "..." } ],              // zoom-overview
    *       "regionId": "north",                                           // zoom-detail (links to overview region)
    *       "html": "<style>...</style><script>...</script><div>...</div>",
@@ -1825,6 +1878,158 @@
     Array.prototype.forEach.call(targets, renderChartTarget);
   }
 
+  // ===== Paper Shaders backgrounds =====
+  // Lazy-loaded; mounts a canvas inside any section.effect-shader-bg.
+  // The shader name is read from data-shader; an opt-in data-shader-config
+  // attribute can pass JSON to override defaults (speed, scale, colors).
+  var __shaderLib = null;
+  function loadShaderLib() {
+    if (__shaderLib) return __shaderLib;
+    __shaderLib = import('https://esm.sh/@paper-design/shaders@0.0.51')
+      .catch(function() {
+        // Fallback CDN
+        return import('https://cdn.jsdelivr.net/npm/@paper-design/shaders@0.0.51/+esm');
+      });
+    return __shaderLib;
+  }
+
+  function shaderColorsFromTokens() {
+    var s = getComputedStyle(document.documentElement);
+    return [
+      s.getPropertyValue('--r-accent-color').trim() || '#36d6a8',
+      s.getPropertyValue('--r-accent-secondary').trim() || '#5b8af5',
+      s.getPropertyValue('--r-background-color').trim() || '#0a0a0a',
+    ];
+  }
+
+  function mountShaderBg(section) {
+    if (!section || section.dataset.shaderMounted === '1') return;
+    var name = section.dataset.shader || 'meshGradient';
+    section.dataset.shaderMounted = '1';
+    var canvas = document.createElement('canvas');
+    canvas.className = 'shader-canvas';
+    canvas.width = 1280; canvas.height = 720;
+    section.insertBefore(canvas, section.firstChild);
+
+    loadShaderLib().then(function(lib) {
+      var Ctor = lib && (lib[name] || (lib.default && lib.default[name]));
+      if (!Ctor) {
+        console.warn('[shader] unknown shader', name, '— available:', lib && Object.keys(lib));
+        return;
+      }
+      var colors = shaderColorsFromTokens();
+      var defaults = { colors: colors, speed: 0.4, scale: 1.0 };
+      var userConfig = {};
+      try { userConfig = JSON.parse(section.dataset.shaderConfig || '{}'); } catch (e) {}
+      var config = Object.assign({}, defaults, userConfig);
+      try {
+        var instance = new Ctor(canvas, config);
+        if (instance && typeof instance.start === 'function') instance.start();
+        section.__shaderInstance = instance;
+      } catch (err) {
+        console.error('[shader] init failed', err);
+      }
+    }).catch(function(err) {
+      console.error('[shader] load failed', err);
+    });
+  }
+
+  function mountAllShaderBgs(container) {
+    var sections = container.querySelectorAll('section.effect-shader-bg');
+    Array.prototype.forEach.call(sections, mountShaderBg);
+  }
+
+  // ===== Shiki Magic Move — token-level code morphs =====
+  // Slide carries steps: [code1, code2, code3]. Each click advances to the
+  // next state; the FLIP animation morphs tokens between states. The agent
+  // can also set `lang` and `theme` (default reads from --r-* tokens).
+  var __magicMoveLib = null;
+  function loadMagicMove() {
+    if (__magicMoveLib) return __magicMoveLib;
+    __magicMoveLib = Promise.all([
+      import('https://esm.sh/shiki@1.22.2'),
+      import('https://esm.sh/shiki-magic-move@0.5.0/renderer')
+    ]).then(function(mods) {
+      return { shiki: mods[0], magic: mods[1] };
+    });
+    return __magicMoveLib;
+  }
+
+  function mountMagicMoveSlide(section) {
+    if (!section || section.dataset.magicMounted === '1') return;
+    section.dataset.magicMounted = '1';
+    var stage = section.querySelector('.magic-stage');
+    if (!stage) return;
+    var steps;
+    try { steps = JSON.parse(stage.dataset.steps || '[]'); } catch (e) { steps = []; }
+    var lang = stage.dataset.lang || 'javascript';
+    var theme = stage.dataset.theme || 'github-dark-default';
+    if (!steps.length) {
+      stage.innerHTML = '<div class="magic-loading">no steps supplied</div>';
+      return;
+    }
+    var stepIdx = 0;
+    loadMagicMove().then(function(libs) {
+      var shiki = libs.shiki;
+      var magic = libs.magic;
+      return shiki.createHighlighter({
+        themes: [theme],
+        langs: [lang]
+      }).then(function(highlighter) {
+        var renderer = magic.createMagicMoveRenderer(stage);
+        function showStep(i) {
+          if (i < 0 || i >= steps.length) return;
+          var tokens = magic.codeToKeyedTokens(highlighter, steps[i], { lang: lang, theme: theme });
+          renderer.render(tokens, { duration: 600 });
+        }
+        showStep(0);
+        // Wire reveal.js fragmentshown to advance steps
+        if (revealInstance) {
+          revealInstance.on('fragmentshown', function(ev) {
+            if (!section.contains(ev.fragment)) return;
+            stepIdx = Math.min(stepIdx + 1, steps.length - 1);
+            showStep(stepIdx);
+          });
+          revealInstance.on('fragmenthidden', function(ev) {
+            if (!section.contains(ev.fragment)) return;
+            stepIdx = Math.max(stepIdx - 1, 0);
+            showStep(stepIdx);
+          });
+        }
+        // Insert hidden fragment markers so reveal advances click-by-click
+        for (var k = 1; k < steps.length; k++) {
+          var f = document.createElement('span');
+          f.className = 'fragment';
+          f.style.display = 'none';
+          f.setAttribute('data-fragment-index', k);
+          stage.appendChild(f);
+        }
+      });
+    }).catch(function(err) {
+      stage.innerHTML = '<div class="magic-loading">magic-move failed: ' + escHtml(err.message) + '</div>';
+      console.error('[magic-move] failed', err);
+    });
+  }
+
+  function mountAllMagicMoveSlides(container) {
+    var sections = container.querySelectorAll('section.code-magic-slide');
+    Array.prototype.forEach.call(sections, mountMagicMoveSlide);
+  }
+
+  function renderCodeMagic(slide) {
+    var steps = Array.isArray(slide.steps) ? slide.steps : [];
+    var lang = typeof slide.language === 'string' ? slide.language : 'javascript';
+    var theme = typeof slide.codeTheme === 'string' ? slide.codeTheme : 'github-dark-default';
+    var stepsJson = '';
+    try { stepsJson = JSON.stringify(steps); } catch (e) { stepsJson = '[]'; }
+    return '<div class="magic-stage" '
+      + 'data-steps="' + escHtml(stepsJson) + '" '
+      + 'data-lang="' + escHtml(lang) + '" '
+      + 'data-theme="' + escHtml(theme) + '">'
+      + '<div class="magic-loading">loading magic-move…</div>'
+      + '</div>';
+  }
+
   function renderZoomOverview(slide) {
     var regions = Array.isArray(slide.regions) ? slide.regions : [];
     var inner = slide.diagram
@@ -1875,6 +2080,14 @@
     }
     if (typeof slide.autoslide === 'number' && slide.autoslide > 0) {
       bg += ' data-autoslide="' + (slide.autoslide | 0) + '"';
+    }
+    // effect-shader-bg wiring: pass data-shader / data-shader-config through
+    if (slide.shader && /^[a-zA-Z]+$/.test(slide.shader)) {
+      bg += ' data-shader="' + slide.shader + '"';
+    }
+    if (slide.shaderConfig && typeof slide.shaderConfig === 'object') {
+      try { bg += ' data-shader-config="' + escHtml(JSON.stringify(slide.shaderConfig)) + '"'; }
+      catch (e) {}
     }
     var notes = slide.notes
       ? '<aside class="notes">' + escHtml(slide.notes) + '</aside>'
@@ -1972,6 +2185,9 @@
 
       case 'chart':
         return wrap('chart-slide', renderChart(slide));
+
+      case 'code-magic':
+        return wrap('code-magic-slide', renderCodeMagic(slide));
 
       case 'zoom-overview':
         return '<section class="' + classOf('zoom-overview') + '"' + bg + '>'
@@ -2131,6 +2347,8 @@
     container.innerHTML = slides.map(renderSlide).join('\n');
     rehydrateHtmlSlideScripts(container);
     renderAllChartTargets(container);
+    mountAllShaderBgs(container);
+    mountAllMagicMoveSlides(container);
     applyRapidAutoslide();
 
     if (revealInstance) {
@@ -2238,6 +2456,14 @@
           if (fresh) {
             var newCharts = fresh.querySelectorAll('.chart-target');
             Array.prototype.forEach.call(newCharts, renderChartTarget);
+            // Mount shader bg if applicable
+            if (fresh.classList && fresh.classList.contains('effect-shader-bg')) {
+              mountShaderBg(fresh);
+            }
+            // Mount magic-move if applicable
+            if (fresh.classList && fresh.classList.contains('code-magic-slide')) {
+              mountMagicMoveSlide(fresh);
+            }
           }
           if (revealInstance) revealInstance.sync();
         }

--- a/skills/presentations/templates/presentation.shtml
+++ b/skills/presentations/templates/presentation.shtml
@@ -892,6 +892,44 @@
       text-align: initial;
     }
 
+    /* chart — live charts via Mermaid (default), Chart.js, or Observable Plot.
+       Engine is loaded on demand from CDN; never blocks the initial deck load.
+       Theme-aware: each engine's render call reads the current --r-* tokens. */
+    .reveal .slides section.chart-slide {
+      text-align: center;
+    }
+    .reveal .slides section.chart-slide .chart-content {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      max-height: 65vh;
+      margin: 1em auto;
+      width: min(100%, 1100px);
+      min-height: 300px;
+    }
+    .reveal .slides section.chart-slide .chart-content canvas,
+    .reveal .slides section.chart-slide .chart-content svg {
+      max-width: 100%;
+      max-height: 65vh;
+    }
+    .reveal .slides section.chart-slide .chart-loading {
+      font-style: italic;
+      opacity: 0.5;
+      font-size: 0.6em;
+    }
+    .reveal .slides section.chart-slide .chart-caption {
+      font-family: var(--r-main-font);
+      font-style: italic;
+      font-size: 0.5em;
+      opacity: 0.7;
+      margin-top: 0.4em;
+    }
+    /* Mermaid theme: ensure Mermaid SVG inherits stardust colors */
+    .reveal .slides section.chart-slide pre.mermaid {
+      background: transparent;
+      text-align: center;
+    }
+
     /* diagram — agent-supplied SVG/HTML, centered with consistent caption styling */
     .reveal .slides section.diagram-slide {
       text-align: center;
@@ -1360,7 +1398,7 @@
    *       "type": "title" | "content" | "code" | "quote" | "image" | "section"
    *             | "big-word" | "metric" | "comparison" | "process"
    *             | "timeline" | "definition" | "cards" | "diagram"
-   *             | "zoom-overview" | "zoom-detail" | "recap" | "html",
+   *             | "chart"  | "zoom-overview" | "zoom-detail" | "recap" | "html",
    *
    *       // Common fields:
    *       "title": "Slide Title",
@@ -1389,6 +1427,8 @@
    *                  "items": [ { "icon": "✱", "title": "...", "description": "..." } ] },
    *       "diagram": "<svg>...</svg> | <div>...</div>",                  // diagram inner HTML
    *       "caption": "...",                                              // diagram caption
+   *       "engine": "mermaid" | "chartjs" | "plot",                      // chart — engine choice (default: mermaid)
+   *       "chart": "graph TD; A-->B" | { type: "bar", data: {...} },    // chart — string for mermaid, object for chartjs/plot
    *       "regions": [ { "id": "north", "label": "..." } ],              // zoom-overview
    *       "regionId": "north",                                           // zoom-detail (links to overview region)
    *       "html": "<style>...</style><script>...</script><div>...</div>",
@@ -1642,6 +1682,149 @@
       + (slide.caption ? '<div class="diagram-caption">' + escHtml(slide.caption) + '</div>' : '');
   }
 
+  // chart slide renderer — emits a placeholder + a marker the post-build
+  // script picks up to lazy-load the right engine and render. The marker
+  // carries the engine name and the JSON-encoded spec as data-* attrs so
+  // each chart is self-contained.
+  function renderChart(slide) {
+    var engine = ['mermaid', 'chartjs', 'plot'].indexOf(slide.engine) >= 0 ? slide.engine : 'mermaid';
+    var spec = '';
+    if (engine === 'mermaid') {
+      spec = typeof slide.chart === 'string' ? slide.chart : '';
+    } else {
+      try { spec = JSON.stringify(slide.chart || {}); } catch (e) { spec = '{}'; }
+    }
+    var encoded = encodeURIComponent(spec);
+    var loadingMsg = '<div class="chart-loading">rendering ' + escHtml(engine) + '…</div>';
+    return '<div class="chart-content">'
+      + '<div class="chart-target" data-engine="' + escHtml(engine) + '" data-spec="' + encoded + '">'
+      + loadingMsg
+      + '</div>'
+      + '</div>'
+      + (slide.caption ? '<div class="chart-caption">' + escHtml(slide.caption) + '</div>' : '');
+  }
+
+  // Engine loaders — cached promises so each library loads at most once
+  // per session. CDN-loaded; no impact on cold start when no chart slides
+  // are in the deck.
+  var __engineLoaders = {
+    mermaid: null,
+    chartjs: null,
+    plot: null
+  };
+
+  function loadScript(src, asModule) {
+    return new Promise(function(resolve, reject) {
+      var s = document.createElement('script');
+      s.src = src;
+      if (asModule) s.type = 'module';
+      s.onload = function() { resolve(); };
+      s.onerror = function() { reject(new Error('failed to load ' + src)); };
+      document.head.appendChild(s);
+    });
+  }
+
+  function loadEngine(engine) {
+    if (__engineLoaders[engine]) return __engineLoaders[engine];
+    if (engine === 'mermaid') {
+      __engineLoaders.mermaid = import('https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs')
+        .then(function(mod) {
+          var bg = getComputedStyle(document.documentElement).getPropertyValue('--r-background-color').trim() || '#0a0a0a';
+          var fg = getComputedStyle(document.documentElement).getPropertyValue('--r-main-color').trim() || '#eee';
+          var accent = getComputedStyle(document.documentElement).getPropertyValue('--r-accent-color').trim() || '#36d6a8';
+          mod.default.initialize({
+            startOnLoad: false,
+            theme: 'base',
+            themeVariables: {
+              background: bg, primaryColor: accent, primaryTextColor: fg,
+              lineColor: fg, secondaryColor: accent, tertiaryColor: bg,
+              fontFamily: getComputedStyle(document.documentElement).getPropertyValue('--r-main-font').trim() || 'sans-serif'
+            }
+          });
+          return mod.default;
+        });
+      return __engineLoaders.mermaid;
+    }
+    if (engine === 'chartjs') {
+      __engineLoaders.chartjs = loadScript('https://cdn.jsdelivr.net/npm/chart.js@4')
+        .then(function() { return window.Chart; });
+      return __engineLoaders.chartjs;
+    }
+    if (engine === 'plot') {
+      __engineLoaders.plot = Promise.all([
+        import('https://cdn.jsdelivr.net/npm/d3@7/+esm'),
+        import('https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6/+esm')
+      ]).then(function(mods) { return mods[1]; });
+      return __engineLoaders.plot;
+    }
+    return Promise.reject(new Error('unknown engine: ' + engine));
+  }
+
+  function renderChartTarget(targetEl) {
+    if (!targetEl || targetEl.dataset.rendered === '1') return;
+    var engine = targetEl.dataset.engine;
+    var spec;
+    try { spec = decodeURIComponent(targetEl.dataset.spec || ''); } catch (e) { spec = ''; }
+    targetEl.dataset.rendered = '1';
+    loadEngine(engine).then(function(lib) {
+      try {
+        if (engine === 'mermaid') {
+          var id = 'mmd-' + Math.random().toString(36).slice(2, 9);
+          return lib.render(id, spec).then(function(r) {
+            targetEl.innerHTML = r.svg;
+          });
+        }
+        if (engine === 'chartjs') {
+          var conf = JSON.parse(spec);
+          targetEl.innerHTML = '<canvas></canvas>';
+          var canvas = targetEl.querySelector('canvas');
+          var accent = getComputedStyle(document.documentElement).getPropertyValue('--r-accent-color').trim() || '#36d6a8';
+          var fg = getComputedStyle(document.documentElement).getPropertyValue('--r-main-color').trim() || '#eee';
+          // Theme defaults if user didn't supply
+          conf.options = conf.options || {};
+          conf.options.color = conf.options.color || fg;
+          conf.options.plugins = conf.options.plugins || {};
+          conf.options.plugins.legend = conf.options.plugins.legend || {};
+          conf.options.plugins.legend.labels = conf.options.plugins.legend.labels || { color: fg };
+          conf.options.scales = conf.options.scales || {};
+          ['x','y','r'].forEach(function(k) {
+            if (conf.options.scales[k]) {
+              conf.options.scales[k].ticks = conf.options.scales[k].ticks || { color: fg };
+              conf.options.scales[k].grid = conf.options.scales[k].grid || { color: 'rgba(127,127,127,0.2)' };
+            }
+          });
+          // Default dataset color if missing
+          (conf.data && conf.data.datasets || []).forEach(function(d) {
+            if (!d.backgroundColor && !d.borderColor) {
+              d.backgroundColor = accent + '88';
+              d.borderColor = accent;
+            }
+          });
+          new lib(canvas.getContext('2d'), conf);
+        }
+        if (engine === 'plot') {
+          var plotSpec = JSON.parse(spec);
+          var fgColor = getComputedStyle(document.documentElement).getPropertyValue('--r-main-color').trim() || '#eee';
+          plotSpec.style = plotSpec.style || {};
+          plotSpec.style.color = plotSpec.style.color || fgColor;
+          plotSpec.style.background = plotSpec.style.background || 'transparent';
+          targetEl.innerHTML = '';
+          targetEl.appendChild(lib.plot(plotSpec));
+        }
+      } catch (err) {
+        targetEl.innerHTML = '<div class="chart-loading">chart error: ' + escHtml(err.message || String(err)) + '</div>';
+        console.error('[chart] render failed', err);
+      }
+    }).catch(function(err) {
+      targetEl.innerHTML = '<div class="chart-loading">load error: ' + escHtml(err.message) + '</div>';
+    });
+  }
+
+  function renderAllChartTargets(container) {
+    var targets = container.querySelectorAll('.chart-target');
+    Array.prototype.forEach.call(targets, renderChartTarget);
+  }
+
   function renderZoomOverview(slide) {
     var regions = Array.isArray(slide.regions) ? slide.regions : [];
     var inner = slide.diagram
@@ -1786,6 +1969,9 @@
 
       case 'diagram':
         return wrap('diagram-slide', renderDiagram(slide));
+
+      case 'chart':
+        return wrap('chart-slide', renderChart(slide));
 
       case 'zoom-overview':
         return '<section class="' + classOf('zoom-overview') + '"' + bg + '>'
@@ -1944,6 +2130,7 @@
     var container = document.getElementById('slides-container');
     container.innerHTML = slides.map(renderSlide).join('\n');
     rehydrateHtmlSlideScripts(container);
+    renderAllChartTargets(container);
     applyRapidAutoslide();
 
     if (revealInstance) {
@@ -2046,6 +2233,11 @@
           if (fresh && fresh.classList && fresh.classList.contains('html-slide')) {
             var container = document.getElementById('slides-container');
             rehydrateHtmlSlideScripts(container);
+          }
+          // Render any chart-target inside the new slide
+          if (fresh) {
+            var newCharts = fresh.querySelectorAll('.chart-target');
+            Array.prototype.forEach.call(newCharts, renderChartTarget);
           }
           if (revealInstance) revealInstance.sync();
         }

--- a/skills/presentations/templates/presentation.shtml
+++ b/skills/presentations/templates/presentation.shtml
@@ -885,6 +885,13 @@
       color: var(--r-accent-color);
     }
 
+    /* html — plain-HTML escape hatch. No imposed layout; agent supplies markup
+       and styles inline. The section gets effects + bg but no text-align,
+       no padding, no auto title. */
+    .reveal .slides section.html-slide {
+      text-align: initial;
+    }
+
     /* diagram — agent-supplied SVG/HTML, centered with consistent caption styling */
     .reveal .slides section.diagram-slide {
       text-align: center;
@@ -1179,7 +1186,7 @@
    *       "type": "title" | "content" | "code" | "quote" | "image" | "section"
    *             | "big-word" | "metric" | "comparison" | "process"
    *             | "timeline" | "definition" | "cards" | "diagram"
-   *             | "zoom-overview" | "zoom-detail",
+   *             | "zoom-overview" | "zoom-detail" | "html",
    *
    *       // Common fields:
    *       "title": "Slide Title",
@@ -1210,6 +1217,12 @@
    *       "caption": "...",                                              // diagram caption
    *       "regions": [ { "id": "north", "label": "..." } ],              // zoom-overview
    *       "regionId": "north",                                           // zoom-detail (links to overview region)
+   *       "html": "<style>...</style><script>...</script><div>...</div>",
+   *                  // html — full section body, no chrome, NO SANITIZER.
+   *                  // <script>, <style>, <iframe>, on*= handlers all
+   *                  // pass through and execute. Trust model: agent
+   *                  // writes the deck. Scripts are rehydrated post-
+   *                  // innerHTML so they actually run.
    *
    *       // Builds: optional staged element-reveal beyond simple fragments.
    *       // The renderer applies data-fragment-index attributes to children
@@ -1614,6 +1627,17 @@
             )
           + notes + '</section>';
 
+      case 'html':
+        // Plain-HTML escape hatch. FULL PASS-THROUGH — no sanitizer.
+        // Agent-supplied <script>, <style>, <iframe>, on*= handlers, and
+        // animated SVG all work. Trust model: the agent writes the deck;
+        // the deck author controls what runs. Use this when you need a
+        // custom mini-component, embedded widget, slide-scoped CSS, or
+        // a one-off animated scene. Builds still apply if requested.
+        return '<section class="' + classOf('html-slide') + '"' + bg + '>'
+          + withBuilds(slide.html || '')
+          + notes + '</section>';
+
       default:
         return '<section' + (fx ? ' class="' + fx + '"' : '') + bg + '>'
           + (slide.title ? '<h2' + titleAttrs + '>' + escHtml(slide.title) + '</h2>' : '')
@@ -1674,9 +1698,30 @@
     if (event && event.currentSlide) animateCounters(event.currentSlide);
   }
 
+  // Scripts inserted via innerHTML don't execute. After building the deck,
+  // walk every .html-slide section and re-create any <script> elements as
+  // fresh nodes so the browser actually runs them. Inline <style> blocks
+  // do apply via innerHTML — no special handling needed.
+  function rehydrateHtmlSlideScripts(container) {
+    var sections = container.querySelectorAll('section.html-slide');
+    Array.prototype.forEach.call(sections, function(sec) {
+      var scripts = sec.querySelectorAll('script');
+      Array.prototype.forEach.call(scripts, function(oldScript) {
+        var fresh = document.createElement('script');
+        // Copy attributes (src, type, async, defer, etc.)
+        Array.prototype.forEach.call(oldScript.attributes, function(a) {
+          try { fresh.setAttribute(a.name, a.value); } catch (e) {}
+        });
+        if (oldScript.textContent) fresh.textContent = oldScript.textContent;
+        oldScript.parentNode.replaceChild(fresh, oldScript);
+      });
+    });
+  }
+
   function buildPresentation(slides, transition) {
     var container = document.getElementById('slides-container');
     container.innerHTML = slides.map(renderSlide).join('\n');
+    rehydrateHtmlSlideScripts(container);
     applyRapidAutoslide();
 
     if (revealInstance) {
@@ -1764,7 +1809,13 @@
         if (sections[data.index]) {
           var temp = document.createElement('div');
           temp.innerHTML = renderSlide(data.slide);
-          sections[data.index].replaceWith(temp.firstElementChild);
+          var fresh = temp.firstElementChild;
+          sections[data.index].replaceWith(fresh);
+          // Rehydrate scripts if this slide is an html-slide
+          if (fresh && fresh.classList && fresh.classList.contains('html-slide')) {
+            var container = document.getElementById('slides-container');
+            rehydrateHtmlSlideScripts(container);
+          }
           if (revealInstance) revealInstance.sync();
         }
       }

--- a/skills/presentations/templates/presentation.shtml
+++ b/skills/presentations/templates/presentation.shtml
@@ -531,6 +531,488 @@
     }
 
     /* ========================================================================
+       CONTRAST PROTECTION
+       Auto-applies behind text on slides with busy backgrounds (any
+       effect-*-bg class except flat ones). Two complementary mechanisms:
+       (1) text-shadow halo in the background color — keeps headings legible
+           when conic/aurora gradients pass behind them.
+       (2) optional .text-protect element — a soft radial mask between bg
+           and text content for very busy compositions.
+       ======================================================================== */
+
+    .reveal .effect-aurora-bg h1,
+    .reveal .effect-aurora-bg h2,
+    .reveal .effect-conic-bg h1,
+    .reveal .effect-conic-bg h2,
+    .reveal .effect-speckled-bg h1,
+    .reveal .effect-speckled-bg h2,
+    .reveal .effect-blueprint-bg h1,
+    .reveal .effect-blueprint-bg h2 {
+      text-shadow:
+        0 0 14px var(--r-background-color),
+        0 0 28px var(--r-background-color);
+    }
+
+    .reveal .effect-aurora-bg p,
+    .reveal .effect-aurora-bg li,
+    .reveal .effect-conic-bg p,
+    .reveal .effect-conic-bg li,
+    .reveal .effect-speckled-bg p,
+    .reveal .effect-speckled-bg li {
+      text-shadow:
+        0 0 8px var(--r-background-color),
+        0 0 16px var(--r-background-color);
+    }
+
+    /* When chromatic aberration is on, force the heading itself to high-contrast
+       white/near-white so the offset RGB shadows read as decoration around a
+       readable core letter, not a low-contrast smear. */
+    .reveal .effect-chromatic-aberration h1,
+    .reveal .effect-chromatic-aberration h2 {
+      color: #fff;
+    }
+
+    /* Holographic text-fill produces low contrast on any heavy bg.
+       Auto-add a text-protect plate when both are on. */
+    .reveal .effect-aurora-bg.effect-holographic h1::after,
+    .reveal .effect-conic-bg.effect-holographic h1::after {
+      content: '';
+      position: absolute;
+      inset: -0.2em -0.4em;
+      background: var(--r-background-color);
+      opacity: 0.5;
+      filter: blur(24px);
+      z-index: -1;
+    }
+
+    /* Explicit utility — agent can add `text-protect` on any element that
+       sits over a busy region. Renders a soft radial darken behind it. */
+    .reveal .text-protect {
+      position: relative;
+      isolation: isolate;
+    }
+    .reveal .text-protect::before {
+      content: '';
+      position: absolute;
+      inset: -0.5em -1em;
+      background: radial-gradient(
+        ellipse at center,
+        var(--r-background-color) 0%,
+        var(--r-background-color) 50%,
+        transparent 100%
+      );
+      opacity: 0.85;
+      z-index: -1;
+      pointer-events: none;
+    }
+
+    /* ========================================================================
+       BESPOKE SLIDE TYPES
+       Replacements for bullet-list slides. Each type expresses a distinct
+       informational shape — comparison, process, metric, timeline, etc. —
+       with HTML structure that earns the screen real-estate.
+       ======================================================================== */
+
+    /* big-word — single phrase fills the screen. Default for rapid mode. */
+    .reveal .slides section.big-word-slide {
+      text-align: center;
+    }
+    .reveal .slides section.big-word-slide .big-word {
+      font-family: var(--r-heading-font);
+      font-weight: var(--r-heading-font-weight, 800);
+      font-size: clamp(64px, 14vw, 220px);
+      line-height: 0.95;
+      letter-spacing: -0.03em;
+      color: var(--r-heading-color);
+      margin: 0;
+    }
+    .reveal .slides section.big-word-slide .big-word-sub {
+      font-family: var(--r-main-font);
+      font-size: 0.32em;
+      opacity: 0.7;
+      margin-top: 0.5em;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    .reveal .slides section.big-word-slide .big-word .accent {
+      color: var(--r-accent-color);
+    }
+
+    /* metric — one huge number + label + optional delta */
+    .reveal .slides section.metric-slide {
+      text-align: center;
+    }
+    .reveal .slides section.metric-slide .metric-value {
+      font-family: var(--r-heading-font);
+      font-weight: var(--r-heading-font-weight, 800);
+      font-size: clamp(80px, 18vw, 280px);
+      line-height: 1;
+      color: var(--r-accent-color);
+      letter-spacing: -0.04em;
+      font-variant-numeric: tabular-nums;
+      display: block;
+    }
+    .reveal .slides section.metric-slide .metric-label {
+      font-family: var(--r-main-font);
+      font-size: 0.42em;
+      opacity: 0.85;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      margin-top: 0.6em;
+      color: var(--r-main-color);
+    }
+    .reveal .slides section.metric-slide .metric-delta {
+      display: inline-block;
+      margin-left: 0.4em;
+      font-size: 0.45em;
+      padding: 0.1em 0.4em;
+      border-radius: 4px;
+      vertical-align: middle;
+    }
+    .reveal .slides section.metric-slide .metric-delta.up   { color: #2ea693; }
+    .reveal .slides section.metric-slide .metric-delta.down { color: #d83a2a; }
+
+    /* comparison — two columns separated by a vs */
+    .reveal .slides section.comparison-slide .comparison-grid {
+      display: grid;
+      grid-template-columns: 1fr auto 1fr;
+      gap: 0;
+      align-items: stretch;
+      margin-top: 1em;
+    }
+    .reveal .slides section.comparison-slide .comparison-col {
+      padding: 0 1.2em;
+    }
+    .reveal .slides section.comparison-slide .comparison-col h3 {
+      font-family: var(--r-heading-font);
+      font-size: 1.1em;
+      margin-bottom: 0.6em;
+      letter-spacing: -0.01em;
+    }
+    .reveal .slides section.comparison-slide .comparison-col.left h3  { color: var(--r-accent-color); }
+    .reveal .slides section.comparison-slide .comparison-col.right h3 { color: var(--r-accent-secondary); }
+    .reveal .slides section.comparison-slide .comparison-col p,
+    .reveal .slides section.comparison-slide .comparison-col li {
+      font-size: 0.72em;
+      line-height: 1.5;
+    }
+    .reveal .slides section.comparison-slide .comparison-vs {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: var(--r-heading-font);
+      font-size: 1.2em;
+      color: var(--r-main-color);
+      opacity: 0.4;
+      writing-mode: vertical-rl;
+      letter-spacing: 0.1em;
+      padding: 0 0.4em;
+      border-left: 1px solid currentColor;
+      border-right: 1px solid currentColor;
+    }
+
+    /* process — numbered horizontal steps with arrow connectors */
+    .reveal .slides section.process-slide .process-steps {
+      display: flex;
+      gap: 0;
+      align-items: stretch;
+      margin-top: 1em;
+      counter-reset: step;
+    }
+    .reveal .slides section.process-slide .process-step {
+      flex: 1;
+      padding: 0.8em 1em;
+      position: relative;
+      counter-increment: step;
+    }
+    .reveal .slides section.process-slide .process-step::before {
+      content: counter(step, decimal-leading-zero);
+      display: block;
+      font-family: var(--r-heading-font);
+      font-size: 0.7em;
+      color: var(--r-accent-color);
+      letter-spacing: 0.1em;
+      margin-bottom: 0.3em;
+    }
+    .reveal .slides section.process-slide .process-step h3 {
+      font-size: 0.9em;
+      margin: 0 0 0.4em 0;
+      letter-spacing: -0.01em;
+    }
+    .reveal .slides section.process-slide .process-step p {
+      font-size: 0.6em;
+      line-height: 1.45;
+      opacity: 0.85;
+    }
+    .reveal .slides section.process-slide .process-step:not(:last-child)::after {
+      content: '→';
+      position: absolute;
+      right: -0.5em;
+      top: 50%;
+      transform: translateY(-50%);
+      font-size: 1.4em;
+      opacity: 0.35;
+      color: var(--r-accent-color);
+    }
+
+    /* timeline — vertical events with date marker */
+    .reveal .slides section.timeline-slide .timeline-events {
+      list-style: none;
+      padding: 0;
+      margin: 1em 0 0 0;
+      position: relative;
+    }
+    .reveal .slides section.timeline-slide .timeline-events::before {
+      content: '';
+      position: absolute;
+      left: 0.5em;
+      top: 0.4em;
+      bottom: 0.4em;
+      width: 2px;
+      background: var(--r-accent-color);
+      opacity: 0.4;
+    }
+    .reveal .slides section.timeline-slide .timeline-event {
+      padding: 0.6em 0 0.6em 2em;
+      position: relative;
+      font-size: 0.74em;
+    }
+    .reveal .slides section.timeline-slide .timeline-event::before {
+      content: '';
+      position: absolute;
+      left: 0.2em;
+      top: 0.85em;
+      width: 0.6em;
+      height: 0.6em;
+      border-radius: 50%;
+      background: var(--r-accent-color);
+      box-shadow: 0 0 0 4px var(--r-background-color);
+    }
+    .reveal .slides section.timeline-slide .timeline-event time {
+      display: block;
+      font-family: var(--r-heading-font);
+      font-size: 0.85em;
+      color: var(--r-accent-color);
+      letter-spacing: 0.04em;
+    }
+    .reveal .slides section.timeline-slide .timeline-event h3 {
+      font-size: 1em;
+      margin: 0.1em 0;
+    }
+    .reveal .slides section.timeline-slide .timeline-event p {
+      font-size: 0.85em;
+      opacity: 0.8;
+      margin: 0;
+    }
+
+    /* definition — term + meaning, dictionary-entry style */
+    .reveal .slides section.definition-slide {
+      text-align: left;
+    }
+    .reveal .slides section.definition-slide .def-term {
+      font-family: var(--r-heading-font);
+      font-size: 2.2em;
+      letter-spacing: -0.02em;
+      color: var(--r-heading-color);
+      display: inline-block;
+      padding-bottom: 0.05em;
+      border-bottom: 3px solid var(--r-accent-color);
+      margin-bottom: 0.3em;
+    }
+    .reveal .slides section.definition-slide .def-pronunciation {
+      font-style: italic;
+      opacity: 0.5;
+      font-size: 0.45em;
+      margin-left: 0.4em;
+    }
+    .reveal .slides section.definition-slide .def-pos {
+      font-style: italic;
+      opacity: 0.6;
+      font-size: 0.5em;
+      letter-spacing: 0.05em;
+      display: block;
+      margin: 0.4em 0 0.3em 0;
+    }
+    .reveal .slides section.definition-slide .def-meaning {
+      font-size: 0.78em;
+      line-height: 1.5;
+      max-width: 80%;
+    }
+    .reveal .slides section.definition-slide .def-meaning + .def-meaning {
+      margin-top: 0.4em;
+    }
+    .reveal .slides section.definition-slide .def-meaning::before {
+      content: counter(def-counter) '. ';
+      counter-increment: def-counter;
+      font-family: var(--r-heading-font);
+      color: var(--r-accent-color);
+      margin-right: 0.4em;
+    }
+    .reveal .slides section.definition-slide {
+      counter-reset: def-counter;
+    }
+
+    /* cards — grid of mini-cards. Use .card-2x2 / .card-3x2 / .card-3x3. */
+    .reveal .slides section.cards-slide .card-grid {
+      display: grid;
+      gap: 0.6em;
+      margin-top: 1em;
+    }
+    .reveal .slides section.cards-slide .card-grid.card-2x2 { grid-template-columns: 1fr 1fr; }
+    .reveal .slides section.cards-slide .card-grid.card-3x2 { grid-template-columns: 1fr 1fr 1fr; }
+    .reveal .slides section.cards-slide .card-grid.card-3x3 { grid-template-columns: 1fr 1fr 1fr; }
+    .reveal .slides section.cards-slide .card {
+      padding: 0.8em 0.9em;
+      background: rgba(127,127,127,0.08);
+      border-left: 3px solid var(--r-accent-color);
+      border-radius: 2px;
+    }
+    .reveal .slides section.cards-slide .card h3 {
+      font-size: 0.78em;
+      margin: 0 0 0.3em 0;
+      letter-spacing: -0.01em;
+      color: var(--r-heading-color);
+    }
+    .reveal .slides section.cards-slide .card p {
+      font-size: 0.55em;
+      line-height: 1.5;
+      margin: 0;
+      opacity: 0.85;
+    }
+    .reveal .slides section.cards-slide .card .card-icon {
+      font-size: 1.4em;
+      margin-bottom: 0.2em;
+      color: var(--r-accent-color);
+    }
+
+    /* diagram — agent-supplied SVG/HTML, centered with consistent caption styling */
+    .reveal .slides section.diagram-slide {
+      text-align: center;
+    }
+    .reveal .slides section.diagram-slide .diagram-content {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      max-height: 65vh;
+      margin: 1em auto;
+    }
+    .reveal .slides section.diagram-slide .diagram-content > svg,
+    .reveal .slides section.diagram-slide .diagram-content > * {
+      max-width: 90%;
+      max-height: 65vh;
+    }
+    .reveal .slides section.diagram-slide .diagram-caption {
+      font-family: var(--r-main-font);
+      font-style: italic;
+      font-size: 0.5em;
+      opacity: 0.7;
+      margin-top: 0.4em;
+    }
+
+    /* ========================================================================
+       MINI-ANIMATIONS — element-level effects for staged builds
+       ======================================================================== */
+
+    /* typewriter — types text out character by character on slide entry */
+    .reveal .slides section.present .typewriter {
+      display: inline-block;
+      overflow: hidden;
+      white-space: nowrap;
+      border-right: 2px solid currentColor;
+      animation:
+        typewriter 1.6s steps(30, end) backwards,
+        blink 0.7s step-end infinite;
+      animation-delay: 0.2s, 1.8s;
+    }
+    @keyframes typewriter { from { width: 0; } to { width: 100%; } }
+    @keyframes blink { 50% { border-color: transparent; } }
+
+    /* counter-up — populated by JS; CSS reserves the visual */
+    .reveal .slides section.present .counter-up { font-variant-numeric: tabular-nums; }
+
+    /* draw-line — animates an SVG path's stroke-dashoffset to 0 */
+    .reveal .slides section.present .draw-line {
+      stroke-dasharray: 1000;
+      stroke-dashoffset: 1000;
+      animation: draw 1.4s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+      animation-delay: 0.3s;
+    }
+    @keyframes draw { to { stroke-dashoffset: 0; } }
+
+    /* flip-card — element flips on entrance */
+    .reveal .slides section.present .flip-card {
+      animation: flip-in 0.7s cubic-bezier(0.2, 0.8, 0.2, 1) backwards;
+      backface-visibility: hidden;
+      transform-style: preserve-3d;
+    }
+    @keyframes flip-in {
+      from { transform: perspective(800px) rotateY(180deg); opacity: 0; }
+      to   { transform: perspective(800px) rotateY(0); opacity: 1; }
+    }
+
+    /* slide-in-from — directional entrance for any element with data-from="left|right|top|bottom" */
+    .reveal .slides section.present [data-from="left"]   { animation: slide-from-left 0.5s cubic-bezier(0.2, 0.8, 0.2, 1) backwards; }
+    .reveal .slides section.present [data-from="right"]  { animation: slide-from-right 0.5s cubic-bezier(0.2, 0.8, 0.2, 1) backwards; }
+    .reveal .slides section.present [data-from="top"]    { animation: slide-from-top 0.5s cubic-bezier(0.2, 0.8, 0.2, 1) backwards; }
+    .reveal .slides section.present [data-from="bottom"] { animation: slide-from-bottom 0.5s cubic-bezier(0.2, 0.8, 0.2, 1) backwards; }
+    @keyframes slide-from-left   { from { opacity: 0; transform: translateX(-40px); } to { opacity: 1; transform: translateX(0); } }
+    @keyframes slide-from-right  { from { opacity: 0; transform: translateX(40px); }  to { opacity: 1; transform: translateX(0); } }
+    @keyframes slide-from-top    { from { opacity: 0; transform: translateY(-30px); } to { opacity: 1; transform: translateY(0); } }
+    @keyframes slide-from-bottom { from { opacity: 0; transform: translateY(30px); }  to { opacity: 1; transform: translateY(0); } }
+
+    /* ========================================================================
+       MODES — traditional, zoom, rapid
+       Set on the .reveal element via data-mode. The agent passes mode at
+       deck creation; the renderer wires up mode-specific behaviors.
+       ======================================================================== */
+
+    /* rapid mode — Lessig style. Suppress entrance effects (slides too short
+       for animations to land). Force big-word visual register on any slide
+       that doesn't explicitly pick a type. */
+    .reveal[data-mode="rapid"] .slides section {
+      transition: none;
+    }
+    .reveal[data-mode="rapid"] .effect-aurora-bg::before,
+    .reveal[data-mode="rapid"] .effect-conic-bg::before {
+      animation-duration: 240s; /* slow background to imperceptible */
+      opacity: 0.25;
+    }
+    .reveal[data-mode="rapid"] .slides section.present .typewriter {
+      animation: none;
+      border-right: none;
+    }
+    /* In rapid mode, default content slides should look big-word-ish */
+    .reveal[data-mode="rapid"] .slides section:not(.title-slide):not(.section-slide):not(.metric-slide):not(.comparison-slide):not(.process-slide):not(.timeline-slide):not(.definition-slide):not(.cards-slide):not(.diagram-slide):not(.code-slide):not(.quote-slide):not(.image-slide):not(.big-word-slide) {
+      text-align: center;
+    }
+    .reveal[data-mode="rapid"] .slides section h2 {
+      font-size: clamp(54px, 10vw, 160px);
+      line-height: 1;
+    }
+
+    /* zoom mode — vertical sub-slides scale into different regions of the
+       parent overview. Each detail slide gets effect-zoom-blur entry and
+       a subtle scale for context-loss feel. */
+    .reveal[data-mode="zoom"] .slides > section.zoom-overview {
+      text-align: center;
+    }
+    .reveal[data-mode="zoom"] .slides > section.zoom-overview .zoom-region {
+      cursor: default;
+      transition: transform 0.4s, box-shadow 0.4s;
+      padding: 0.6em 0.9em;
+      border-radius: 4px;
+      border: 2px solid var(--r-accent-color);
+      background: rgba(127,127,127,0.06);
+    }
+    .reveal[data-mode="zoom"] .slides > section.zoom-detail.present {
+      animation: zoom-in 0.6s cubic-bezier(0.2, 0.8, 0.2, 1) backwards;
+    }
+    @keyframes zoom-in {
+      from { opacity: 0; transform: scale(0.6) translateY(40px); filter: blur(8px); }
+      to   { opacity: 1; transform: scale(1) translateY(0);    filter: blur(0); }
+    }
+
+    /* ========================================================================
        END BESPOKE EFFECTS LAYER
        ======================================================================== */
   </style>
@@ -689,23 +1171,53 @@
    *
    * Full content push (includes optional themeCSS for custom styling):
    * {
+   *   "mode": "traditional" | "zoom" | "rapid",
+   *           // traditional = default; zoom = big-picture-first with vertical
+   *           // detail slides; rapid = Lessig-style auto-advance ≤20s/slide.
    *   "slides": [
    *     {
-   *       "type": "title" | "content" | "code" | "quote" | "image" | "section",
+   *       "type": "title" | "content" | "code" | "quote" | "image" | "section"
+   *             | "big-word" | "metric" | "comparison" | "process"
+   *             | "timeline" | "definition" | "cards" | "diagram"
+   *             | "zoom-overview" | "zoom-detail",
+   *
+   *       // Common fields:
    *       "title": "Slide Title",
    *       "subtitle": "Optional subtitle",
-   *       "content": "HTML content or markdown",
-   *       "bullets": ["bullet 1", "bullet 2"],
-   *       "code": "code block content",
-   *       "language": "js",
-   *       "quote": "Quote text",
-   *       "attribution": "Quote author",
    *       "background": "#hex or image URL",
    *       "notes": "Speaker notes",
-   *       "fragments": true,         // animate bullets one by one
-   *       "effects": ["effect-aurora-bg", "effect-displaced-heading", "effect-3d-flip-in"]
-   *                                  // space-joined onto the section's class.
-   *                                  // see style-guide.md § Effects vocabulary.
+   *       "fragments": true,           // animate bullets/children one by one
+   *       "effects": ["effect-..."],   // see style-guide.md § Effects vocabulary
+   *       "autoslide": 12000,          // ms; rapid-mode default = 20000
+   *
+   *       // Per-type fields:
+   *       "content": "<p>HTML</p>",                       // content
+   *       "bullets": ["b1", "b2"],                        // content
+   *       "code": "...", "language": "js",                // code
+   *       "quote": "...", "attribution": "...",           // quote
+   *       "src": "url", "alt": "...",                     // image
+   *       "word": "TRANSFORM", "accent": "FORM",          // big-word (accent is highlighted substring)
+   *       "metric": { "value": "73%", "label": "...", "delta": "+12", "direction": "up" },
+   *       "comparison": { "left":  { "title": "Today",     "items": ["..."] },
+   *                       "right": { "title": "Tomorrow",  "items": ["..."] }, "vs": "VS" },
+   *       "steps": [ { "title": "...", "description": "..." }, ... ],   // process
+   *       "events": [ { "date": "2024", "title": "...", "description": "..." }, ... ],  // timeline
+   *       "definition": { "term": "...", "pronunciation": "/.../", "pos": "noun",
+   *                       "meanings": ["...", "..."] },
+   *       "cards": { "layout": "card-2x2"|"card-3x2"|"card-3x3",
+   *                  "items": [ { "icon": "✱", "title": "...", "description": "..." } ] },
+   *       "diagram": "<svg>...</svg> | <div>...</div>",                  // diagram inner HTML
+   *       "caption": "...",                                              // diagram caption
+   *       "regions": [ { "id": "north", "label": "..." } ],              // zoom-overview
+   *       "regionId": "north",                                           // zoom-detail (links to overview region)
+   *
+   *       // Builds: optional staged element-reveal beyond simple fragments.
+   *       // The renderer applies data-fragment-index attributes to children
+   *       // matching the selector. Reveal.js handles the actual reveal.
+   *       "builds": [
+   *         { "selector": ".card", "stagger": true },          // reveal cards one by one
+   *         { "selector": "h3", "at": 1 }                      // reveal h3 at fragment index 1
+   *       ]
    *     }
    *   ],
    *   "theme": "stardust-derived",
@@ -754,6 +1266,7 @@
   let currentSlides = [];
   let currentTheme = 'black';
   let currentTransition = 'slide';
+  let currentMode = 'traditional';
   let revealInstance = null;
 
   // Fallback CSS for when themeCSS is not provided by the agent.
@@ -815,14 +1328,168 @@
       .join(' ');
   }
 
+  // Allowlist of inline tags + attrs we accept inside diagram HTML and content fields.
+  // Strips <script>, on*= handlers, and javascript: URLs.
+  function sanitizeRichHtml(html) {
+    if (typeof html !== 'string') return '';
+    return html
+      .replace(/<script\b[\s\S]*?<\/script\s*>/gi, '')
+      .replace(/<\/?(?:iframe|object|embed|link|meta|style|form)\b[^>]*>/gi, '')
+      .replace(/\s(on[a-z]+)\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, '')
+      .replace(/(href|xlink:href|src)\s*=\s*("|')\s*javascript:[^"']*\2/gi, '$1=$2#$2');
+  }
+
   // --- Slide rendering ---
-  // Converts a slide object from the DATA CONTRACT into a <section> HTML string.
   function renderBullets(bullets, fragments) {
     if (!bullets || !bullets.length) return '';
     var items = bullets.map(function(b) {
       return '<li' + (fragments ? ' class="fragment"' : '') + '>' + escHtml(b) + '</li>';
     }).join('\n          ');
     return '<ul>\n          ' + items + '\n        </ul>';
+  }
+
+  // Splits a phrase into a leading and accent span when slide.accent is a substring of slide.word.
+  function renderBigWord(slide) {
+    var word = slide.word || slide.title || '';
+    var accent = slide.accent;
+    if (!accent || word.indexOf(accent) === -1) {
+      return '<p class="big-word">' + escHtml(word) + '</p>';
+    }
+    var parts = word.split(accent);
+    return '<p class="big-word">' + escHtml(parts[0])
+      + '<span class="accent">' + escHtml(accent) + '</span>'
+      + escHtml(parts.slice(1).join(accent)) + '</p>';
+  }
+
+  function renderMetric(slide) {
+    var m = slide.metric || {};
+    var deltaCls = (m.direction === 'down') ? 'down' : (m.direction === 'up' ? 'up' : '');
+    var arrow = (m.direction === 'down') ? '▼' : (m.direction === 'up' ? '▲' : '');
+    return '<div class="metric-value">' + escHtml(m.value || '')
+      + (m.delta ? '<span class="metric-delta ' + deltaCls + '">' + arrow + ' ' + escHtml(m.delta) + '</span>' : '')
+      + '</div>'
+      + (m.label ? '<div class="metric-label">' + escHtml(m.label) + '</div>' : '');
+  }
+
+  function renderComparisonCol(col, side) {
+    if (!col) return '';
+    var items = '';
+    if (Array.isArray(col.items)) {
+      items = '<ul>' + col.items.map(function(i) {
+        return '<li>' + escHtml(i) + '</li>';
+      }).join('') + '</ul>';
+    }
+    return '<div class="comparison-col ' + side + '">'
+      + (col.title ? '<h3>' + escHtml(col.title) + '</h3>' : '')
+      + items
+      + (col.content ? '<p>' + escHtml(col.content) + '</p>' : '')
+      + '</div>';
+  }
+
+  function renderComparison(slide) {
+    var c = slide.comparison || {};
+    return '<div class="comparison-grid">'
+      + renderComparisonCol(c.left, 'left')
+      + '<div class="comparison-vs">' + escHtml(c.vs || 'VS') + '</div>'
+      + renderComparisonCol(c.right, 'right')
+      + '</div>';
+  }
+
+  function renderProcess(slide) {
+    if (!Array.isArray(slide.steps)) return '';
+    return '<div class="process-steps">'
+      + slide.steps.map(function(s) {
+        return '<div class="process-step">'
+          + (s.title ? '<h3>' + escHtml(s.title) + '</h3>' : '')
+          + (s.description ? '<p>' + escHtml(s.description) + '</p>' : '')
+          + '</div>';
+      }).join('')
+      + '</div>';
+  }
+
+  function renderTimeline(slide) {
+    if (!Array.isArray(slide.events)) return '';
+    return '<ul class="timeline-events">'
+      + slide.events.map(function(e) {
+        return '<li class="timeline-event">'
+          + (e.date ? '<time>' + escHtml(e.date) + '</time>' : '')
+          + (e.title ? '<h3>' + escHtml(e.title) + '</h3>' : '')
+          + (e.description ? '<p>' + escHtml(e.description) + '</p>' : '')
+          + '</li>';
+      }).join('')
+      + '</ul>';
+  }
+
+  function renderDefinition(slide) {
+    var d = slide.definition || {};
+    var meanings = Array.isArray(d.meanings) ? d.meanings : [];
+    return '<div class="def-term">' + escHtml(d.term || '')
+      + (d.pronunciation ? '<span class="def-pronunciation">' + escHtml(d.pronunciation) + '</span>' : '')
+      + '</div>'
+      + (d.pos ? '<span class="def-pos">' + escHtml(d.pos) + '</span>' : '')
+      + meanings.map(function(m) {
+        return '<p class="def-meaning">' + escHtml(m) + '</p>';
+      }).join('');
+  }
+
+  function renderCards(slide) {
+    var c = slide.cards || {};
+    var layout = ['card-2x2','card-3x2','card-3x3'].indexOf(c.layout) >= 0 ? c.layout : 'card-2x2';
+    var items = Array.isArray(c.items) ? c.items : [];
+    return '<div class="card-grid ' + layout + '">'
+      + items.map(function(item) {
+        return '<div class="card">'
+          + (item.icon ? '<div class="card-icon">' + escHtml(item.icon) + '</div>' : '')
+          + (item.title ? '<h3>' + escHtml(item.title) + '</h3>' : '')
+          + (item.description ? '<p>' + escHtml(item.description) + '</p>' : '')
+          + '</div>';
+      }).join('')
+      + '</div>';
+  }
+
+  function renderDiagram(slide) {
+    var inner = sanitizeRichHtml(slide.diagram || '');
+    return '<div class="diagram-content">' + inner + '</div>'
+      + (slide.caption ? '<div class="diagram-caption">' + escHtml(slide.caption) + '</div>' : '');
+  }
+
+  function renderZoomOverview(slide) {
+    var regions = Array.isArray(slide.regions) ? slide.regions : [];
+    var inner = slide.diagram
+      ? '<div class="diagram-content">' + sanitizeRichHtml(slide.diagram) + '</div>'
+      : ('<div style="display:flex; gap:1em; flex-wrap:wrap; justify-content:center;">'
+          + regions.map(function(r) {
+            return '<div class="zoom-region" data-region-id="' + escHtml(r.id || '') + '">'
+              + escHtml(r.label || r.id || '') + '</div>';
+          }).join('')
+          + '</div>');
+    return inner;
+  }
+
+  // Apply builds: assign data-fragment-index to matching children for staged reveals.
+  // builds = [{ selector, stagger?: bool, at?: number }]
+  function applyBuilds(html, builds) {
+    if (!Array.isArray(builds) || !builds.length) return html;
+    var temp = document.createElement('div');
+    temp.innerHTML = html;
+    builds.forEach(function(b) {
+      if (!b || !b.selector) return;
+      var matches;
+      try { matches = temp.querySelectorAll(b.selector); }
+      catch (e) { return; }
+      if (b.stagger) {
+        Array.prototype.forEach.call(matches, function(el, i) {
+          el.classList.add('fragment');
+          el.setAttribute('data-fragment-index', i);
+        });
+      } else {
+        Array.prototype.forEach.call(matches, function(el) {
+          el.classList.add('fragment');
+          if (typeof b.at === 'number') el.setAttribute('data-fragment-index', b.at);
+        });
+      }
+    });
+    return temp.innerHTML;
   }
 
   function renderSlide(slide) {
@@ -834,16 +1501,31 @@
         bg = ' data-background-image="' + slide.background + '" data-background-size="cover"';
       }
     }
+    if (typeof slide.autoslide === 'number' && slide.autoslide > 0) {
+      bg += ' data-autoslide="' + (slide.autoslide | 0) + '"';
+    }
     var notes = slide.notes
       ? '<aside class="notes">' + escHtml(slide.notes) + '</aside>'
       : '';
 
     var fx = effectClasses(slide.effects);
-    // data-text on h1/h2 enables effect-misregister's ::before to mirror the heading
     var titleAttrs = slide.title ? ' data-text="' + escHtml(slide.title) + '"' : '';
 
     function classOf(base) {
       return (base + (fx ? ' ' + fx : '')).trim();
+    }
+
+    function withBuilds(innerHtml) {
+      return applyBuilds(innerHtml, slide.builds);
+    }
+
+    function wrap(extraClass, innerHtml) {
+      var cls = classOf(extraClass);
+      return '<section class="' + cls + '"' + bg + '>'
+        + (slide.title && extraClass !== 'title-slide' && extraClass !== 'section-slide' && extraClass !== 'big-word-slide'
+            ? '<h2' + titleAttrs + '>' + escHtml(slide.title) + '</h2>' : '')
+        + withBuilds(innerHtml)
+        + notes + '</section>';
     }
 
     switch (slide.type) {
@@ -862,12 +1544,14 @@
       case 'content':
         return '<section' + (fx ? ' class="' + fx + '"' : '') + bg + '>'
           + (slide.title ? '<h2' + titleAttrs + '>' + escHtml(slide.title) + '</h2>' : '')
-          + (slide.content ? '<div>' + slide.content + '</div>' : '')
-          + (slide.bullets ? renderBullets(slide.bullets, slide.fragments) : '')
+          + withBuilds(
+              (slide.content ? '<div>' + sanitizeRichHtml(slide.content) + '</div>' : '')
+              + (slide.bullets ? renderBullets(slide.bullets, slide.fragments) : '')
+            )
           + notes + '</section>';
 
       case 'code':
-        return '<section' + (fx ? ' class="' + fx + '"' : '') + bg + '>'
+        return '<section class="' + classOf('code-slide') + '"' + bg + '>'
           + (slide.title ? '<h2' + titleAttrs + '>' + escHtml(slide.title) + '</h2>' : '')
           + '<pre><code class="' + (slide.language || '') + '" data-trim data-noescape>'
           + escHtml(slide.code || '') + '</code></pre>'
@@ -881,32 +1565,134 @@
           + notes + '</section>';
 
       case 'image':
-        return '<section' + (fx ? ' class="' + fx + '"' : '') + bg + '>'
+        return '<section class="' + classOf('image-slide') + '"' + bg + '>'
           + (slide.title ? '<h2' + titleAttrs + '>' + escHtml(slide.title) + '</h2>' : '')
           + (slide.src ? '<img src="' + escHtml(slide.src) + '" alt="' + escHtml(slide.alt || slide.title || '') + '" style="max-height: 60vh; max-width: 90%; object-fit: contain;">' : '')
-          + (slide.content ? '<div>' + slide.content + '</div>' : '')
+          + (slide.content ? '<div>' + sanitizeRichHtml(slide.content) + '</div>' : '')
+          + notes + '</section>';
+
+      case 'big-word':
+        return '<section class="' + classOf('big-word-slide') + '"' + bg + '>'
+          + renderBigWord(slide)
+          + (slide.subtitle ? '<p class="big-word-sub">' + escHtml(slide.subtitle) + '</p>' : '')
+          + notes + '</section>';
+
+      case 'metric':
+        return wrap('metric-slide', renderMetric(slide));
+
+      case 'comparison':
+        return wrap('comparison-slide', renderComparison(slide));
+
+      case 'process':
+        return wrap('process-slide', renderProcess(slide));
+
+      case 'timeline':
+        return wrap('timeline-slide', renderTimeline(slide));
+
+      case 'definition':
+        return wrap('definition-slide', renderDefinition(slide));
+
+      case 'cards':
+        return wrap('cards-slide', renderCards(slide));
+
+      case 'diagram':
+        return wrap('diagram-slide', renderDiagram(slide));
+
+      case 'zoom-overview':
+        return '<section class="' + classOf('zoom-overview') + '"' + bg + '>'
+          + (slide.title ? '<h2' + titleAttrs + '>' + escHtml(slide.title) + '</h2>' : '')
+          + withBuilds(renderZoomOverview(slide))
+          + notes + '</section>';
+
+      case 'zoom-detail':
+        return '<section class="' + classOf('zoom-detail') + '"' + bg
+          + (slide.regionId ? ' data-region-id="' + escHtml(slide.regionId) + '"' : '') + '>'
+          + (slide.title ? '<h2' + titleAttrs + '>' + escHtml(slide.title) + '</h2>' : '')
+          + withBuilds(
+              (slide.content ? '<div>' + sanitizeRichHtml(slide.content) + '</div>' : '')
+              + (slide.bullets ? renderBullets(slide.bullets, slide.fragments) : '')
+            )
           + notes + '</section>';
 
       default:
-        // Fallback: treat as generic content slide
         return '<section' + (fx ? ' class="' + fx + '"' : '') + bg + '>'
           + (slide.title ? '<h2' + titleAttrs + '>' + escHtml(slide.title) + '</h2>' : '')
-          + (slide.content ? '<div>' + slide.content + '</div>' : '')
-          + (slide.bullets ? renderBullets(slide.bullets, slide.fragments) : '')
+          + withBuilds(
+              (slide.content ? '<div>' + sanitizeRichHtml(slide.content) + '</div>' : '')
+              + (slide.bullets ? renderBullets(slide.bullets, slide.fragments) : '')
+            )
           + notes + '</section>';
     }
   }
 
+  // Animate any .counter-up element on slide entry: counts from 0 to its
+  // final numeric value over ~1.2s. Final value is read from data-target.
+  function animateCounters(section) {
+    if (!section) return;
+    var els = section.querySelectorAll('.counter-up');
+    Array.prototype.forEach.call(els, function(el) {
+      var target = parseFloat(el.getAttribute('data-target') || el.textContent);
+      if (isNaN(target)) return;
+      var start = performance.now();
+      var duration = 1200;
+      var fmt = el.getAttribute('data-format') || '';
+      var suffix = el.getAttribute('data-suffix') || '';
+      function tick(now) {
+        var t = Math.min(1, (now - start) / duration);
+        var eased = 1 - Math.pow(1 - t, 3);
+        var val = target * eased;
+        el.textContent = (fmt === 'int' ? Math.round(val) : val.toFixed(1)) + suffix;
+        if (t < 1) requestAnimationFrame(tick);
+      }
+      requestAnimationFrame(tick);
+    });
+  }
+
   // --- Presentation lifecycle ---
+  function applyMode(mode) {
+    var revealEl = document.querySelector('.reveal');
+    if (!revealEl) return;
+    var validModes = ['traditional', 'zoom', 'rapid'];
+    var m = validModes.indexOf(mode) >= 0 ? mode : 'traditional';
+    revealEl.setAttribute('data-mode', m);
+    currentMode = m;
+  }
+
+  // In rapid mode, default each slide that lacks an explicit autoslide to 20s.
+  function applyRapidAutoslide() {
+    if (currentMode !== 'rapid') return;
+    var sections = document.querySelectorAll('#slides-container > section');
+    Array.prototype.forEach.call(sections, function(s) {
+      if (!s.hasAttribute('data-autoslide')) {
+        s.setAttribute('data-autoslide', '20000');
+      }
+    });
+  }
+
+  function onSlideChanged(event) {
+    updateSlideCounter();
+    if (event && event.currentSlide) animateCounters(event.currentSlide);
+  }
+
   function buildPresentation(slides, transition) {
     var container = document.getElementById('slides-container');
     container.innerHTML = slides.map(renderSlide).join('\n');
+    applyRapidAutoslide();
 
     if (revealInstance) {
       // Sync existing instance with new DOM
+      revealInstance.configure({
+        transition: transition || currentTransition || 'slide',
+        autoSlide: 0,                   // per-slide data-autoslide overrides
+        autoSlideStoppable: true,
+      });
       revealInstance.sync();
       revealInstance.slide(0);
       updateSlideCounter();
+      // Fire counter animation on the now-current slide
+      var idx = revealInstance.getIndices();
+      var present = revealInstance.getSlides()[idx.h] || null;
+      if (present) animateCounters(present);
     } else {
       revealInstance = new Reveal({
         hash: false,
@@ -920,11 +1706,15 @@
         margin: 0.04,
         minScale: 0.2,
         maxScale: 2.0,
-        embedded: true,  // critical for sprinkle panel embedding
+        embedded: true,                 // critical for sprinkle panel embedding
+        autoSlide: 0,                   // honor per-slide data-autoslide
+        autoSlideStoppable: true,
       });
       revealInstance.initialize().then(function() {
-        revealInstance.on('slidechanged', updateSlideCounter);
+        revealInstance.on('slidechanged', onSlideChanged);
         updateSlideCounter();
+        var first = document.querySelector('#slides-container > section.present');
+        if (first) animateCounters(first);
       });
     }
   }
@@ -986,6 +1776,7 @@
       currentSlides = data.slides;
       if (data.theme) applyTheme(data.theme, data.themeCSS);
       if (data.transition) currentTransition = data.transition;
+      applyMode(data.mode || 'traditional');
       setState('ready');
       buildPresentation(currentSlides, currentTransition);
     }

--- a/skills/presentations/templates/presentation.shtml
+++ b/skills/presentations/templates/presentation.shtml
@@ -1484,12 +1484,15 @@
    *       "shaderConfig": { "speed": 0.4, "scale": 1.2 },                // optional per-shader options
    *       "regions": [ { "id": "north", "label": "..." } ],              // zoom-overview
    *       "regionId": "north",                                           // zoom-detail (links to overview region)
-   *       "html": "<style>...</style><script>...</script><div>...</div>",
+   *       "html": "<style>...<\/style><script>...<\/script><div>...<\/div>",
    *                  // html — full section body, no chrome, NO SANITIZER.
    *                  // <script>, <style>, <iframe>, on*= handlers all
    *                  // pass through and execute. Trust model: agent
    *                  // writes the deck. Scripts are rehydrated post-
    *                  // innerHTML so they actually run.
+   *                  // (the </ in this docstring is escaped as <\/ so the
+   *                  //  HTML parser doesn't see a script-end inside the
+   *                  //  inline <script> block this whole comment lives in.)
    *       "takeaways": ["...", "...", "..."],                            // recap — 3 takeaway lines
    *       "cta": { "label": "...", "text": "..." },                      // recap — closing call-to-action
    *

--- a/skills/presentations/templates/presentation.shtml
+++ b/skills/presentations/templates/presentation.shtml
@@ -1020,6 +1020,178 @@
     }
 
     /* ========================================================================
+       VIEW TRANSITIONS — same-document API (Baseline since Oct 2025)
+       Browsers with support animate matched elements between slide changes.
+       Each named element class gets a unique view-transition-name; if the
+       same name appears on the next slide, the browser morphs old → new
+       (size, position, opacity). Falls back gracefully when unsupported.
+       ======================================================================== */
+
+    @supports (view-transition-name: a) {
+      .reveal .slides section.title-slide h1 { view-transition-name: deck-headline; }
+      .reveal .slides section.section-slide h2 { view-transition-name: deck-headline; }
+      .reveal .slides section.metric-slide .metric-value { view-transition-name: deck-metric; }
+      .reveal .slides section.big-word-slide .big-word { view-transition-name: deck-bigword; }
+      .reveal .slides section.recap-slide { view-transition-name: deck-recap; }
+      .reveal .slides section h2 { view-transition-name: slide-h2; }
+      /* Custom keyframes — slow + ease for cinematic feel */
+      ::view-transition-old(deck-headline),
+      ::view-transition-new(deck-headline),
+      ::view-transition-old(deck-metric),
+      ::view-transition-new(deck-metric),
+      ::view-transition-old(deck-bigword),
+      ::view-transition-new(deck-bigword) {
+        animation-duration: 0.55s;
+        animation-timing-function: cubic-bezier(0.2, 0.8, 0.2, 1);
+      }
+    }
+
+    /* Per-element opt-in via data-vt-name="..." — agent can match any two
+       elements across slides for custom morphs. */
+    @supports (view-transition-name: a) {
+      [data-vt-name] { view-transition-name: attr(data-vt-name type(<custom-ident>), none); }
+    }
+
+    /* ========================================================================
+       SCROLL-DRIVEN PROGRESS BAR — pure CSS, no JS, no IntersectionObserver
+       Visible at the top of the deck in scroll view mode; signals deck length.
+       ======================================================================== */
+
+    @supports (animation-timeline: scroll()) {
+      .reveal[data-mode="scroll"] .deck-progress {
+        position: fixed;
+        top: 0; left: 0;
+        height: 3px;
+        background: var(--r-accent-color, #36d6a8);
+        transform-origin: left center;
+        animation: deck-progress-fill linear;
+        animation-timeline: scroll(root block);
+        z-index: 10000;
+      }
+      @keyframes deck-progress-fill {
+        from { transform: scaleX(0); }
+        to   { transform: scaleX(1); }
+      }
+    }
+    /* Hide by default; only the scroll mode shows it */
+    .deck-progress {
+      position: fixed;
+      top: 0; left: 0;
+      height: 0;
+      width: 100%;
+      background: transparent;
+      pointer-events: none;
+      z-index: 10000;
+    }
+
+    /* ========================================================================
+       ANCHOR-POSITIONED CALLOUTS — declarative tooltips/asides that
+       auto-flip when they would overflow. Pairs with the Popover API for
+       click-to-reveal. Particularly valuable for `definition` and
+       `diagram` slides. Falls back to position: absolute on older browsers.
+       ======================================================================== */
+
+    .reveal .anchor {
+      color: var(--r-accent-color);
+      text-decoration: underline dotted;
+      cursor: help;
+    }
+
+    @supports (anchor-name: --x) {
+      .reveal .anchor[id] { anchor-name: var(--anchor-name, --auto); }
+      .reveal .callout {
+        position: absolute;
+        position-anchor: var(--anchor);
+        top: anchor(bottom);
+        left: anchor(center);
+        translate: -50% 8px;
+        position-try-fallbacks: flip-block, flip-inline;
+        max-width: 28ch;
+        padding: 0.5em 0.8em;
+        background: var(--r-background-color);
+        color: var(--r-main-color);
+        border: 1px solid var(--r-accent-color);
+        border-radius: 4px;
+        font-size: 0.6em;
+        line-height: 1.4;
+        z-index: 100;
+      }
+    }
+
+    /* Popover-API variant — click an .anchor with popovertarget to reveal */
+    .reveal [popover] {
+      border: 1px solid var(--r-accent-color);
+      background: var(--r-background-color);
+      color: var(--r-main-color);
+      padding: 0.6em 0.9em;
+      border-radius: 4px;
+      max-width: 32ch;
+      font-size: 0.65em;
+    }
+    .reveal [popover]::backdrop { background: rgba(0,0,0,0.4); }
+
+    /* ========================================================================
+       RECAP SLIDE — closing-screen "3 takeaways + CTA" (the new normal
+       because decks are shared async after the talk).
+       ======================================================================== */
+
+    .reveal .slides section.recap-slide {
+      text-align: left;
+    }
+    .reveal .slides section.recap-slide .recap-grid {
+      display: grid;
+      grid-template-columns: 2fr 1fr;
+      gap: 2em;
+      align-items: stretch;
+    }
+    .reveal .slides section.recap-slide .recap-takeaways {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      counter-reset: recap;
+    }
+    .reveal .slides section.recap-slide .recap-takeaways li {
+      counter-increment: recap;
+      padding: 0.6em 0 0.6em 2.2em;
+      position: relative;
+      font-size: 0.78em;
+      border-bottom: 1px solid color-mix(in oklab, var(--r-main-color) 20%, transparent);
+    }
+    .reveal .slides section.recap-slide .recap-takeaways li:last-child {
+      border-bottom: none;
+    }
+    .reveal .slides section.recap-slide .recap-takeaways li::before {
+      content: counter(recap);
+      position: absolute;
+      left: 0;
+      top: 0.5em;
+      font-family: var(--r-heading-font);
+      font-size: 1.6em;
+      color: var(--r-accent-color);
+      line-height: 1;
+    }
+    .reveal .slides section.recap-slide .recap-cta {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      padding: 1em;
+      background: color-mix(in oklab, var(--r-accent-color) 12%, transparent);
+      border-left: 3px solid var(--r-accent-color);
+    }
+    .reveal .slides section.recap-slide .recap-cta-label {
+      font-family: var(--r-heading-font);
+      font-size: 0.55em;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--r-accent-color);
+      margin-bottom: 0.4em;
+    }
+    .reveal .slides section.recap-slide .recap-cta-text {
+      font-size: 0.82em;
+      line-height: 1.4;
+    }
+
+    /* ========================================================================
        END BESPOKE EFFECTS LAYER
        ======================================================================== */
   </style>
@@ -1178,15 +1350,17 @@
    *
    * Full content push (includes optional themeCSS for custom styling):
    * {
-   *   "mode": "traditional" | "zoom" | "rapid",
+   *   "mode": "traditional" | "zoom" | "rapid" | "scroll",
    *           // traditional = default; zoom = big-picture-first with vertical
-   *           // detail slides; rapid = Lessig-style auto-advance ≤20s/slide.
+   *           // detail slides; rapid = Lessig-style auto-advance ≤20s/slide;
+   *           // scroll = built-in reveal v5 scroll-doc view, scrolls vertically
+   *           // through every slide. Adds a CSS-only top progress bar.
    *   "slides": [
    *     {
    *       "type": "title" | "content" | "code" | "quote" | "image" | "section"
    *             | "big-word" | "metric" | "comparison" | "process"
    *             | "timeline" | "definition" | "cards" | "diagram"
-   *             | "zoom-overview" | "zoom-detail" | "html",
+   *             | "zoom-overview" | "zoom-detail" | "recap" | "html",
    *
    *       // Common fields:
    *       "title": "Slide Title",
@@ -1223,6 +1397,8 @@
    *                  // pass through and execute. Trust model: agent
    *                  // writes the deck. Scripts are rehydrated post-
    *                  // innerHTML so they actually run.
+   *       "takeaways": ["...", "...", "..."],                            // recap — 3 takeaway lines
+   *       "cta": { "label": "...", "text": "..." },                      // recap — closing call-to-action
    *
    *       // Builds: optional staged element-reveal beyond simple fragments.
    *       // The renderer applies data-fragment-index attributes to children
@@ -1627,6 +1803,24 @@
             )
           + notes + '</section>';
 
+      case 'recap':
+        // Closing-screen recap: 3 takeaways + a single call-to-action.
+        var takeawayItems = Array.isArray(slide.takeaways) ? slide.takeaways : [];
+        var ctaBlock = slide.cta
+          ? '<div class="recap-cta">'
+            + (slide.cta.label ? '<div class="recap-cta-label">' + escHtml(slide.cta.label) + '</div>' : '')
+            + (slide.cta.text  ? '<div class="recap-cta-text">'  + escHtml(slide.cta.text)  + '</div>' : '')
+            + '</div>'
+          : '';
+        return wrap('recap-slide',
+          '<div class="recap-grid">'
+          + '<ol class="recap-takeaways">'
+          + takeawayItems.map(function(t) { return '<li>' + escHtml(t) + '</li>'; }).join('')
+          + '</ol>'
+          + ctaBlock
+          + '</div>'
+        );
+
       case 'html':
         // Plain-HTML escape hatch. FULL PASS-THROUGH — no sanitizer.
         // Agent-supplied <script>, <style>, <iframe>, on*= handlers, and
@@ -1676,10 +1870,38 @@
   function applyMode(mode) {
     var revealEl = document.querySelector('.reveal');
     if (!revealEl) return;
-    var validModes = ['traditional', 'zoom', 'rapid'];
+    var validModes = ['traditional', 'zoom', 'rapid', 'scroll'];
     var m = validModes.indexOf(mode) >= 0 ? mode : 'traditional';
     revealEl.setAttribute('data-mode', m);
     currentMode = m;
+    // Add the progress bar element in scroll mode (no-op if already present)
+    if (m === 'scroll' && !document.querySelector('.deck-progress')) {
+      var bar = document.createElement('div');
+      bar.className = 'deck-progress';
+      document.body.appendChild(bar);
+    } else if (m !== 'scroll') {
+      var existing = document.querySelector('.deck-progress');
+      if (existing) existing.remove();
+    }
+  }
+
+  // Wraps a slide-change navigation in the View Transitions API when supported.
+  // We can't intercept reveal's native slidechanged BEFORE the DOM change, so
+  // we hook the keyboard / nav-button events that drive reveal and wrap the
+  // call. Falls through cleanly when the API isn't available.
+  function setupViewTransitions() {
+    if (typeof document.startViewTransition !== 'function') return;
+    if (!revealInstance) return;
+    var origNext = revealInstance.next.bind(revealInstance);
+    var origPrev = revealInstance.prev.bind(revealInstance);
+    revealInstance.next = function() {
+      try { document.startViewTransition(function() { origNext(); }); }
+      catch (e) { origNext(); }
+    };
+    revealInstance.prev = function() {
+      try { document.startViewTransition(function() { origPrev(); }); }
+      catch (e) { origPrev(); }
+    };
   }
 
   // In rapid mode, default each slide that lacks an explicit autoslide to 20s.
@@ -1739,7 +1961,7 @@
       var present = revealInstance.getSlides()[idx.h] || null;
       if (present) animateCounters(present);
     } else {
-      revealInstance = new Reveal({
+      var revealConfig = {
         hash: false,
         history: false,
         controls: true,
@@ -1754,9 +1976,18 @@
         embedded: true,                 // critical for sprinkle panel embedding
         autoSlide: 0,                   // honor per-slide data-autoslide
         autoSlideStoppable: true,
-      });
+      };
+      // Scroll view mode is built into reveal.js v5 — turn the deck into a
+      // scrollable doc. The agent picks this via mode: "scroll".
+      if (currentMode === 'scroll') {
+        revealConfig.view = 'scroll';
+        revealConfig.scrollProgress = 'auto';
+        revealConfig.scrollSnap = 'mandatory';
+      }
+      revealInstance = new Reveal(revealConfig);
       revealInstance.initialize().then(function() {
         revealInstance.on('slidechanged', onSlideChanged);
+        setupViewTransitions();
         updateSlideCounter();
         var first = document.querySelector('#slides-container > section.present');
         if (first) animateCounters(first);

--- a/skills/presentations/templates/presentation.shtml
+++ b/skills/presentations/templates/presentation.shtml
@@ -19,6 +19,8 @@
       --r-main-color: #eee;
       --r-heading-font: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
       --r-heading-color: #fff;
+      --r-accent-color: #36d6a8;
+      --r-accent-secondary: #5b8af5;
       --r-link-color: #42affa;
       --r-link-color-hover: #8dcffc;
     }
@@ -111,6 +113,10 @@
     /* reveal.js sizing override for sprinkle panels */
     .reveal {
       height: 100% !important;
+      perspective: 1600px;
+    }
+    .reveal .slides {
+      transform-style: preserve-3d;
     }
 
     /* --- Toolbar --- */
@@ -179,7 +185,7 @@
       flex-direction: column;
     }
     .reveal .slides section.quote-slide blockquote {
-      border-left: 4px solid var(--r-link-color, #42affa);
+      border-left: 4px solid var(--r-accent-color, #42affa);
       padding: 10px 20px;
       margin: 20px 0;
       font-style: italic;
@@ -196,10 +202,438 @@
       opacity: 0.7;
       margin-top: 10px;
     }
+
+    /* ========================================================================
+       BESPOKE EFFECTS LAYER
+       SVG filters, CSS shaders, 3D animations.
+       Triggered by space-separated class names on <section> from the
+       per-slide `effects` array. See style-guide.md § Effects vocabulary.
+       Effects layer on top of theme tokens; theme tokens layer on the moods.
+       ======================================================================== */
+
+    /* Animated CSS variables (Houdini @property) for shader-style effects.
+       Browsers without @property support degrade gracefully — the gradient
+       still paints, just without animation. */
+    @property --aurora-rot { syntax: '<angle>'; inherits: false; initial-value: 0deg; }
+    @property --conic-rot  { syntax: '<angle>'; inherits: false; initial-value: 0deg; }
+    @property --holo-shift { syntax: '<percentage>'; inherits: false; initial-value: 0%; }
+
+    /* --- Backgrounds --- */
+
+    .reveal .effect-aurora-bg {
+      position: relative;
+      overflow: hidden;
+      isolation: isolate;
+    }
+    .reveal .effect-aurora-bg::before {
+      content: '';
+      position: absolute;
+      inset: -50%;
+      background: conic-gradient(
+        from var(--aurora-rot),
+        var(--r-accent-color, #36d6a8) 0deg,
+        var(--r-background-color, #0b1120) 80deg,
+        var(--r-accent-secondary, #5b8af5) 160deg,
+        var(--r-background-color, #0b1120) 260deg,
+        var(--r-accent-color, #36d6a8) 360deg
+      );
+      filter: blur(80px) saturate(1.3);
+      opacity: 0.55;
+      animation: aurora-rotate 45s linear infinite;
+      z-index: -1;
+      pointer-events: none;
+    }
+    @keyframes aurora-rotate { to { --aurora-rot: 360deg; } }
+
+    .reveal .effect-conic-bg {
+      position: relative;
+      overflow: hidden;
+      isolation: isolate;
+    }
+    .reveal .effect-conic-bg::before {
+      content: '';
+      position: absolute;
+      inset: -25%;
+      background: conic-gradient(
+        from var(--conic-rot),
+        var(--r-accent-color, #d64077) 0deg,
+        var(--r-accent-secondary, #7c3aed) 90deg,
+        var(--r-background-color, #fef7f7) 180deg,
+        var(--r-accent-color, #d64077) 270deg,
+        var(--r-accent-secondary, #7c3aed) 360deg
+      );
+      filter: blur(60px);
+      opacity: 0.4;
+      animation: conic-spin 60s linear infinite;
+      z-index: -1;
+      pointer-events: none;
+    }
+    @keyframes conic-spin { to { --conic-rot: 360deg; } }
+
+    .reveal .effect-grid-bg {
+      background-image:
+        linear-gradient(to right, rgba(255,255,255,0.04) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(255,255,255,0.04) 1px, transparent 1px);
+      background-size: 40px 40px;
+    }
+
+    .reveal .effect-grain-overlay {
+      position: relative;
+      isolation: isolate;
+    }
+    .reveal .effect-grain-overlay::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.7 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+      opacity: 0.08;
+      mix-blend-mode: overlay;
+      z-index: 1;
+    }
+
+    .reveal .effect-scanlines {
+      position: relative;
+    }
+    .reveal .effect-scanlines::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      background: repeating-linear-gradient(
+        transparent 0,
+        transparent 2px,
+        rgba(0,0,0,0.18) 2px,
+        rgba(0,0,0,0.18) 4px
+      );
+      mix-blend-mode: multiply;
+      z-index: 2;
+    }
+
+    .reveal .effect-speckled-bg {
+      background-image:
+        radial-gradient(circle at 12% 23%, var(--r-accent-color, #c4652a) 0 6px, transparent 7px),
+        radial-gradient(circle at 78% 63%, var(--r-accent-secondary, #4a7c6f) 0 4px, transparent 5px),
+        radial-gradient(circle at 33% 71%, var(--r-accent-color, #c4652a) 0 3px, transparent 4px),
+        radial-gradient(circle at 88% 18%, var(--r-accent-secondary, #4a7c6f) 0 5px, transparent 6px),
+        radial-gradient(circle at 51% 39%, var(--r-accent-color, #c4652a) 0 2px, transparent 3px);
+      background-size: 240px 240px;
+      background-color: var(--r-background-color);
+    }
+
+    .reveal .effect-blueprint-bg {
+      background:
+        radial-gradient(ellipse at center, rgba(91,138,245,0.12) 0%, transparent 70%),
+        repeating-linear-gradient(45deg, transparent 0 20px, rgba(91,138,245,0.05) 20px 21px),
+        var(--r-background-color);
+    }
+
+    /* --- Heading effects --- */
+
+    .reveal .effect-displaced-heading h1,
+    .reveal .effect-displaced-heading h2 {
+      filter: url(#filter-displace-soft);
+    }
+
+    .reveal .effect-ink-bleed h1,
+    .reveal .effect-ink-bleed h2 {
+      filter: url(#filter-displace-bleed);
+    }
+
+    .reveal .effect-emboss h1,
+    .reveal .effect-emboss h2 {
+      filter: url(#filter-emboss);
+    }
+
+    .reveal .effect-photogram img,
+    .reveal .effect-photogram h1 {
+      filter: url(#filter-photogram);
+    }
+
+    .reveal .effect-veneer h1,
+    .reveal .effect-veneer h2 {
+      filter: url(#filter-veneer);
+    }
+
+    .reveal .effect-chromatic-aberration h1,
+    .reveal .effect-chromatic-aberration h2 {
+      text-shadow:
+        -2px 0 0 rgba(255,61,113,0.85),
+         2px 0 0 rgba(0,212,170,0.85);
+      animation: chroma-jitter 4s steps(8) infinite;
+    }
+    @keyframes chroma-jitter {
+      0%, 100% { transform: translate(0, 0); }
+      50%      { transform: translate(0.5px, -0.5px); }
+    }
+
+    .reveal .effect-misregister h1,
+    .reveal .effect-misregister h2 {
+      position: relative;
+      color: var(--r-heading-color);
+    }
+    .reveal .effect-misregister h1::before,
+    .reveal .effect-misregister h2::before {
+      content: attr(data-text);
+      position: absolute;
+      inset: 0;
+      color: var(--r-accent-color);
+      transform: translate(3px, -3px);
+      mix-blend-mode: screen;
+      pointer-events: none;
+    }
+
+    .reveal .effect-neon-glow h1,
+    .reveal .effect-neon-glow h2 {
+      color: var(--r-heading-color);
+      text-shadow:
+        0 0 4px var(--r-accent-color),
+        0 0 12px var(--r-accent-color),
+        0 0 28px var(--r-accent-color),
+        0 0 60px var(--r-accent-color);
+    }
+
+    .reveal .effect-glossy-stroke h1,
+    .reveal .effect-glossy-stroke h2 {
+      -webkit-text-stroke: 1.5px var(--r-accent-color);
+      color: transparent;
+      filter: drop-shadow(0 4px 12px rgba(0,0,0,0.4));
+    }
+
+    .reveal .effect-hard-stroke h1,
+    .reveal .effect-hard-stroke h2 {
+      -webkit-text-stroke: 2px var(--r-heading-color);
+      color: var(--r-background-color);
+      text-shadow: 8px 8px 0 var(--r-accent-color);
+    }
+
+    .reveal .effect-holographic h1,
+    .reveal .effect-holographic h2 {
+      background: linear-gradient(
+        90deg,
+        var(--r-accent-color, #d64077) 0%,
+        var(--r-accent-secondary, #7c3aed) 25%,
+        var(--r-heading-color, #2a1a2c) 50%,
+        var(--r-accent-secondary, #7c3aed) 75%,
+        var(--r-accent-color, #d64077) 100%
+      );
+      background-size: 200% 100%;
+      background-position: var(--holo-shift) 0;
+      -webkit-background-clip: text;
+      background-clip: text;
+      color: transparent;
+      animation: holo-shift 6s linear infinite;
+    }
+    @keyframes holo-shift { to { --holo-shift: 200%; } }
+
+    .reveal .effect-mix-blend-headings {
+      position: relative;
+      isolation: isolate;
+    }
+    .reveal .effect-mix-blend-headings::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: 30%;
+      height: 30%;
+      background: var(--r-accent-color);
+      z-index: -1;
+      opacity: 0.85;
+    }
+    .reveal .effect-mix-blend-headings h1,
+    .reveal .effect-mix-blend-headings h2 {
+      mix-blend-mode: difference;
+      color: white;
+    }
+
+    /* --- Slide-level entrance / 3D --- */
+
+    .reveal .slides section.effect-3d-flip-in.present {
+      animation: flip-in-3d 0.6s cubic-bezier(0.2, 0.8, 0.2, 1) backwards;
+    }
+    @keyframes flip-in-3d {
+      from { opacity: 0; transform: perspective(1600px) rotateY(60deg); }
+      to   { opacity: 1; transform: perspective(1600px) rotateY(0); }
+    }
+
+    .reveal .slides section.effect-3d-tilt-in.present {
+      animation: tilt-in-3d 0.55s cubic-bezier(0.2, 0.8, 0.2, 1) backwards;
+    }
+    @keyframes tilt-in-3d {
+      from { opacity: 0; transform: perspective(1600px) rotateX(20deg) translateZ(-100px); }
+      to   { opacity: 1; transform: perspective(1600px) rotateX(0) translateZ(0); }
+    }
+
+    .reveal .slides section.effect-zoom-blur.present {
+      animation: zoom-blur 0.7s cubic-bezier(0.2, 0.8, 0.2, 1) backwards;
+    }
+    @keyframes zoom-blur {
+      from { opacity: 0; transform: scale(1.5); filter: blur(20px); }
+      to   { opacity: 1; transform: scale(1); filter: blur(0); }
+    }
+
+    .reveal .slides section.effect-slide-stack.present > * {
+      animation: stack-in 0.5s cubic-bezier(0.2, 0.8, 0.2, 1) backwards;
+    }
+    .reveal .slides section.effect-slide-stack.present > *:nth-child(1) { animation-delay: 0.0s; }
+    .reveal .slides section.effect-slide-stack.present > *:nth-child(2) { animation-delay: 0.08s; }
+    .reveal .slides section.effect-slide-stack.present > *:nth-child(3) { animation-delay: 0.16s; }
+    .reveal .slides section.effect-slide-stack.present > *:nth-child(4) { animation-delay: 0.24s; }
+    .reveal .slides section.effect-slide-stack.present > *:nth-child(5) { animation-delay: 0.32s; }
+    .reveal .slides section.effect-slide-stack.present > *:nth-child(6) { animation-delay: 0.40s; }
+    @keyframes stack-in {
+      from { opacity: 0; transform: translateY(24px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+
+    /* --- Per-element decorations --- */
+
+    .reveal .effect-fold-shadow blockquote,
+    .reveal .effect-fold-shadow .card {
+      position: relative;
+      clip-path: polygon(0 0, 100% 0, 100% calc(100% - 24px), calc(100% - 24px) 100%, 0 100%);
+      background: linear-gradient(135deg, transparent 0, transparent 70%, rgba(0,0,0,0.15) 100%);
+    }
+
+    .reveal .effect-pattern-stitch blockquote,
+    .reveal .effect-pattern-stitch .card,
+    .reveal .effect-pattern-stitch pre {
+      border: 1.5px dashed var(--r-accent-color);
+      border-radius: 0;
+    }
+
+    .reveal .effect-decal-edge img,
+    .reveal .effect-decal-edge .card {
+      clip-path: polygon(2% 0, 100% 1%, 99% 100%, 0 98%);
+      filter: drop-shadow(0 6px 24px rgba(0,0,0,0.35));
+    }
+
+    .reveal .effect-marginalia {
+      position: relative;
+    }
+    .reveal .effect-marginalia .marginalia-note {
+      position: absolute;
+      right: 2%;
+      font-style: italic;
+      font-size: 0.5em;
+      opacity: 0.6;
+      max-width: 18%;
+      text-align: left;
+    }
+
+    .reveal .effect-marginalia .marginalia-note::before {
+      content: '';
+      display: block;
+      border-top: 1px dotted currentColor;
+      width: 100%;
+      margin-bottom: 4px;
+    }
+
+    /* ========================================================================
+       END BESPOKE EFFECTS LAYER
+       ======================================================================== */
   </style>
 </head>
 <body>
 
+
+  <!-- ===================== INLINE SVG FILTER LIBRARY =====================
+       Reusable filter primitives. Referenced from CSS via filter: url(#name).
+       Keep ids stable — style-guide.md § Bespoke effects layer documents them.
+       ===================================================================== -->
+  <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+    <defs>
+      <!-- Soft displacement: subtle ripple, good for kiss-impression / ink-bleed -->
+      <filter id="filter-displace-soft" x="-5%" y="-5%" width="110%" height="110%">
+        <feTurbulence type="fractalNoise" baseFrequency="0.02 0.04" numOctaves="2" seed="7" result="noise"/>
+        <feDisplacementMap in="SourceGraphic" in2="noise" scale="1.5" xChannelSelector="R" yChannelSelector="G"/>
+      </filter>
+
+      <!-- Strong displacement: organic warp, useful on display headings -->
+      <filter id="filter-displace-strong" x="-10%" y="-10%" width="120%" height="120%">
+        <feTurbulence type="fractalNoise" baseFrequency="0.012" numOctaves="3" seed="3" result="noise"/>
+        <feDisplacementMap in="SourceGraphic" in2="noise" scale="6" xChannelSelector="R" yChannelSelector="G"/>
+      </filter>
+
+      <!-- Letterpress kiss-impression bleed -->
+      <filter id="filter-displace-bleed" x="-5%" y="-5%" width="110%" height="110%">
+        <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" seed="11" result="bleed"/>
+        <feDisplacementMap in="SourceGraphic" in2="bleed" scale="0.6" xChannelSelector="R" yChannelSelector="G"/>
+      </filter>
+
+      <!-- Lit relief / emboss -->
+      <filter id="filter-emboss" x="-5%" y="-5%" width="110%" height="110%">
+        <feGaussianBlur in="SourceAlpha" stdDeviation="1.5" result="blur"/>
+        <feSpecularLighting in="blur" surfaceScale="3" specularConstant="0.9" specularExponent="20" lighting-color="white" result="light">
+          <feDistantLight azimuth="135" elevation="60"/>
+        </feSpecularLighting>
+        <feComposite in="light" in2="SourceAlpha" operator="in" result="lit"/>
+        <feMerge>
+          <feMergeNode in="SourceGraphic"/>
+          <feMergeNode in="lit"/>
+        </feMerge>
+      </filter>
+
+      <!-- High-contrast B&W with halo (photogram) -->
+      <filter id="filter-photogram" x="-5%" y="-5%" width="110%" height="110%">
+        <feColorMatrix type="matrix" values="0.4 0.4 0.4 0 0
+                                              0.4 0.4 0.4 0 0
+                                              0.4 0.4 0.4 0 0
+                                              0   0   0   1 0"/>
+        <feComponentTransfer>
+          <feFuncR type="discrete" tableValues="0 1"/>
+          <feFuncG type="discrete" tableValues="0 1"/>
+          <feFuncB type="discrete" tableValues="0 1"/>
+        </feComponentTransfer>
+        <feGaussianBlur stdDeviation="0.3" result="halo"/>
+        <feMerge>
+          <feMergeNode in="halo"/>
+          <feMergeNode in="SourceGraphic"/>
+        </feMerge>
+      </filter>
+
+      <!-- Wood-veneer marquetry -->
+      <filter id="filter-veneer" x="-5%" y="-5%" width="110%" height="110%">
+        <feTurbulence type="turbulence" baseFrequency="0.04 0.5" numOctaves="2" seed="19" result="grain"/>
+        <feColorMatrix in="grain" type="matrix" values="0 0 0 0 0.4
+                                                         0 0 0 0 0.25
+                                                         0 0 0 0 0.1
+                                                         0 0 0 0.4 0" result="wood"/>
+        <feComposite in="wood" in2="SourceAlpha" operator="in" result="grainedFill"/>
+        <feMerge>
+          <feMergeNode in="SourceGraphic"/>
+          <feMergeNode in="grainedFill"/>
+        </feMerge>
+      </filter>
+
+      <!-- Blueprint cyan tint -->
+      <filter id="filter-blueprint">
+        <feColorMatrix type="matrix" values="0   0   0   0 0
+                                              0.2 0.6 1   0 0.05
+                                              0.4 0.8 1   0 0.1
+                                              0   0   0   1 0"/>
+      </filter>
+
+      <!-- Generic glow halo -->
+      <filter id="filter-glow" x="-30%" y="-30%" width="160%" height="160%">
+        <feGaussianBlur stdDeviation="6" result="glow"/>
+        <feMerge>
+          <feMergeNode in="glow"/>
+          <feMergeNode in="SourceGraphic"/>
+        </feMerge>
+      </filter>
+
+      <!-- Grain texture (used as background pattern via feImage in CSS) -->
+      <filter id="filter-grain">
+        <feTurbulence type="fractalNoise" baseFrequency="0.65" numOctaves="2" stitchTiles="stitch"/>
+        <feColorMatrix values="0 0 0 0 0
+                               0 0 0 0 0
+                               0 0 0 0 0
+                               0 0 0 0.7 0"/>
+      </filter>
+    </defs>
+  </svg>
 
   <!-- ===================== THREE-STATE UI ===================== -->
 
@@ -268,10 +702,13 @@
    *       "attribution": "Quote author",
    *       "background": "#hex or image URL",
    *       "notes": "Speaker notes",
-   *       "fragments": true  // animate bullets one by one
+   *       "fragments": true,         // animate bullets one by one
+   *       "effects": ["effect-aurora-bg", "effect-displaced-heading", "effect-3d-flip-in"]
+   *                                  // space-joined onto the section's class.
+   *                                  // see style-guide.md § Effects vocabulary.
    *     }
    *   ],
-   *   "theme": "midnight-aurora",
+   *   "theme": "stardust-derived",
    *   "themeCSS": "@import url(...); :root { --r-background-color: ... } ...",
    *   "transition": "slide" | "fade" | "convex" | "none"
    * }
@@ -296,7 +733,7 @@
    * Theme change (with full custom CSS):
    * {
    *   "action": "update-theme",
-   *   "theme": "midnight-aurora",
+   *   "theme": "stardust-derived",
    *   "themeCSS": "@import url(...); :root { --r-background-color: ... } ..."
    * }
    *
@@ -329,6 +766,8 @@
     '  --r-main-color: #eee;',
     '  --r-heading-font: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;',
     '  --r-heading-color: #fff;',
+    '  --r-accent-color: #36d6a8;',
+    '  --r-accent-secondary: #5b8af5;',
     '  --r-link-color: #42affa;',
     '  --r-link-color-hover: #8dcffc;',
     '}',
@@ -343,6 +782,8 @@
     '  --r-main-color: #222;',
     '  --r-heading-font: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;',
     '  --r-heading-color: #111;',
+    '  --r-accent-color: #d64077;',
+    '  --r-accent-secondary: #7c3aed;',
     '  --r-link-color: #2a76dd;',
     '  --r-link-color-hover: #6ca0e8;',
     '}',
@@ -350,7 +791,7 @@
   ].join('\n');
 
   // Light-themed keywords — if the theme name contains any of these, use light fallback
-  const LIGHT_THEME_KEYWORDS = ['light', 'white', 'clean', 'beige', 'serif', 'simple', 'solarized'];
+  const LIGHT_THEME_KEYWORDS = ['light', 'white', 'clean', 'beige', 'serif', 'simple', 'solarized', 'paper', 'dune', 'frost', 'rose', 'cream'];
 
   // --- Helpers ---
   function setState(name) {
@@ -364,6 +805,14 @@
     if (!str) return '';
     return str.replace(/&/g, '&amp;').replace(/</g, '&lt;')
               .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+
+  // Safe class string from slide.effects array (validates against known prefix).
+  function effectClasses(effects) {
+    if (!effects || !Array.isArray(effects)) return '';
+    return effects
+      .filter(function(e) { return typeof e === 'string' && /^effect-[a-z0-9-]+$/.test(e); })
+      .join(' ');
   }
 
   // --- Slide rendering ---
@@ -389,51 +838,59 @@
       ? '<aside class="notes">' + escHtml(slide.notes) + '</aside>'
       : '';
 
+    var fx = effectClasses(slide.effects);
+    // data-text on h1/h2 enables effect-misregister's ::before to mirror the heading
+    var titleAttrs = slide.title ? ' data-text="' + escHtml(slide.title) + '"' : '';
+
+    function classOf(base) {
+      return (base + (fx ? ' ' + fx : '')).trim();
+    }
+
     switch (slide.type) {
       case 'title':
-        return '<section class="title-slide"' + bg + '>'
-          + '<h1>' + escHtml(slide.title || '') + '</h1>'
+        return '<section class="' + classOf('title-slide') + '"' + bg + '>'
+          + '<h1' + titleAttrs + '>' + escHtml(slide.title || '') + '</h1>'
           + (slide.subtitle ? '<p class="slide-subtitle">' + escHtml(slide.subtitle) + '</p>' : '')
           + notes + '</section>';
 
       case 'section':
-        return '<section class="section-slide"' + bg + '>'
-          + '<h2>' + escHtml(slide.title || '') + '</h2>'
+        return '<section class="' + classOf('section-slide') + '"' + bg + '>'
+          + '<h2' + titleAttrs + '>' + escHtml(slide.title || '') + '</h2>'
           + (slide.subtitle ? '<p class="slide-subtitle">' + escHtml(slide.subtitle) + '</p>' : '')
           + notes + '</section>';
 
       case 'content':
-        return '<section' + bg + '>'
-          + (slide.title ? '<h2>' + escHtml(slide.title) + '</h2>' : '')
+        return '<section' + (fx ? ' class="' + fx + '"' : '') + bg + '>'
+          + (slide.title ? '<h2' + titleAttrs + '>' + escHtml(slide.title) + '</h2>' : '')
           + (slide.content ? '<div>' + slide.content + '</div>' : '')
           + (slide.bullets ? renderBullets(slide.bullets, slide.fragments) : '')
           + notes + '</section>';
 
       case 'code':
-        return '<section' + bg + '>'
-          + (slide.title ? '<h2>' + escHtml(slide.title) + '</h2>' : '')
+        return '<section' + (fx ? ' class="' + fx + '"' : '') + bg + '>'
+          + (slide.title ? '<h2' + titleAttrs + '>' + escHtml(slide.title) + '</h2>' : '')
           + '<pre><code class="' + (slide.language || '') + '" data-trim data-noescape>'
           + escHtml(slide.code || '') + '</code></pre>'
           + notes + '</section>';
 
       case 'quote':
-        return '<section class="quote-slide"' + bg + '>'
-          + (slide.title ? '<h2>' + escHtml(slide.title) + '</h2>' : '')
+        return '<section class="' + classOf('quote-slide') + '"' + bg + '>'
+          + (slide.title ? '<h2' + titleAttrs + '>' + escHtml(slide.title) + '</h2>' : '')
           + '<blockquote>' + escHtml(slide.quote || '') + '</blockquote>'
           + (slide.attribution ? '<p class="attribution">— ' + escHtml(slide.attribution) + '</p>' : '')
           + notes + '</section>';
 
       case 'image':
-        return '<section' + bg + '>'
-          + (slide.title ? '<h2>' + escHtml(slide.title) + '</h2>' : '')
+        return '<section' + (fx ? ' class="' + fx + '"' : '') + bg + '>'
+          + (slide.title ? '<h2' + titleAttrs + '>' + escHtml(slide.title) + '</h2>' : '')
           + (slide.src ? '<img src="' + escHtml(slide.src) + '" alt="' + escHtml(slide.alt || slide.title || '') + '" style="max-height: 60vh; max-width: 90%; object-fit: contain;">' : '')
           + (slide.content ? '<div>' + slide.content + '</div>' : '')
           + notes + '</section>';
 
       default:
         // Fallback: treat as generic content slide
-        return '<section' + bg + '>'
-          + (slide.title ? '<h2>' + escHtml(slide.title) + '</h2>' : '')
+        return '<section' + (fx ? ' class="' + fx + '"' : '') + bg + '>'
+          + (slide.title ? '<h2' + titleAttrs + '>' + escHtml(slide.title) + '</h2>' : '')
           + (slide.content ? '<div>' + slide.content + '</div>' : '')
           + (slide.bullets ? renderBullets(slide.bullets, slide.fragments) : '')
           + notes + '</section>';


### PR DESCRIPTION
## Summary

Closes #62. The presentations skill now leans on Adobe's **stardust** design system for distinctive, brand-aware visual direction, and ships a mandatory bespoke effects layer (SVG filters, CSS shader patterns, 3D animations) so even fallback decks no longer look like reveal.js defaults with nicer fonts.

- **Phase 0 — Stardust gate.** Detects `DESIGN.json`/`DESIGN.md` at the project root; when present, generates theme CSS dynamically from brand tokens (palette role names, divergence seed, font deck) instead of picking from a static preset. When stardust isn't installed, offers four install paths: Claude Code plugin marketplace, `upskill` (SLICC), `gh upskill` (gh extension), or `npx skills`. Surfaces stardust's `impeccable` dependency.
- **Anchor-mood fallback.** The 8 presets remain as starting points (Midnight Aurora, Paper & Ink, Electric Signal, Dune, Phosphor, Nordic Frost, Oxide, Rose Quartz), reframed explicitly as anchor moods rather than finished designs.
- **Bespoke effects layer (mandatory).** Inline SVG filter library — displacement (soft, strong, ink-bleed), emboss (feSpecularLighting), photogram, veneer, blueprint, glow. CSS shader patterns — animated conic-gradient backgrounds via Houdini `@property`, mix-blend-mode heading bands, scanlines, chromatic aberration, holographic text-fill, Riso misregister, neon glow. 3D entrance animations — flip-in, tilt-in, zoom-blur, slide-stack — wired through `perspective: 1600px` on `.reveal`.
- **Per-slide `effects` array.** Slides take `effects: ["effect-foo", ...]`; renderer validates against `/^effect-[a-z0-9-]+$/` so injected class strings can't smuggle markup. Style guide defines effect vocabulary, composition rules (one bg-effect, one heading-effect, slide-level entrance can stack), and a craft-seed → dominant-effect mapping (Letterpress → ink-bleed; Riso → misregister; folded-paper → fold-shadow; etc.).
- **Anti-tells.** Style guide imports stardust's divergence toolkit rules: cream-ground ban (HSL-L 80–97 + R−B ≥ 5 + S < 40% with brand-category justification), stat-callout-bar / generic-2026-SaaS-silhouette / triplet-cadence / editorial-vocabulary-on-non-editorial bans, fabricated-content (invented stats, named-customer logos, dollar amounts) requires `data-placeholder="true"`.

## Files changed

| File | Lines | What |
|---|---|---|
| `skills/presentations/SKILL.md` | +139 / –72 | Phase 0 (stardust detection + install offer), restructured discovery, hard-rules block, effects array doc |
| `skills/presentations/style-guide.md` | +479 / –150 | Stardust integration spec, font-deck table, craft → effect mapping, ground-family rules, effects vocabulary, anti-tells |
| `skills/presentations/templates/presentation.shtml` | +497 / –7 | SVG filter `<defs>` library, `@property` animations, perspective on `.reveal`, effects-class wiring + sanitization, `data-text` mirror for misregister |

## Test plan

- [x] Tag balance check on the template (style/script/defs all balanced)
- [x] Structural checks for all 6 SVG filters and all named effect classes (15/15 pass)
- [x] Wire-up checks for SKILL.md (Phase 0, all 4 install methods named, effects array doc) and style-guide.md (stardust integration, anti-tells, font-deck table) (14/14 pass)
- [x] `renderSlide` smoke test with all 6 slide types + effects array + injected `<script>bad</script>` class — sanitizer strips it, all 7 cases produce valid `<section>` markup
- [ ] Open the sprinkle in a SLICC harness and confirm reveal.js initializes with the new perspective and Houdini @property animation runs (manual)
- [ ] Run with a stardust-emitted `DESIGN.json` in the project root and confirm dynamic theme generation produces brand-native role-name comments in the CSS (manual)
- [ ] Decline the stardust install prompt and confirm anchor-mood fallback still applies the effects layer (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)