### PR TITLE
feat: add Swarm (Foursquare) check-in history skill

### DIFF
--- a/skills/swarm/SKILL.md
+++ b/skills/swarm/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: swarm
+description: CLI access to Foursquare/Swarm check-in history, venue visits, and location search via the Foursquare v2 API. Use when the user mentions Foursquare, Swarm, check-ins, venues, venue history, places visited, top venues, location search, or wants stats about where they've been. Supports paginated check-in lookups, category filtering, nearby venue search, full venue detail (rating, hours, personal visit count), and overall check-in statistics with top 5 most-visited venues.
+allowed-tools: bash
+---
+
+# Swarm
+
+Direct API access to Foursquare/Swarm check-in history via the v2 API
+(`api.foursquare.com/v2/`). Auth is **page-context fetch** through
+`playwright-cli eval`: the script finds an open `app.foursquare.com` browser
+tab and issues `fetch(..., { credentials: 'include' })` from inside the page,
+so the session cookies are sent automatically. No API token, no client
+credentials, no separate config — zero-config as long as the Foursquare web
+app is open in the browser.
+
+If no `app.foursquare.com` tab is open, the command prints an error and
+exits. Open <https://app.foursquare.com> in the browser, wait for the page to
+load, then retry.
+
+## Quick start
+
+```bash
+# Recent check-ins (default: latest 20)
+swarm checkins
+
+# Latest 10 check-ins
+swarm checkins --limit=10
+
+# Venue visit history sorted by visit count
+swarm history
+
+# Venues you've been to in a specific category
+swarm history --category=4bf58dd8d48988d1d2941735
+
+# Search for venues near a lat,lng
+swarm search coffee --near=52.3906,13.0645
+
+# Full detail for a single venue
+swarm venue 4b5a0c05f964a5200a4f28e3
+
+# Overall stats + top 5 most-visited venues
+swarm stats
+```
+
+## Commands
+
+All commands print colored, human-readable output to stdout.
+
+### swarm checkins [--limit=N] [--offset=N] [--category=ID]
+
+Recent check-ins from `/users/self/checkins`. Each entry shows venue name,
+city, primary category, and check-in date.
+
+- `--limit=<n>` — page size (default `20`, max `250`).
+- `--offset=<n>` — pagination offset (default `0`).
+- `--category=<id>` — filter by Foursquare category ID.
+
+```bash
+swarm checkins --limit=50 --offset=50
+```
+
+### swarm history [--category=ID]
+
+Venue visit history from `/users/self/venuehistory`, sorted by visit count
+(`beenHere`) descending. Useful for "where have I been most often".
+
+- `--category=<id>` — filter by category ID.
+
+```bash
+swarm history --category=4bf58dd8d48988d16d941735   # cafés
+```
+
+### swarm search <query> --near=<lat,lng>
+
+Search for venues near a location via `/venues/search`. `--near` is
+**required** and takes a `lat,lng` pair. Returns up to 10 venues with name,
+city, distance, category, and venue ID.
+
+```bash
+swarm search sushi --near=52.52,13.405
+```
+
+### swarm venue <venue-id>
+
+Full detail for a single venue from `/venues/:id`: name, category, address,
+rating, your personal check-in count (`beenHere`), website, and current
+open/closed hours status.
+
+```bash
+swarm venue 4b5a0c05f964a5200a4f28e3
+```
+
+### swarm stats
+
+Overall stats: total check-in count, unique venue count, and the top 5
+most-visited venues. Combines `/users/self/checkins` (for total count) with
+`/users/self/venuehistory` (for unique venues and top rankings).
+
+```bash
+swarm stats
+```
+
+## References
+
+See [references/endpoints.md](references/endpoints.md) for per-endpoint
+documentation: query parameters, response shapes, and common category IDs.

--- a/skills/swarm/references/endpoints.md
+++ b/skills/swarm/references/endpoints.md
@@ -1,4 +1,4 @@
-# Foursquare API v2  Endpoint Reference
+# Foursquare API v2 â€” Endpoint Reference
 
 Base URL: `https://api.foursquare.com/v2/`
 
@@ -19,8 +19,8 @@ User's check-in history.
 |------------|--------|---------|------------------------------|
 | limit      | int    | 20      | Number of results (max 250)  |
 | offset     | int    | 0       | Pagination offset            |
-| categoryId | string |        | Filter by category ID        |
-| v          | string |        | API version (YYYYMMDD)       |
+| categoryId | string | -       | Filter by category ID        |
+| v          | string | -       | API version (YYYYMMDD)       |
 
 ### Example Request
 
@@ -43,9 +43,9 @@ GET /users/self/checkins?v=20231001&limit=5&offset=0
           "type": "checkin",
           "venue": {
             "id": "4b5a0c05f964a5200a4f28e3",
-            "name": "Café Einstein",
+            "name": "CafÃ© Einstein",
             "location": {
-              "address": "Kurfürstenstr. 58",
+              "address": "KurfÃ¼rstenstr. 58",
               "city": "Berlin",
               "state": "Berlin",
               "country": "Germany",
@@ -55,7 +55,7 @@ GET /users/self/checkins?v=20231001&limit=5&offset=0
             "categories": [
               {
                 "id": "4bf58dd8d48988d16d941735",
-                "name": "Café",
+                "name": "CafÃ©",
                 "primary": true
               }
             ]
@@ -99,7 +99,7 @@ GET /users/self/venuehistory?v=20231001
           "beenHere": 47,
           "venue": {
             "id": "4b5a0c05f964a5200a4f28e3",
-            "name": "Café Einstein",
+            "name": "CafÃ© Einstein",
             "location": {
               "city": "Berlin",
               "country": "Germany",
@@ -109,7 +109,7 @@ GET /users/self/venuehistory?v=20231001
             "categories": [
               {
                 "id": "4bf58dd8d48988d16d941735",
-                "name": "Café"
+                "name": "CafÃ©"
               }
             ]
           }
@@ -197,11 +197,11 @@ GET /venues/4b5a0c05f964a5200a4f28e3?v=20231001
   "response": {
     "venue": {
       "id": "4b5a0c05f964a5200a4f28e3",
-      "name": "Café Einstein",
+      "name": "CafÃ© Einstein",
       "url": "https://cafeeinstein.com",
       "rating": 8.7,
       "location": {
-        "address": "Kurfürstenstr. 58",
+        "address": "KurfÃ¼rstenstr. 58",
         "city": "Berlin",
         "state": "Berlin",
         "country": "Germany",
@@ -211,7 +211,7 @@ GET /venues/4b5a0c05f964a5200a4f28e3?v=20231001
       "categories": [
         {
           "id": "4bf58dd8d48988d16d941735",
-          "name": "Café",
+          "name": "CafÃ©",
           "primary": true
         }
       ],
@@ -236,7 +236,7 @@ GET /venues/4b5a0c05f964a5200a4f28e3?v=20231001
 |------------|----------------------------------|
 | Sushi      | `4bf58dd8d48988d1d2941735`       |
 | Japanese   | `4bf58dd8d48988d111941735`       |
-| Café       | `4bf58dd8d48988d16d941735`       |
+| CafÃ©       | `4bf58dd8d48988d16d941735`       |
 | Bar        | `4bf58dd8d48988d116941735`       |
 | Restaurant | `4bf58dd8d48988d1c4941735`       |
 | Hotel      | `4bf58dd8d48988d1fa931735`       |

--- a/skills/swarm/references/endpoints.md
+++ b/skills/swarm/references/endpoints.md
@@ -1,0 +1,252 @@
+# Foursquare API v2  Endpoint Reference
+
+Base URL: `https://api.foursquare.com/v2/`
+
+All requests require `?v=20231001` (API version date parameter).
+
+Authentication is via page-context fetch from an open `app.foursquare.com` tab
+(cookies sent automatically with `credentials: 'include'`).
+
+---
+
+## GET /users/self/checkins
+
+User's check-in history.
+
+### Parameters
+
+| Param      | Type   | Default | Description                  |
+|------------|--------|---------|------------------------------|
+| limit      | int    | 20      | Number of results (max 250)  |
+| offset     | int    | 0       | Pagination offset            |
+| categoryId | string |        | Filter by category ID        |
+| v          | string |        | API version (YYYYMMDD)       |
+
+### Example Request
+
+```
+GET /users/self/checkins?v=20231001&limit=5&offset=0
+```
+
+### Example Response
+
+```json
+{
+  "meta": { "code": 200 },
+  "response": {
+    "checkins": {
+      "count": 4823,
+      "items": [
+        {
+          "id": "664a1b...",
+          "createdAt": 1716123456,
+          "type": "checkin",
+          "venue": {
+            "id": "4b5a0c05f964a5200a4f28e3",
+            "name": "Café Einstein",
+            "location": {
+              "address": "Kurfürstenstr. 58",
+              "city": "Berlin",
+              "state": "Berlin",
+              "country": "Germany",
+              "lat": 52.5045,
+              "lng": 13.3555
+            },
+            "categories": [
+              {
+                "id": "4bf58dd8d48988d16d941735",
+                "name": "Café",
+                "primary": true
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+---
+
+## GET /users/self/venuehistory
+
+Venue visit history with counts.
+
+### Parameters
+
+| Param      | Type   | Description            |
+|------------|--------|------------------------|
+| categoryId | string | Filter by category ID  |
+| v          | string | API version (YYYYMMDD) |
+
+### Example Request
+
+```
+GET /users/self/venuehistory?v=20231001
+```
+
+### Example Response
+
+```json
+{
+  "meta": { "code": 200 },
+  "response": {
+    "venues": {
+      "count": 1245,
+      "items": [
+        {
+          "beenHere": 47,
+          "venue": {
+            "id": "4b5a0c05f964a5200a4f28e3",
+            "name": "Café Einstein",
+            "location": {
+              "city": "Berlin",
+              "country": "Germany",
+              "lat": 52.5045,
+              "lng": 13.3555
+            },
+            "categories": [
+              {
+                "id": "4bf58dd8d48988d16d941735",
+                "name": "Café"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+---
+
+## GET /venues/search
+
+Search for venues near a location.
+
+### Parameters
+
+| Param  | Type   | Description                          |
+|--------|--------|--------------------------------------|
+| ll     | string | Latitude,longitude (e.g. 52.52,13.4) |
+| query  | string | Search query                         |
+| limit  | int    | Max results (default 10)             |
+| v      | string | API version (YYYYMMDD)               |
+
+### Example Request
+
+```
+GET /venues/search?v=20231001&ll=52.52,13.405&query=sushi&limit=5
+```
+
+### Example Response
+
+```json
+{
+  "meta": { "code": 200 },
+  "response": {
+    "venues": [
+      {
+        "id": "5a1b2c3d4e5f...",
+        "name": "Omoni Sushi",
+        "location": {
+          "address": "Kantstr. 12",
+          "city": "Berlin",
+          "country": "Germany",
+          "lat": 52.5067,
+          "lng": 13.3189,
+          "distance": 450
+        },
+        "categories": [
+          {
+            "id": "4bf58dd8d48988d1d2941735",
+            "name": "Sushi Restaurant"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+---
+
+## GET /venues/:id
+
+Detailed venue information.
+
+### Parameters
+
+| Param | Type   | Description            |
+|-------|--------|------------------------|
+| v     | string | API version (YYYYMMDD) |
+
+### Example Request
+
+```
+GET /venues/4b5a0c05f964a5200a4f28e3?v=20231001
+```
+
+### Example Response
+
+```json
+{
+  "meta": { "code": 200 },
+  "response": {
+    "venue": {
+      "id": "4b5a0c05f964a5200a4f28e3",
+      "name": "Café Einstein",
+      "url": "https://cafeeinstein.com",
+      "rating": 8.7,
+      "location": {
+        "address": "Kurfürstenstr. 58",
+        "city": "Berlin",
+        "state": "Berlin",
+        "country": "Germany",
+        "lat": 52.5045,
+        "lng": 13.3555
+      },
+      "categories": [
+        {
+          "id": "4bf58dd8d48988d16d941735",
+          "name": "Café",
+          "primary": true
+        }
+      ],
+      "beenHere": {
+        "count": 47,
+        "lastCheckinExpiredAt": 0
+      },
+      "hours": {
+        "status": "Open until 11:00 PM",
+        "isOpen": true
+      }
+    }
+  }
+}
+```
+
+---
+
+## Common Category IDs
+
+| Category   | ID                               |
+|------------|----------------------------------|
+| Sushi      | `4bf58dd8d48988d1d2941735`       |
+| Japanese   | `4bf58dd8d48988d111941735`       |
+| Café       | `4bf58dd8d48988d16d941735`       |
+| Bar        | `4bf58dd8d48988d116941735`       |
+| Restaurant | `4bf58dd8d48988d1c4941735`       |
+| Hotel      | `4bf58dd8d48988d1fa931735`       |
+| Airport    | `4bf58dd8d48988d1ed931735`       |
+
+---
+
+## Auth Notes
+
+- Direct API calls with `oauth_token` param return 401 for this user's token
+- Page-context fetch from `app.foursquare.com` works because session cookies
+  are sent automatically with `credentials: 'include'`
+- The `playwright-cli eval --tab=<id>` mechanism executes in the tab's context

--- a/skills/swarm/scripts/swarm.jsh
+++ b/skills/swarm/scripts/swarm.jsh
@@ -1,0 +1,229 @@
+#!/usr/bin/env jsh
+// swarm.jsh  Foursquare/Swarm check-in history CLI
+
+const args = process.argv.slice(2);
+const command = args[0];
+
+const CYAN = '\x1b[36m';
+const YELLOW = '\x1b[33m';
+const GRAY = '\x1b[90m';
+const BOLD = '\x1b[1m';
+const RESET = '\x1b[0m';
+
+function parseFlag(name) {
+  const prefix = `--${name}=`;
+  const arg = args.find(a => a.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : null;
+}
+
+function positionalAfter(index) {
+  return args.slice(index).filter(a => !a.startsWith('--'));
+}
+
+async function findFoursquareTab() {
+  const { stdout } = await exec('playwright-cli tab-list');
+  const lines = stdout.split('\n');
+  for (const line of lines) {
+    const match = line.match(/\[([A-F0-9]+)\]\s+https?:\/\/[^\s]*app\.foursquare\.com/);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+async function apiCall(tabId, endpoint) {
+  const url = `https://api.foursquare.com/v2${endpoint}${endpoint.includes('?') ? '&' : '?'}v=20231001`;
+  const expr = `fetch('${url}',{credentials:'include'}).then(r=>r.json()).then(d=>JSON.stringify(d))`;
+  const { stdout } = await exec(`playwright-cli eval --tab=${tabId} "${expr.replace(/"/g, '\\"')}"`);
+  // stdout may have quotes wrapping the JSON string  parse it
+  let cleaned = stdout.trim();
+  // playwright-cli eval may return the result as a quoted JSON string
+  if (cleaned.startsWith('"') && cleaned.endsWith('"')) {
+    cleaned = JSON.parse(cleaned);
+  }
+  return JSON.parse(cleaned);
+}
+
+function formatDate(ts) {
+  const d = new Date(ts * 1000);
+  return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+async function cmdCheckins(tabId) {
+  const limit = parseFlag('limit') || '20';
+  const offset = parseFlag('offset') || '0';
+  const category = parseFlag('category');
+  let endpoint = `/users/self/checkins?limit=${limit}&offset=${offset}`;
+  if (category) endpoint += `&categoryId=${category}`;
+
+  const data = await apiCall(tabId, endpoint);
+  const checkins = data.response.checkins.items;
+  const total = data.response.checkins.count;
+
+  console.log(`${BOLD}Check-ins${RESET} ${GRAY}(${checkins.length} of ${total})${RESET}\n`);
+
+  for (const ci of checkins) {
+    const venue = ci.venue || {};
+    const name = venue.name || 'Unknown venue';
+    const city = (venue.location && venue.location.city) || '';
+    const cat = (venue.categories && venue.categories[0] && venue.categories[0].name) || '';
+    const date = formatDate(ci.createdAt);
+    console.log(`  ${CYAN}${name}${RESET}${city ? ` ${GRAY} ${city}${RESET}` : ''}`);
+    console.log(`    ${YELLOW}${cat}${RESET}  ${GRAY}${date}${RESET}`);
+  }
+}
+
+async function cmdHistory(tabId) {
+  const category = parseFlag('category');
+  let endpoint = `/users/self/venuehistory?`;
+  if (category) endpoint += `categoryId=${category}&`;
+  endpoint = endpoint.replace(/[&?]$/, '') || endpoint;
+
+  const data = await apiCall(tabId, endpoint.endsWith('?') ? endpoint.slice(0, -1) : endpoint);
+  const venues = data.response.venues.items;
+
+  // Sort by beenHere descending
+  venues.sort((a, b) => b.beenHere - a.beenHere);
+
+  console.log(`${BOLD}Venue History${RESET} ${GRAY}(${venues.length} venues)${RESET}\n`);
+
+  for (const v of venues) {
+    const venue = v.venue || v;
+    const name = venue.name || 'Unknown';
+    const city = (venue.location && venue.location.city) || '';
+    const count = v.beenHere || 0;
+    console.log(`  ${CYAN}${name}${RESET}${city ? ` ${GRAY} ${city}${RESET}` : ''}  ${YELLOW}×${count}${RESET}`);
+  }
+}
+
+async function cmdSearch(tabId) {
+  const near = parseFlag('near');
+  if (!near) {
+    console.error(`${YELLOW}Error:${RESET} --near=<lat,lng> is required for search`);
+    process.exit(1);
+  }
+  const queryParts = positionalAfter(1);
+  const query = queryParts.join(' ');
+  if (!query) {
+    console.error(`${YELLOW}Error:${RESET} search query is required`);
+    process.exit(1);
+  }
+
+  const endpoint = `/venues/search?ll=${near}&query=${encodeURIComponent(query)}&limit=10`;
+  const data = await apiCall(tabId, endpoint);
+  const venues = data.response.venues || [];
+
+  console.log(`${BOLD}Search: "${query}"${RESET} ${GRAY}near ${near}${RESET}\n`);
+
+  for (const v of venues) {
+    const city = (v.location && v.location.city) || '';
+    const cat = (v.categories && v.categories[0] && v.categories[0].name) || '';
+    const dist = v.location && v.location.distance ? `${v.location.distance}m` : '';
+    console.log(`  ${CYAN}${v.name}${RESET}${city ? ` ${GRAY} ${city}${RESET}` : ''} ${dist ? GRAY + dist + RESET : ''}`);
+    console.log(`    ${YELLOW}${cat}${RESET}  ${GRAY}id: ${v.id}${RESET}`);
+  }
+}
+
+async function cmdVenue(tabId) {
+  const venueId = args[1];
+  if (!venueId || venueId.startsWith('--')) {
+    console.error(`${YELLOW}Error:${RESET} venue ID is required`);
+    process.exit(1);
+  }
+
+  const data = await apiCall(tabId, `/venues/${venueId}?`);
+  const v = data.response.venue;
+
+  console.log(`\n${BOLD}${CYAN}${v.name}${RESET}`);
+  if (v.categories && v.categories[0]) {
+    console.log(`  ${YELLOW}${v.categories[0].name}${RESET}`);
+  }
+  if (v.location) {
+    const loc = v.location;
+    const addr = [loc.address, loc.city, loc.state, loc.country].filter(Boolean).join(', ');
+    console.log(`  ${GRAY}${addr}${RESET}`);
+  }
+  if (v.rating) {
+    console.log(`  Rating: ${CYAN}${v.rating}${RESET}/10`);
+  }
+  if (v.beenHere && v.beenHere.count) {
+    console.log(`  ${YELLOW}You've been here ${v.beenHere.count} time(s)${RESET}`);
+  }
+  if (v.url) {
+    console.log(`  ${GRAY}${v.url}${RESET}`);
+  }
+  if (v.hours && v.hours.status) {
+    console.log(`  ${GRAY}${v.hours.status}${RESET}`);
+  }
+  console.log();
+}
+
+async function cmdStats(tabId) {
+  // Get total checkins count
+  const checkinsData = await apiCall(tabId, `/users/self/checkins?limit=1&offset=0`);
+  const totalCheckins = checkinsData.response.checkins.count;
+
+  // Get venue history for count and top venues
+  const historyData = await apiCall(tabId, `/users/self/venuehistory?`);
+  const venues = historyData.response.venues.items;
+  const totalVenues = venues.length;
+
+  // Sort by visits
+  venues.sort((a, b) => b.beenHere - a.beenHere);
+  const top5 = venues.slice(0, 5);
+
+  console.log(`\n${BOLD}Swarm Stats${RESET}\n`);
+  console.log(`  Total check-ins:  ${CYAN}${totalCheckins}${RESET}`);
+  console.log(`  Unique venues:    ${CYAN}${totalVenues}${RESET}`);
+  console.log(`\n  ${BOLD}Top 5 Venues${RESET}`);
+
+  for (let i = 0; i < top5.length; i++) {
+    const v = top5[i];
+    const venue = v.venue || v;
+    const name = venue.name || 'Unknown';
+    const city = (venue.location && venue.location.city) || '';
+    console.log(`    ${YELLOW}${i + 1}.${RESET} ${CYAN}${name}${RESET}${city ? ` ${GRAY} ${city}${RESET}` : ''} ${YELLOW}×${v.beenHere}${RESET}`);
+  }
+  console.log();
+}
+
+// Main
+(async () => {
+  if (!command || command === '--help' || command === '-h') {
+    console.log(`${BOLD}swarm${RESET}  Foursquare/Swarm check-in history\n`);
+    console.log(`Usage:`);
+    console.log(`  swarm checkins [--limit=N] [--offset=N] [--category=<id>]`);
+    console.log(`  swarm history [--category=<id>]`);
+    console.log(`  swarm search <query> --near=<lat,lng>`);
+    console.log(`  swarm venue <venue-id>`);
+    console.log(`  swarm stats`);
+    process.exit(0);
+  }
+
+  const tabId = await findFoursquareTab();
+  if (!tabId) {
+    console.error(`${YELLOW}Error:${RESET} No Foursquare tab found.`);
+    console.error(`Please open ${CYAN}https://app.foursquare.com${RESET} in your browser and try again.`);
+    process.exit(1);
+  }
+
+  switch (command) {
+    case 'checkins':
+      await cmdCheckins(tabId);
+      break;
+    case 'history':
+      await cmdHistory(tabId);
+      break;
+    case 'search':
+      await cmdSearch(tabId);
+      break;
+    case 'venue':
+      await cmdVenue(tabId);
+      break;
+    case 'stats':
+      await cmdStats(tabId);
+      break;
+    default:
+      console.error(`${YELLOW}Unknown command:${RESET} ${command}`);
+      process.exit(1);
+  }
+})();

--- a/skills/swarm/scripts/swarm.jsh
+++ b/skills/swarm/scripts/swarm.jsh
@@ -1,5 +1,5 @@
 #!/usr/bin/env jsh
-// swarm.jsh  Foursquare/Swarm check-in history CLI
+// swarm.jsh — Foursquare/Swarm check-in history CLI
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -21,26 +21,49 @@ function positionalAfter(index) {
 }
 
 async function findFoursquareTab() {
-  const { stdout } = await exec('playwright-cli tab-list');
-  const lines = stdout.split('\n');
-  for (const line of lines) {
-    const match = line.match(/\[([A-F0-9]+)\]\s+https?:\/\/[^\s]*app\.foursquare\.com/);
-    if (match) return match[1];
+  const { stdout, stderr, exitCode } = await exec('playwright-cli tab-list');
+  if (exitCode !== 0) {
+    throw new Error(`playwright-cli tab-list failed: ${stderr || stdout}`);
   }
-  return null;
+  const lines = stdout.split('\n');
+  const fsLine = lines.find(l => l.includes('app.foursquare.com'));
+  if (!fsLine) return null;
+  const idMatch = fsLine.match(/\[targetId:\s*([^\]]+)\]/) || fsLine.match(/^\[([^\]]+)\]/);
+  if (!idMatch) return null;
+  return idMatch[1].trim();
 }
 
 async function apiCall(tabId, endpoint) {
   const url = `https://api.foursquare.com/v2${endpoint}${endpoint.includes('?') ? '&' : '?'}v=20231001`;
   const expr = `fetch('${url}',{credentials:'include'}).then(r=>r.json()).then(d=>JSON.stringify(d))`;
-  const { stdout } = await exec(`playwright-cli eval --tab=${tabId} "${expr.replace(/"/g, '\\"')}"`);
-  // stdout may have quotes wrapping the JSON string  parse it
+  const { stdout, stderr, exitCode } = await exec(
+    'playwright-cli eval --tab=' + tabId + ' ' + JSON.stringify(expr)
+  );
+  if (exitCode !== 0) {
+    throw new Error(`playwright-cli eval failed: ${stderr || stdout}`);
+  }
   let cleaned = stdout.trim();
+  if (!cleaned) {
+    throw new Error('Empty response from playwright-cli eval — is the Foursquare tab still open?');
+  }
   // playwright-cli eval may return the result as a quoted JSON string
   if (cleaned.startsWith('"') && cleaned.endsWith('"')) {
-    cleaned = JSON.parse(cleaned);
+    try {
+      cleaned = JSON.parse(cleaned);
+    } catch (e) {
+      throw new Error(`Failed to unwrap playwright-cli eval output: ${cleaned.slice(0, 200)}`);
+    }
   }
-  return JSON.parse(cleaned);
+  let data;
+  try {
+    data = JSON.parse(cleaned);
+  } catch (e) {
+    throw new Error(`Failed to parse Foursquare response as JSON: ${String(cleaned).slice(0, 200)}`);
+  }
+  if (data && data.meta && data.meta.code !== 200) {
+    throw new Error(`Foursquare API ${data.meta.code}: ${data.meta.errorType || ''} ${data.meta.errorDetail || ''}`.trim());
+  }
+  return data;
 }
 
 function formatDate(ts) {
@@ -67,18 +90,18 @@ async function cmdCheckins(tabId) {
     const city = (venue.location && venue.location.city) || '';
     const cat = (venue.categories && venue.categories[0] && venue.categories[0].name) || '';
     const date = formatDate(ci.createdAt);
-    console.log(`  ${CYAN}${name}${RESET}${city ? ` ${GRAY} ${city}${RESET}` : ''}`);
+    console.log(`  ${CYAN}${name}${RESET}${city ? ` ${GRAY}— ${city}${RESET}` : ''}`);
     console.log(`    ${YELLOW}${cat}${RESET}  ${GRAY}${date}${RESET}`);
   }
 }
 
 async function cmdHistory(tabId) {
   const category = parseFlag('category');
-  let endpoint = `/users/self/venuehistory?`;
-  if (category) endpoint += `categoryId=${category}&`;
-  endpoint = endpoint.replace(/[&?]$/, '') || endpoint;
+  const endpoint = category
+    ? `/users/self/venuehistory?categoryId=${category}`
+    : '/users/self/venuehistory';
 
-  const data = await apiCall(tabId, endpoint.endsWith('?') ? endpoint.slice(0, -1) : endpoint);
+  const data = await apiCall(tabId, endpoint);
   const venues = data.response.venues.items;
 
   // Sort by beenHere descending
@@ -91,7 +114,7 @@ async function cmdHistory(tabId) {
     const name = venue.name || 'Unknown';
     const city = (venue.location && venue.location.city) || '';
     const count = v.beenHere || 0;
-    console.log(`  ${CYAN}${name}${RESET}${city ? ` ${GRAY} ${city}${RESET}` : ''}  ${YELLOW}�${count}${RESET}`);
+    console.log(`  ${CYAN}${name}${RESET}${city ? ` ${GRAY}— ${city}${RESET}` : ''}  ${YELLOW}×${count}${RESET}`);
   }
 }
 
@@ -118,7 +141,7 @@ async function cmdSearch(tabId) {
     const city = (v.location && v.location.city) || '';
     const cat = (v.categories && v.categories[0] && v.categories[0].name) || '';
     const dist = v.location && v.location.distance ? `${v.location.distance}m` : '';
-    console.log(`  ${CYAN}${v.name}${RESET}${city ? ` ${GRAY} ${city}${RESET}` : ''} ${dist ? GRAY + dist + RESET : ''}`);
+    console.log(`  ${CYAN}${v.name}${RESET}${city ? ` ${GRAY}— ${city}${RESET}` : ''} ${dist ? GRAY + dist + RESET : ''}`);
     console.log(`    ${YELLOW}${cat}${RESET}  ${GRAY}id: ${v.id}${RESET}`);
   }
 }
@@ -130,7 +153,7 @@ async function cmdVenue(tabId) {
     process.exit(1);
   }
 
-  const data = await apiCall(tabId, `/venues/${venueId}?`);
+  const data = await apiCall(tabId, `/venues/${encodeURIComponent(venueId)}`);
   const v = data.response.venue;
 
   console.log(`\n${BOLD}${CYAN}${v.name}${RESET}`);
@@ -163,7 +186,7 @@ async function cmdStats(tabId) {
   const totalCheckins = checkinsData.response.checkins.count;
 
   // Get venue history for count and top venues
-  const historyData = await apiCall(tabId, `/users/self/venuehistory?`);
+  const historyData = await apiCall(tabId, '/users/self/venuehistory');
   const venues = historyData.response.venues.items;
   const totalVenues = venues.length;
 
@@ -181,7 +204,7 @@ async function cmdStats(tabId) {
     const venue = v.venue || v;
     const name = venue.name || 'Unknown';
     const city = (venue.location && venue.location.city) || '';
-    console.log(`    ${YELLOW}${i + 1}.${RESET} ${CYAN}${name}${RESET}${city ? ` ${GRAY} ${city}${RESET}` : ''} ${YELLOW}�${v.beenHere}${RESET}`);
+    console.log(`    ${YELLOW}${i + 1}.${RESET} ${CYAN}${name}${RESET}${city ? ` ${GRAY}— ${city}${RESET}` : ''} ${YELLOW}×${v.beenHere}${RESET}`);
   }
   console.log();
 }
@@ -189,7 +212,7 @@ async function cmdStats(tabId) {
 // Main
 (async () => {
   if (!command || command === '--help' || command === '-h') {
-    console.log(`${BOLD}swarm${RESET}  Foursquare/Swarm check-in history\n`);
+    console.log(`${BOLD}swarm${RESET} — Foursquare/Swarm check-in history\n`);
     console.log(`Usage:`);
     console.log(`  swarm checkins [--limit=N] [--offset=N] [--category=<id>]`);
     console.log(`  swarm history [--category=<id>]`);


### PR DESCRIPTION
## Swarm (Foursquare) Check-in History Skill

Adds a new `swarm` skill providing CLI access to your Foursquare/Swarm check-in history, venue visits, and location search.

### What it does

- Query your full Foursquare/Swarm check-in history with pagination and category filters
- View venue visit history sorted by visit count
- Search for venues near any location
- Get detailed venue information (rating, hours, your personal visit count)
- Display overall check-in statistics and top 5 most-visited venues

### Auth mechanism

Uses **page-context fetch** via `playwright-cli eval`. Requires an open `app.foursquare.com` browser tab. Cookies are sent automatically with `credentials: include` — no separate API token configuration needed.

### Available commands

```
swarm checkins [--limit=N] [--offset=N] [--category=<id>]
swarm history [--category=<id>]
swarm search <query> --near=<lat,lng>
swarm venue <venue-id>
swarm stats
```

### Example usage

```bash
swarm checkins --limit=10
swarm history --category=4bf58dd8d48988d1d2941735
swarm search coffee --near=52.3906,13.0645
swarm stats
```

### Files

- `skills/swarm/SKILL.md` — Skill manifest and CLI documentation
- `skills/swarm/scripts/swarm.jsh` — Full CLI implementation (5 commands)
- `skills/swarm/references/endpoints.md` — API endpoint reference with request/response examples