### PR TITLE
feat(outlook): add accept/decline/tentative commands for calendar events

### DIFF
--- a/skills/outlook/SKILL.md
+++ b/skills/outlook/SKILL.md
@@ -38,6 +38,16 @@ outlook calendar
 # View calendar for the next week
 outlook calendar --date 7d
 
+# Accept/decline calendar events by ID
+outlook accept <event-id>
+outlook decline <event-id> --comment "Conflict"
+
+# Accept all pending events
+outlook accept --all
+
+# Decline all pending in the next week
+outlook decline --all --date 7d
+
 # View a single message
 outlook view <message-id>
 
@@ -87,6 +97,27 @@ List upcoming calendar events with time, organizer, location, and response statu
 ### outlook view \<message-id\>
 
 View a single email message with full headers and body text.
+
+### outlook accept|decline|tentative \<event-id\> [...] [options]
+
+Respond to one or more calendar events. Get event IDs from `outlook calendar --json`.
+
+**Options:**
+- `--comment TEXT` — optional message to the organizer
+- `--silent` — don't send a response notification to the organizer
+- `--all` — respond to all `NotResponded` events in the date range
+- `--date PERIOD` — date range for `--all` (default: `2d`)
+
+```bash
+# Accept a single event
+outlook accept AAMkADQ...
+
+# Decline multiple events
+outlook decline AAMk...1 AAMk...2 --comment "Schedule conflict"
+
+# Tentatively accept all pending
+outlook tentative --all --date 7d
+```
 
 ### outlook send --to EMAIL --subject TEXT --body TEXT
 

--- a/skills/outlook/scripts/outlook.jsh
+++ b/skills/outlook/scripts/outlook.jsh
@@ -496,33 +496,52 @@ async function cmdView() {
 
 // ─── Calendar Response Commands ──────────────────────────────────────────────
 
+const RESPOND_LABELS = {
+  accept: { progressive: 'Accepting', past: 'Accepted' },
+  decline: { progressive: 'Declining', past: 'Declined' },
+  tentativelyAccept: { progressive: 'Tentatively accepting', past: 'Tentative' },
+};
+
 async function cmdRespond(action) {
   const token = await getToken();
   const comment = flags.comment || flags.message || '';
   const silent = flags.silent === true || flags.silent === 'true';
+  const labels = RESPOND_LABELS[action];
 
   // Collect event IDs: positional args or --all pending events
   let eventIds = [...positional];
+  const subjectsById = new Map();
 
   if (eventIds.length === 0 && flags.all) {
-    // Respond to all pending events in the calendar window
+    // Respond to all pending events in the calendar window, paging through results
     const date = flags.date || '2d';
     const range = futureRange(date, 2);
-    const data = await owaGet(token, '/me/calendarview', {
+    let page = await owaGet(token, '/me/calendarview', {
       '$top': '50',
       'startDateTime': range.start,
       'endDateTime': range.end,
       '$select': 'Id,Subject,ResponseStatus',
     });
-    const events = (data.value || []).filter(
-      ev => ev.ResponseStatus?.Response === 'NotResponded'
-    );
-    if (events.length === 0) {
+    const pending = [];
+    while (true) {
+      for (const ev of page.value || []) {
+        if (ev.ResponseStatus?.Response === 'NotResponded') {
+          pending.push(ev);
+        }
+      }
+      const next = page['@odata.nextLink'];
+      if (!next) break;
+      page = await owaGet(token, next);
+    }
+    if (pending.length === 0) {
       console.log('No pending events to respond to.');
       return;
     }
-    eventIds = events.map(ev => ev.Id);
-    console.log(`${C.bold(action)}ing ${events.length} pending event(s)...\n`);
+    for (const ev of pending) {
+      eventIds.push(ev.Id);
+      if (ev.Subject) subjectsById.set(ev.Id, ev.Subject);
+    }
+    console.log(`${C.bold(labels.progressive)} ${pending.length} pending event(s)...\n`);
   }
 
   if (eventIds.length === 0) {
@@ -539,15 +558,16 @@ async function cmdRespond(action) {
     try {
       await owaPost(token, `/me/events/${encodeURIComponent(id)}/${action}`, body);
       success++;
-      // Try to get the event subject for feedback
-      try {
-        const ev = await owaGet(token, `/me/events/${encodeURIComponent(id)}`, { '$select': 'Subject' });
-        const verb = action === 'accept' ? 'Accepted' : action === 'decline' ? 'Declined' : 'Tentative';
-        console.log(`  ${C.green('✓')} ${verb}: ${ev.Subject}`);
-      } catch {
-        const verb = action === 'accept' ? 'Accepted' : action === 'decline' ? 'Declined' : 'Tentative';
-        console.log(`  ${C.green('✓')} ${verb}: ${id.slice(0, 20)}...`);
+      // Use the subject from the initial fetch when available; fall back to a lookup otherwise
+      let subject = subjectsById.get(id);
+      if (!subject) {
+        try {
+          const ev = await owaGet(token, `/me/events/${encodeURIComponent(id)}`, { '$select': 'Subject' });
+          subject = ev.Subject;
+        } catch { /* ignore */ }
       }
+      const display = subject || `${id.slice(0, 20)}...`;
+      console.log(`  ${C.green('✓')} ${labels.past}: ${display}`);
     } catch (e) {
       failed++;
       const msg = e.message || '';
@@ -597,6 +617,7 @@ Respond options (accept/decline/tentative):
   --comment TEXT    Optional message to organizer
   --silent          Don't send response to organizer
   --all             Act on all NotResponded events in date range
+  --date PERIOD     With --all, calendar window to scan (default: 2d)
 
 Send options:
   --to EMAIL         Recipient(s), comma-separated
@@ -637,7 +658,7 @@ try {
       break;
     case 'tentative':
     case 'maybe':
-      await cmdRespond('tentativelyaccept');
+      await cmdRespond('tentativelyAccept');
       break;
     case 'send':
       await cmdSend();

--- a/skills/outlook/scripts/outlook.jsh
+++ b/skills/outlook/scripts/outlook.jsh
@@ -494,6 +494,74 @@ async function cmdView() {
   }
 }
 
+// ─── Calendar Response Commands ──────────────────────────────────────────────
+
+async function cmdRespond(action) {
+  const token = await getToken();
+  const comment = flags.comment || flags.message || '';
+  const silent = flags.silent === true || flags.silent === 'true';
+
+  // Collect event IDs: positional args or --all pending events
+  let eventIds = [...positional];
+
+  if (eventIds.length === 0 && flags.all) {
+    // Respond to all pending events in the calendar window
+    const date = flags.date || '2d';
+    const range = futureRange(date, 2);
+    const data = await owaGet(token, '/me/calendarview', {
+      '$top': '50',
+      'startDateTime': range.start,
+      'endDateTime': range.end,
+      '$select': 'Id,Subject,ResponseStatus',
+    });
+    const events = (data.value || []).filter(
+      ev => ev.ResponseStatus?.Response === 'NotResponded'
+    );
+    if (events.length === 0) {
+      console.log('No pending events to respond to.');
+      return;
+    }
+    eventIds = events.map(ev => ev.Id);
+    console.log(`${C.bold(action)}ing ${events.length} pending event(s)...\n`);
+  }
+
+  if (eventIds.length === 0) {
+    die(`outlook ${action}: provide one or more event IDs, or use --all`);
+  }
+
+  const body = { SendResponse: !silent };
+  if (comment) body.Comment = comment;
+
+  let success = 0;
+  let failed = 0;
+
+  for (const id of eventIds) {
+    try {
+      await owaPost(token, `/me/events/${encodeURIComponent(id)}/${action}`, body);
+      success++;
+      // Try to get the event subject for feedback
+      try {
+        const ev = await owaGet(token, `/me/events/${encodeURIComponent(id)}`, { '$select': 'Subject' });
+        const verb = action === 'accept' ? 'Accepted' : action === 'decline' ? 'Declined' : 'Tentative';
+        console.log(`  ${C.green('✓')} ${verb}: ${ev.Subject}`);
+      } catch {
+        const verb = action === 'accept' ? 'Accepted' : action === 'decline' ? 'Declined' : 'Tentative';
+        console.log(`  ${C.green('✓')} ${verb}: ${id.slice(0, 20)}...`);
+      }
+    } catch (e) {
+      failed++;
+      const msg = e.message || '';
+      if (msg.includes('organizer') || msg.includes('response')) {
+        console.log(`  ${C.yellow('⚠')} Skipped (no response allowed): ${id.slice(0, 20)}...`);
+      } else {
+        console.log(`  ${C.red('✗')} Failed: ${msg}`);
+      }
+    }
+  }
+
+  console.log(`\n${success} responded, ${failed} failed/skipped.`);
+}
+
 function showHelp() {
   console.log(`outlook — Microsoft Outlook CLI for SLICC
 
@@ -502,6 +570,9 @@ Usage: outlook <command> [options]
 Commands:
   mail       List inbox messages
   calendar   List calendar events
+  accept     Accept calendar event(s)
+  decline    Decline calendar event(s)
+  tentative  Tentatively accept calendar event(s)
   send       Send an email
   view       View a single message
   monday     Aggregated inbox items for monday dispatcher
@@ -517,6 +588,15 @@ Calendar options:
   --limit N          Number of events (default: 20)
   --date PERIOD      How far ahead to look (default: 2d)
   --json             Output raw JSON
+
+Respond options (accept/decline/tentative):
+  outlook accept <event-id> [<event-id>...]
+  outlook decline <event-id> --comment "Can't make it"
+  outlook accept --all              Accept all pending events
+  outlook decline --all --date 7d   Decline all pending in next week
+  --comment TEXT    Optional message to organizer
+  --silent          Don't send response to organizer
+  --all             Act on all NotResponded events in date range
 
 Send options:
   --to EMAIL         Recipient(s), comma-separated
@@ -548,6 +628,16 @@ try {
     case 'calendar':
     case 'cal':
       await cmdCalendar();
+      break;
+    case 'accept':
+      await cmdRespond('accept');
+      break;
+    case 'decline':
+      await cmdRespond('decline');
+      break;
+    case 'tentative':
+    case 'maybe':
+      await cmdRespond('tentativelyaccept');
       break;
     case 'send':
       await cmdSend();


### PR DESCRIPTION
## Summary

Adds calendar RSVP commands to the outlook skill so the agent can respond to meeting invitations directly:

```bash
outlook accept <event-id>
outlook decline <event-id> --comment "Schedule conflict"
outlook tentative --all --date 7d
```

## Features

- **Single or batch**: pass event IDs directly, or use `--all` to respond to every pending event in range
- **`--comment`**: optional message to the organizer
- **`--silent`**: suppress response notification
- **Graceful errors**: events that don't allow responses (broadcast, organizer-set) are skipped with a warning instead of crashing
- Aliases: `tentative` / `maybe`

## Motivation

Previously, responding to calendar events required manual `curl` calls with extracted MSAL tokens and raw event IDs. This was the main gap in the outlook skill — you could see your calendar but not act on it.