### PR TITLE
fix(pptx2pdf): add YAML frontmatter and re-add to tile

### DIFF
--- a/skills/pptx2pdf/SKILL.md
+++ b/skills/pptx2pdf/SKILL.md
@@ -1,3 +1,14 @@
+---
+name: pptx2pdf
+description: |
+  Convert PPTX files to PDF, preserving slide backgrounds, text styles, colors,
+  alignment, word-wrap, and embedded PNG/JPEG images. No external tools required —
+  uses pdf-lib via esm.sh and the pre-loaded JSZip.
+  Use when the user asks to convert a presentation to PDF, export slides as PDF,
+  or download a PPTX as PDF. Triggers on phrases like "convert ppt to pdf",
+  "export presentation as pdf", "turn this pptx into a pdf", "save slides as pdf".
+---
+
 # pptx2pdf
 
 Convert a PPTX file to a PDF, preserving slide backgrounds, text, font styles, colors, alignment, word-wrap, and embedded PNG/JPEG images. No external tools or packages required — uses `pdf-lib` (via esm.sh) and the pre-loaded `JSZip`.

--- a/tile.json
+++ b/tile.json
@@ -21,6 +21,7 @@
     "pdf": { "path": "skills/pdf/SKILL.md" },
     "pm-prd": { "path": "skills/pm-prd/SKILL.md" },
     "pptx": { "path": "skills/pptx/SKILL.md" },
+    "pptx2pdf": { "path": "skills/pptx2pdf/SKILL.md" },
     "presentations": { "path": "skills/presentations/SKILL.md" },
     "review": { "path": "skills/review/SKILL.md" },
     "save-the-cat": { "path": "skills/save-the-cat/SKILL.md" },


### PR DESCRIPTION
Follow-up to #85.

`skills/pptx2pdf/SKILL.md` was missing the YAML frontmatter that `tessl skill lint` requires, which is why it was excluded from the tile in #85.

## Changes

- Add `name` + `description` frontmatter to `skills/pptx2pdf/SKILL.md` — description is composed from the existing Triggers section.
- Re-add `pptx2pdf` to `tile.json`.

## Verification

`tessl skill lint .` passes locally (`Tile ai-ecoverse/skills@0.1.0 is valid`). CI runs the same command scoped to the changed skill.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author