### PR TITLE
ci: gate PRs on tessl skill review (≥ 90% per changed skill)

### DIFF
--- a/.github/workflows/tessl-review.yml
+++ b/.github/workflows/tessl-review.yml
@@ -1,0 +1,84 @@
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'skills/**'
+      - '.github/workflows/tessl-review.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      skills: ${{ steps.detect.outputs.skills }}
+      has_skills: ${{ steps.detect.outputs.has_skills }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed skills in tile
+        id: detect
+        run: |
+          CHANGED_FILES=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+
+          # Unique skill dirs touched in this PR
+          CHANGED_SKILLS=$(echo "$CHANGED_FILES" \
+            | grep -E '^skills/[^/]+/' \
+            | awk -F/ '{print $2}' \
+            | sort -u)
+
+          # Keep only skills that are listed in tile.json and have a SKILL.md
+          KEPT=""
+          for skill in $CHANGED_SKILLS; do
+            if jq -e --arg k "$skill" '.skills[$k]' tile.json >/dev/null 2>&1 \
+               && [ -f "skills/$skill/SKILL.md" ]; then
+              KEPT="$KEPT $skill"
+            else
+              echo "::notice::Skipping review for $skill (not in tile.json or no SKILL.md)"
+            fi
+          done
+
+          # shellcheck disable=SC2086
+          set -- $KEPT
+          if [ "$#" -eq 0 ]; then
+            echo "has_skills=false" >> "$GITHUB_OUTPUT"
+            echo "skills=[]" >> "$GITHUB_OUTPUT"
+            echo "No tile skills changed — review skipped."
+          else
+            JSON=$(printf '%s\n' "$@" | jq -R . | jq -sc .)
+            echo "has_skills=true" >> "$GITHUB_OUTPUT"
+            echo "skills=$JSON" >> "$GITHUB_OUTPUT"
+            echo "Skills to review: $JSON"
+          fi
+
+      - name: Skip summary
+        if: steps.detect.outputs.has_skills == 'false'
+        run: |
+          {
+            echo "## Tessl Skill Review"
+            echo ""
+            echo "No tile skills changed — review skipped."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  review:
+    needs: detect
+    if: needs.detect.outputs.has_skills == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        skill: ${{ fromJSON(needs.detect.outputs.skills) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: tesslio/setup-tessl@v2
+        with:
+          token: ${{ secrets.TESSLIO_TOKEN }}
+
+      - name: Review skill (threshold 90%)
+        run: tessl skill review "skills/${{ matrix.skill }}" --threshold 90


### PR DESCRIPTION
Adds a new `tessl-review.yml` workflow that runs `tessl skill review --threshold 90` on every skill changed in a PR. Any skill scoring below 90% fails the PR.

## How it works

- **Trigger**: `pull_request` against `main`, scoped via `paths: ['skills/**']` so PRs that don't touch skills don't pay the cost.
- **`detect` job**: diffs against `origin/main`, collects unique `skills/<name>/` directories, then keeps only ones that are listed in `tile.json` and have a `SKILL.md`. Outputs the list as JSON.
- **`review` job**: matrix-strategy over the detected skills with `fail-fast: false`, so a PR touching multiple skills gets one parallel review run per skill and reports all failures at once instead of stopping at the first.
- **Auth**: uses `secrets.TESSLIO_TOKEN` (same secret as the publish workflow).

## Behaviour matrix

| PR touches | Review jobs |
|---|---|
| One skill in the tile | 1 review job |
| Two skills in the tile | 2 parallel review jobs |
| A skill not in `tile.json` | Skipped with a notice |
| Only non-skill files | Workflow doesn't trigger |
| `tile.json` only | Workflow doesn't trigger |

## Verification

- `actionlint` clean.
- Local sanity-check: `tessl skill review skills/ai-writing-detector --threshold 90` scored that skill at 89% and exited with code 1 — confirming the threshold gate works.

## Note on existing skills

This workflow only gates skills that are **changed** in a PR. Skills already on `main` that may score below 90% (e.g. `ai-writing-detector` at 89%) are not retroactively gated; they only become subject to the gate the next time someone edits them. If we want to drive everything up to 90%, the next step would be a separate one-off PR (or `tessl skill review --optimize` runs) per under-threshold skill.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author