### PR TITLE
improve(aem): raise tessl review score to ≥90%

### DIFF
--- a/skills/aem/SKILL.md
+++ b/skills/aem/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aem
-description: AEM Edge Delivery Services — read, write, preview, and publish EDS pages
+description: AEM Edge Delivery Services (EDS) skill for reading, writing, previewing, and publishing EDS pages via the `aem` CLI. Use when the user asks about AEM Edge Delivery Services, EDS pages, Franklin, Helix, AEM EDS, edge delivery content, document-based authoring, or needs to list, get, put, preview, publish, or upload content in AEM EDS. Supports the full get→edit→put→preview→publish pipeline.
 allowed-tools: bash
 ---
 
@@ -31,6 +31,34 @@ Or use `--org`/`--repo` flags with a plain path.
 - `aem publish <url>` — Trigger AEM publish
 - `aem upload <vfs-file> <url>` — Upload a media file
 - `aem help` — Show usage
+
+## Typical Workflow
+
+For editing a page, follow this sequence:
+
+1. **Get** — Fetch the current page HTML:
+   ```bash
+   aem get https://main--myrepo--myorg.aem.page/page --output /workspace/page.html
+   ```
+2. **Edit** — Modify `/workspace/page.html` as needed.
+3. **Put** — Write the updated HTML back. Verify the command exits successfully (exit code 0) before continuing:
+   ```bash
+   aem put https://main--myrepo--myorg.aem.page/page /workspace/page.html
+   ```
+4. **Preview** — Trigger a preview and confirm the response indicates success:
+   ```bash
+   aem preview https://main--myrepo--myorg.aem.page/page
+   ```
+5. **Verify** — Optionally re-fetch the page (`aem get`) or inspect the preview URL to confirm the changes appear correctly.
+6. **Publish** — Once the preview looks correct, publish:
+   ```bash
+   aem publish https://main--myrepo--myorg.aem.page/page
+   ```
+
+**Error guidance:**
+- If `aem put` fails, check that the VFS file path is correct and the file is valid HTML before retrying.
+- If `aem preview` or `aem publish` fails, re-run the command — transient network issues are common. If it continues to fail, verify authentication with `oauth-token adobe`.
+- Always confirm `aem put` succeeds before running `aem preview` to avoid publishing stale content.
 
 ## Examples
 


### PR DESCRIPTION
Raises the tessl review score for the `aem` skill from **72% → 97%**.

## Changes
- Expanded the SKILL.md `description` with an explicit "Use when…" clause and additional trigger terms (Franklin, Helix, AEM EDS, edge delivery content, document-based authoring).
- Added a **Typical Workflow** section walking through the get→edit→put→preview→verify→publish pipeline with validation checkpoints.
- Added brief error-handling guidance for failed `put`, `preview`, `publish`, and authentication issues.

## Verification
- `tessl skill review skills/aem --threshold 90` → **97%** (passed)
- `tessl skill lint .` → exit 0 (passed)

Only `skills/aem/SKILL.md` was modified.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author