### PR TITLE
improve(github): raise tessl review score to ≥90%

### DIFF
--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -32,12 +32,12 @@ git config github.token <YOUR_PAT>     # persisted across shells
 export GITHUB_TOKEN=<YOUR_PAT>          # session-scoped
 ```
 
-**Repo defaults** — all commands accept an optional trailing `owner/repo` argument. If omitted, the script infers it from the current directory's `git remote get-url origin`. Pass it explicitly to override. The examples below show the short form; append `owner/repo` to any command to target a different repo.
+**Repo defaults** — most subcommands that act on a repo (e.g. `pr`, `issue`, `branch`, `content`, `run`, `release`, `search`, `vars`, `repo`) accept an optional trailing `owner/repo` argument. If omitted, the script infers it from the current directory's `git remote get-url origin`. Pass it explicitly to override. The `api` passthrough and utility commands like `auth` do **not** take a trailing repo — `api` requires a full REST path. The examples below show the short form; append `owner/repo` to repo-scoped commands to target a different repo.
 
 ## Running the script
 
 ```bash
-/workspace/skills/github/gh.jsh <command> <subcommand> [args] [owner/repo]
+/workspace/skills/github/scripts/gh.jsh <command> <subcommand> [args] [owner/repo]
 ```
 
 ---
@@ -46,43 +46,45 @@ export GITHUB_TOKEN=<YOUR_PAT>          # session-scoped
 
 ### Create a PR from scratch
 
-This is the most common multi-step flow. Follow these steps in order, validating each before proceeding:
+This is the most common multi-step flow. Follow these steps in order, validating each before proceeding. **Important:** `pr create` returns a PR number — capture it and use that exact value in later steps. Do not hard-code the example number `<PR_NUMBER>` shown below; replace it with the number printed by step 3 in your own session.
 
 ```bash
 # 1. Create the branch
-/workspace/skills/github/gh.jsh branch create my-feature owner/repo
+/workspace/skills/github/scripts/gh.jsh branch create my-feature owner/repo
 
 # 2. Push file changes to that branch
-/workspace/skills/github/gh.jsh content put src/index.js ./index.js "Add entry point" --branch=my-feature owner/repo
+/workspace/skills/github/scripts/gh.jsh content put src/index.js ./index.js "Add entry point" --branch=my-feature owner/repo
 
-# 3. Open the PR
-/workspace/skills/github/gh.jsh pr create "My title" "PR body" my-feature owner/repo
-# → note the returned PR number (e.g. 42)
+# 3. Open the PR — note the returned PR number, e.g. "Created PR #123"
+/workspace/skills/github/scripts/gh.jsh pr create "My title" "PR body" my-feature owner/repo
 
-# 4. Verify CI has started (wait for status to move past 'queued')
-/workspace/skills/github/gh.jsh run list owner/repo
+# 4. Verify CI has started for that PR (substitute the real number for <PR_NUMBER>)
+/workspace/skills/github/scripts/gh.jsh pr view <PR_NUMBER> owner/repo
+/workspace/skills/github/scripts/gh.jsh run list owner/repo
 
-# 5. Once CI is green, merge
-/workspace/skills/github/gh.jsh pr merge 42 --squash owner/repo
+# 5. Once CI is green, merge that same PR number
+/workspace/skills/github/scripts/gh.jsh pr merge <PR_NUMBER> --squash owner/repo
 ```
 
 **Validation checkpoints:**
 - After `branch create`: confirm no error output before pushing content.
-- After `pr create`: capture the PR number for subsequent steps.
-- After `run list`: check that all jobs show `✓` (success) before merging. If any show `✗` (failure), inspect with `run view <id>` before proceeding.
+- After `pr create`: capture the new PR number from the command's output and reuse it in steps 4 and 5 — never reuse a number from another PR.
+- After `pr view`: read the `Checks:` line in the output (e.g. `Checks:  3 passed`) — only proceed to merge when there are no `failed` or `pending` entries. If any check failed, inspect with `run view <id>` before proceeding.
 
 ### Review and merge an existing PR
 
-```bash
-# Inspect the PR and its checks
-/workspace/skills/github/gh.jsh pr view 42 owner/repo
+Substitute `<PR_NUMBER>` with the actual PR number you intend to act on.
 
-# Confirm CI is passing
-/workspace/skills/github/gh.jsh run list owner/repo
+```bash
+# Inspect the PR and its checks (look at the 'Checks:' line in the output)
+/workspace/skills/github/scripts/gh.jsh pr view <PR_NUMBER> owner/repo
+
+# Confirm CI is passing (cross-check the per-job status from 'run list')
+/workspace/skills/github/scripts/gh.jsh run list owner/repo
 
 # Post a comment then merge
-/workspace/skills/github/gh.jsh pr comment 42 "Automated: all checks passed, merging." owner/repo
-/workspace/skills/github/gh.jsh pr merge 42 --squash owner/repo
+/workspace/skills/github/scripts/gh.jsh pr comment <PR_NUMBER> "Automated: all checks passed, merging." owner/repo
+/workspace/skills/github/scripts/gh.jsh pr merge <PR_NUMBER> --squash owner/repo
 ```
 
 ---

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -32,15 +32,58 @@ git config github.token <YOUR_PAT>     # persisted across shells
 export GITHUB_TOKEN=<YOUR_PAT>          # session-scoped
 ```
 
-**Repo defaults** — if you omit `owner/repo`, the script infers it from the current directory's `git remote get-url origin`. Pass it explicitly to override.
+**Repo defaults** — all commands accept an optional trailing `owner/repo` argument. If omitted, the script infers it from the current directory's `git remote get-url origin`. Pass it explicitly to override. The examples below show the short form; append `owner/repo` to any command to target a different repo.
 
 ## Running the script
 
 ```bash
-/workspace/skills/github/gh.jsh <command> <subcommand> [args]
+/workspace/skills/github/gh.jsh <command> <subcommand> [args] [owner/repo]
 ```
 
-All commands follow the pattern: `gh.jsh <noun> <verb> [positional args] [owner/repo]`
+---
+
+## Common Workflows
+
+### Create a PR from scratch
+
+This is the most common multi-step flow. Follow these steps in order, validating each before proceeding:
+
+```bash
+# 1. Create the branch
+/workspace/skills/github/gh.jsh branch create my-feature owner/repo
+
+# 2. Push file changes to that branch
+/workspace/skills/github/gh.jsh content put src/index.js ./index.js "Add entry point" --branch=my-feature owner/repo
+
+# 3. Open the PR
+/workspace/skills/github/gh.jsh pr create "My title" "PR body" my-feature owner/repo
+# → note the returned PR number (e.g. 42)
+
+# 4. Verify CI has started (wait for status to move past 'queued')
+/workspace/skills/github/gh.jsh run list owner/repo
+
+# 5. Once CI is green, merge
+/workspace/skills/github/gh.jsh pr merge 42 --squash owner/repo
+```
+
+**Validation checkpoints:**
+- After `branch create`: confirm no error output before pushing content.
+- After `pr create`: capture the PR number for subsequent steps.
+- After `run list`: check that all jobs show `✓` (success) before merging. If any show `✗` (failure), inspect with `run view <id>` before proceeding.
+
+### Review and merge an existing PR
+
+```bash
+# Inspect the PR and its checks
+/workspace/skills/github/gh.jsh pr view 42 owner/repo
+
+# Confirm CI is passing
+/workspace/skills/github/gh.jsh run list owner/repo
+
+# Post a comment then merge
+/workspace/skills/github/gh.jsh pr comment 42 "Automated: all checks passed, merging." owner/repo
+/workspace/skills/github/gh.jsh pr merge 42 --squash owner/repo
+```
 
 ---
 
@@ -48,172 +91,86 @@ All commands follow the pattern: `gh.jsh <noun> <verb> [positional args] [owner/
 
 ### Pull Requests
 
-**List open PRs**
 ```bash
 gh.jsh pr list
-gh.jsh pr list owner/repo
-```
-Output: number, title, branch, state (with `[DRAFT]` tag if applicable)
-
-**View a PR**
-```bash
 gh.jsh pr view 42
-gh.jsh pr view 42 owner/repo
-```
-Shows title, author, branch, URL, check summary (passed/failed/pending), and body preview (first 400 chars).
-
-**Create a PR**
-```bash
 gh.jsh pr create "My title" "PR body text" my-feature-branch
 gh.jsh pr create "My title" "PR body" my-branch --base=develop
 gh.jsh pr create "My title" "PR body" my-branch --draft
-gh.jsh pr create "My title" "PR body" my-branch owner/repo
-```
-`head` is the branch to merge from. `--base` defaults to the repo's default branch. Returns the PR number and URL.
-
-**Merge a PR**
-```bash
 gh.jsh pr merge 42                        # default: merge commit
 gh.jsh pr merge 42 --squash
 gh.jsh pr merge 42 --rebase
-gh.jsh pr merge 42 --squash owner/repo
-```
-
-**Post a comment**
-```bash
 gh.jsh pr comment 42 "LGTM, merging now"
-gh.jsh pr comment 42 "Please rebase" owner/repo
+gh.jsh pr checkout 42                     # prints git fetch/checkout commands (does not execute)
 ```
-
-**Checkout commands**
-```bash
-gh.jsh pr checkout 42
-```
-Prints the `git fetch` and `git checkout` commands to check out the PR branch. Does not execute them (VFS-safe).
+`pr create`: `head` is the branch to merge from; `--base` defaults to the repo's default branch. Returns the PR number and URL.
 
 ---
 
 ### Issues
 
-**List open issues**
 ```bash
 gh.jsh issue list
-gh.jsh issue list owner/repo
-```
-Output: number, title, labels
-
-**View an issue**
-```bash
 gh.jsh issue view 123
-gh.jsh issue view 123 owner/repo
-```
-Shows title, author, URL, labels, body preview.
-
-**Create an issue**
-```bash
 gh.jsh issue create "Title" "Body text"
 gh.jsh issue create "Title" "Body text" --label=bug
-gh.jsh issue create "Title" "Body text" --label=bug --label=triage owner/repo
-gh.jsh issue create "Title" "Body text" --labels=bug,triage owner/repo
+gh.jsh issue create "Title" "Body text" --labels=bug,triage
 ```
-Returns the new issue number and URL. `--label=` may be repeated; `--labels=` accepts a comma-separated list. Title and body are required positional args; pass `""` for an empty body.
+Returns the new issue number and URL. `--label=` may be repeated; `--labels=` accepts a comma-separated list. Title and body are required; pass `""` for an empty body.
 
 ---
 
 ### Repository
 
-**View repo info**
 ```bash
 gh.jsh repo view
-gh.jsh repo view owner/repo
+gh.jsh repo archive owner/repo           # irreversible without admin unarchive
 ```
-Shows description, stars, forks, default branch, language, topics, last push, URL.
-
----
-
-### Repository Management
-
-**Archive a repo**
-```bash
-gh.jsh repo archive owner/repo
-```
-Archives the repository (irreversible without admin unarchive). Useful after retiring a project.
 
 ---
 
 ### Branches
 
-**Create a branch**
 ```bash
 gh.jsh branch create my-feature
 gh.jsh branch create my-feature --from=develop
-gh.jsh branch create my-feature --from=abc1234... owner/repo
-```
-Creates a branch from the default branch (or `--from` ref/SHA). Use this before `content put` to prepare a PR branch.
-
-**Delete a branch**
-```bash
+gh.jsh branch create my-feature --from=abc1234...
 gh.jsh branch delete my-feature
-gh.jsh branch delete my-feature owner/repo
 ```
+Creates from the default branch (or `--from` ref/SHA). Use before `content put` to prepare a PR branch.
 
 ---
 
 ### File Content (Contents API)
 
-**Create or update a file**
 ```bash
 gh.jsh content put README.md ./local-readme.md "Update README" --branch=my-feature
 gh.jsh content put src/index.js ./index.js "Add entry point" --branch=my-feature owner/repo
 ```
-Reads a local VFS file, base64-encodes it, and creates/updates it on the specified branch via the GitHub Contents API. Handles SHA lookup for existing files automatically. This is the way to "push" file changes without git clone + push.
-
----
-
-### Raw API Passthrough
-
-**Call any GitHub API endpoint**
-```bash
-gh.jsh api /repos/owner/repo
-gh.jsh api /repos/owner/repo/git/ref/heads/main --jq .object.sha
-gh.jsh api /repos/owner/repo/git/refs -X POST -f ref=refs/heads/new-branch -f sha=abc123
-```
-Generic passthrough for any GitHub REST API endpoint. Supports `-X METHOD`, `-f key=value` (sent as JSON body on non-GET), and `--jq .path.to.field` for simple field extraction.
+Reads a local VFS file, base64-encodes it, and creates/updates it on the specified branch via the GitHub Contents API. Handles SHA lookup for existing files automatically. Use this to push file changes without git clone + push.
 
 ---
 
 ### Workflow Runs
 
-**List recent runs**
 ```bash
 gh.jsh run list
-gh.jsh run list owner/repo
-```
-Output: run ID, workflow name, status/conclusion, branch, date
-
-**View a run**
-```bash
 gh.jsh run view 12345678
-gh.jsh run view 12345678 owner/repo
 ```
-Shows run details, commit, and per-job status with duration.
+`run view` shows run details, commit, and per-job status with duration.
 
 ---
 
 ### Releases
 
-**List recent releases**
 ```bash
 gh.jsh release list
-gh.jsh release list owner/repo
 ```
-Output: tag, name, published date. Pre-release and draft tags shown inline.
 
 ---
 
 ### Search
 
-**Search PRs**
 ```bash
 gh.jsh search prs "fix login"
 gh.jsh search prs "fix login" owner/repo
@@ -224,73 +181,19 @@ Uses GitHub search API. Returns PR number, title, repo, and state.
 
 ### Actions Variables
 
-**List variables**
 ```bash
 gh.jsh vars list
-gh.jsh vars list owner/repo
-```
-
-**Set a variable**
-```bash
 gh.jsh vars set MY_VAR "hello world"
-gh.jsh vars set MY_VAR "hello world" owner/repo
 ```
 Creates or updates the variable (PATCH if exists, POST if new).
 
 ---
 
-## Output Format
-
-Columns are aligned with fixed widths. ANSI color coding:
-
-| Color  | Meaning                          |
-|--------|----------------------------------|
-| Green  | success / open / merged          |
-| Red    | failure / closed                 |
-| Yellow | pending / in_progress / draft    |
-| Gray   | skipped / cancelled / metadata   |
-| Cyan   | IDs, variable names, PR numbers  |
-
-Status symbols:
-- `✓` success / open / merged (green)
-- `✗` failure / closed (red)
-- `●` pending / in_progress (yellow)
-- `○` skipped / cancelled / draft (gray)
-
----
-
-## Error Handling
-
-API errors print to stderr and exit 1:
-```
-gh: pr list failed: HTTP 404: Not Found
-```
-
-Missing required arguments exit with a usage hint.
-
----
-
-## Examples for Agents
+### Raw API Passthrough
 
 ```bash
-# Check what PRs are waiting for review
-/workspace/skills/github/gh.jsh pr list ai-ecoverse/slicc
-
-# Inspect a specific PR before merging
-/workspace/skills/github/gh.jsh pr view 42 ai-ecoverse/slicc
-
-# Merge after review
-/workspace/skills/github/gh.jsh pr merge 42 --squash ai-ecoverse/slicc
-
-# Post a status comment
-/workspace/skills/github/gh.jsh pr comment 42 "Automated: all checks passed, merging." ai-ecoverse/slicc
-
-# Check CI for a repo
-/workspace/skills/github/gh.jsh run list ai-ecoverse/slicc
-
-# Diagnose a failed run
-/workspace/skills/github/gh.jsh run view 14567890123 ai-ecoverse/slicc
-
-# Find PRs related to a feature
-/workspace/skills/github/gh.jsh search prs "auth token" ai-ecoverse/slicc
+gh.jsh api /repos/owner/repo
+gh.jsh api /repos/owner/repo/git/ref/heads/main --jq .object.sha
+gh.jsh api /repos/owner/repo/git/refs -X POST -f ref=refs/heads/new-branch -f sha=abc123
 ```
+Generic passthrough for any GitHub REST API endpoint. Supports `-X METHOD`, `-f key=value` (sent as JSON body on non-GET), and `--jq .path.to.field` for simple field extraction.


### PR DESCRIPTION
Auto-optimized the github skill via `tessl skill review --optimize`.

**Scores**: 85% → 96% (+11)

**Changes (SKILL.md only)**:
- Added a 'Common Workflows' section with explicit multi-step sequences (branch create → content put → pr create → run list → pr merge) and validation checkpoints between steps.
- Factored out the repeated `owner/repo` trailing-arg pattern: stated once at the top, removed from every command example.
- Consolidated the Command Reference into compact code blocks per noun (PRs, Issues, Repo, Branches, Content, Runs, Releases, Search, Vars, API), trimming ~100 lines.
- Removed the Output Format color/symbol table and the Error Handling section (Claude doesn't need them spelled out).

**Verification on this branch**:
- `tessl skill review skills/github --threshold 90` → exit 0 (96%)
- `tessl skill lint .` → exit 0
