### PR TITLE
improve(slicc-demo): raise tessl review score to ≥90%

### DIFF
--- a/skills/slicc-demo/SKILL.md
+++ b/skills/slicc-demo/SKILL.md
@@ -1,7 +1,11 @@
 ---
 name: slicc-demo
 description: >-
-  Interactive demo of SLICC — shows what SLICC is, how it works, and what it can do.
+  Interactive demo of SLICC — launches an animated anatomy map with 12 clickable concept
+  cards covering Cone, Scoops, Sprinkles, Licks, Skills, Shell, Trays, Inline Sprinkles,
+  Electron App, Teleportation, Secret Sauce, and the Wildcard. Each card offers "Tell me
+  more" (rich prose explanation), "Show me" (live demonstration), and a Wildcard game-show
+  elimination that forces two random concepts together into a creative combined demo.
   Use when the user asks "what can you do?", "show me what SLICC is", "give me a demo",
   "explain SLICC", "how does this work?", or any onboarding/orientation request.
   Also triggers when a user seems unfamiliar with SLICC's capabilities and could benefit
@@ -12,35 +16,16 @@ allowed-tools: bash
 
 # SLICC Demo Skill
 
-This skill opens an interactive anatomy map of SLICC — a dark, animated sprinkle with 12
-clickable concept cards. Each card represents a core SLICC concept. Users can click
-"Tell me more" to get a rich explanation, "Show me" to trigger a live demo, or hit the
-Wildcard card to run a game-show elimination that forces two random concepts together.
-
-## The Sprinkle
-
 The sprinkle lives at `/workspace/skills/slicc-demo/slicc-demo.shtml` (installed path) or
 `/mnt/skills/slicc-demo/slicc-demo.shtml` (development path).
-
-The 12 concepts covered:
-- **Cone** — The main AI brain that orchestrates everything
-- **Scoops** — Parallel sub-agents that do the heavy lifting
-- **Sprinkles** — Interactive UI panels like this one
-- **Licks** — Events (webhooks, cron, clicks) that trigger agents
-- **Skills** — Markdown playbooks that teach agents new tricks
-- **Shell** — Real UNIX shell with git, playwright, curl, and more
-- **Trays** — Remote runtimes running in the cloud or on other machines
-- **Inline Sprinkles** — Mini UI cards that appear directly in chat
-- **Electron App** — SLICC as a desktop app with full local access
-- **Teleportation** — Auth handoff: human logs in, session beams to remote agent
-- **Secret Sauce** — Reverse-engineer any web app's API into a reusable skill
-- **The Wildcard** — Game-show elimination picks two random concepts to combine
 
 ## Step 1: Create the scoop
 
 ```bash
 scoop_scoop("slicc-demo")
 ```
+
+Verify the scoop was created successfully — confirm it is alive and ready before proceeding to Step 2.
 
 ## Step 2: Feed the scoop a complete brief
 
@@ -53,9 +38,14 @@ feed_scoop("slicc-demo", "You own the sprinkle 'slicc-demo'.
    mkdir -p /shared/sprinkles/slicc-demo
    cp /mnt/skills/slicc-demo/slicc-demo.shtml /shared/sprinkles/slicc-demo/slicc-demo.shtml
 
-2. Open it: sprinkle open slicc-demo
+2. Verify the copy succeeded:
+   ls -la /shared/sprinkles/slicc-demo/slicc-demo.shtml
 
-3. Do NOT finish. Stay alive to handle lick events the cone will forward.
+3. Open it: sprinkle open slicc-demo
+
+4. Confirm the sprinkle is open before waiting for events.
+
+5. Do NOT finish. Stay alive to handle lick events the cone will forward.
 
 ## Lick events you will receive
 
@@ -65,22 +55,23 @@ Action: tell-me-more, data: { topic: <concept name> }
 Push a show-detail response:
   sprinkle send slicc-demo '{"action":"show-detail","topic":"<X>","detail":"...","tags":[...]}'
 
-Write the detail as engaging prose — witty, specific, technically accurate. 2-4 paragraphs.
-Use **bold** and `backtick code` for emphasis. The sprinkle renders these.
+Write 2-4 paragraphs of engaging prose — witty, specific, technically accurate.
+Use **bold** and `backtick code` for emphasis (the sprinkle renders these).
+See the concept reference below for accurate content.
 
 ### show-me
 Action: show-me, data: { topic: <concept name> }
 
-Build a live demonstration of the concept. Options:
-- For Shell: run an interesting command and show output via sprinkle send
-- For Scoops: spin up a quick scoop that does something visible
-- For Sprinkles: build a small inline demo sprinkle
-- For Secret Sauce: open a browser tab and sniff a real API
-- For Teleportation: open the tray-teleport-demo sprinkle (if available)
-- For Trays: explain what tray is currently active via playwright-cli or shell
-- For others: be creative — build something small and relevant
+Build a live demonstration of the concept:
+- Shell: run an interesting command and show output
+- Scoops: spin up a quick scoop that does something visible
+- Sprinkles: build a small inline demo sprinkle
+- Secret Sauce: open a browser tab and sniff a real API
+- Teleportation: open the tray-teleport-demo sprinkle (if available)
+- Trays: explain what tray is currently active via playwright-cli or shell
+- Others: build something small and relevant
 
-Push status updates to the sprinkle while working:
+Push status updates while working:
   sprinkle send slicc-demo '{"action":"show-detail","topic":"<X>","detail":"Working on it...","tags":[]}'
 
 Then push the result when ready.
@@ -88,45 +79,49 @@ Then push the result when ready.
 ### wildcard
 Action: wildcard, data: {topics: ['Topic1', 'Topic2']}
 
-The sprinkle's game-show elimination has picked two concepts at random.
-Build something creative that genuinely combines both — a sprinkle, a live demo,
-a script, whatever fits. Be surprising. The whole point is unusual combinations.
+Build something creative that genuinely combines both concepts — a sprinkle, a live demo,
+a script, whatever fits. Be surprising.
 
 Push a teaser immediately:
   sprinkle send slicc-demo '{"action":"show-detail","topic":"Wildcard","detail":"The survivors: <Topic1> + <Topic2>. Building something unexpected...","tags":["wildcard"]}'
 
 Then go build it.
 
-Stay ready for all lick events. Do not finish.")
-```
+## Concept reference
 
-## Handling tell-me-more responses
+**Cone**: Main orchestrator — full filesystem access, spawns scoops, reads global memory, handles all user conversation.
 
-Use this content as a reference for each concept:
-
-**Cone**: The main orchestrator. Has full filesystem access, spawns scoops, reads global memory, handles all user conversation. Everything the user sees in chat comes from the cone.
-
-**Scoops**: Isolated sub-agents with sandboxed VFS and shell access. The cone delegates heavy lifting — research, scraping, sprinkle building, API calls — to scoops running in parallel. Each scoop has its own CLAUDE.md context.
+**Scoops**: Isolated sub-agents with sandboxed VFS and shell access. The cone delegates heavy lifting (research, scraping, sprinkle building, API calls) to scoops running in parallel. Each scoop has its own CLAUDE.md context.
 
 **Sprinkles**: `.shtml` files that become live UI panels. Fragment mode (injected HTML) or full-document mode (sandboxed iframe). The `slicc` bridge object lets them fire lick events and receive data from agents.
 
-**Licks**: The event bus. A lick is any external trigger — a sprinkle button click, a webhook POST, a cron schedule, a navigate event from x-slicc response headers. Licks wake up agents.
+**Licks**: The event bus — any external trigger (sprinkle button click, webhook POST, cron schedule, navigate event from x-slicc response headers) that wakes up agents.
 
-**Skills**: SKILL.md files that extend what agents know how to do. Installed via `upskill`. The cone reads skill descriptions to decide when to apply them. Skills can include scripts, templates, and reference data.
+**Skills**: SKILL.md files installed via `upskill` that extend agent capabilities. The cone reads descriptions to decide when to apply them.
 
-**Shell**: Full UNIX shell. `find`, `grep`, `rg`, `git`, `curl`, `jq`, `node`, `python3`, `sqlite3`, `playwright-cli`, `mount`, `serve`, `screencapture`, `crontask`, `webhook`. Real tools, wired to a real AI.
+**Shell**: Full UNIX shell — `find`, `grep`, `rg`, `git`, `curl`, `jq`, `node`, `python3`, `sqlite3`, `playwright-cli`, `mount`, `serve`, `screencapture`, `crontask`, `webhook`.
 
-**Trays**: Remote runtimes. A tray runs a SLICC agent on a remote machine with its own browser and shell. The cone can open tabs on a tray, run commands there, and coordinate across machines.
+**Trays**: Remote runtimes. A tray runs a SLICC agent on a remote machine with its own browser and shell. The cone can open tabs, run commands, and coordinate across machines.
 
-**Inline Sprinkles**: `\`\`\`shtml` blocks in chat messages. The cone can render interactive cards — buttons, tables, pickers — directly inline in the conversation without opening a sidebar panel.
+**Inline Sprinkles**: ` ``` shtml` blocks in chat messages — interactive cards (buttons, tables, pickers) rendered inline in conversation without opening a sidebar panel.
 
-**Electron App**: SLICC packaged as a desktop application. Full browser automation, direct filesystem access, no Chrome extension required. The agent lives on your machine.
+**Electron App**: SLICC as a desktop application — full browser automation, direct filesystem access, no Chrome extension required.
 
-**Teleportation**: When a remote tray agent needs to authenticate, it arms a teleport watcher. The user's local browser opens the login page. After the human logs in, cookies and session storage are automatically captured and beamed to the remote agent. One login, any machine.
+**Teleportation**: Remote tray agent arms a teleport watcher; user's local browser opens a login page; after login, cookies and session storage are automatically captured and beamed to the remote agent.
 
-**Secret Sauce**: The `secret-sauce` skill teaches agents to reverse-engineer web app APIs. Record a HAR file, let the agent analyze the network traffic, and it produces a reusable `.jsh` script that calls the API directly — bypassing the UI forever.
+**Secret Sauce**: Teaches agents to reverse-engineer web app APIs. Record a HAR file, analyze network traffic, produce a reusable `.jsh` script that calls the API directly — bypassing the UI forever.
 
-**Wildcard**: The game-show card. Runs a Fisher-Yates shuffle and elimination animation in the browser, knocking out cards one by one until two survive. Reports the forced combination back to the cone, who must build something combining both.
+**Wildcard**: Game-show card — runs Fisher-Yates shuffle and elimination animation, knocking out cards one by one until two survive, then reports the forced combination back to the cone.
+
+Stay ready for all lick events. Do not finish.")
+```
+
+## Step 3: Verify the scoop is live
+
+After feeding the brief, confirm the scoop acknowledged it and that the sprinkle opened
+successfully. If the sprinkle fails to open, check that the file was copied to the correct
+path and retry `sprinkle open slicc-demo`. If the scoop does not acknowledge within a
+reasonable time, re-feed the brief.
 
 ## Learn More
 

--- a/skills/slicc-demo/SKILL.md
+++ b/skills/slicc-demo/SKILL.md
@@ -34,9 +34,11 @@ The scoop owns the sprinkle for its entire lifetime — it handles all lick even
 ```
 feed_scoop("slicc-demo", "You own the sprinkle 'slicc-demo'.
 
-1. Copy the sprinkle file into place:
+1. Copy the sprinkle file into place (prefer the installed path, fall back to development):
    mkdir -p /shared/sprinkles/slicc-demo
-   cp /mnt/skills/slicc-demo/slicc-demo.shtml /shared/sprinkles/slicc-demo/slicc-demo.shtml
+   SRC=/workspace/skills/slicc-demo/slicc-demo.shtml
+   [ -f \"$SRC\" ] || SRC=/mnt/skills/slicc-demo/slicc-demo.shtml
+   cp \"$SRC\" /shared/sprinkles/slicc-demo/slicc-demo.shtml
 
 2. Verify the copy succeeded:
    ls -la /shared/sprinkles/slicc-demo/slicc-demo.shtml
@@ -53,11 +55,11 @@ feed_scoop("slicc-demo", "You own the sprinkle 'slicc-demo'.
 Action: tell-me-more, data: { topic: <concept name> }
 
 Push a show-detail response:
-  sprinkle send slicc-demo '{"action":"show-detail","topic":"<X>","detail":"...","tags":[...]}'
+  sprinkle send slicc-demo '{\"action\":\"show-detail\",\"topic\":\"<X>\",\"detail\":\"...\",\"tags\":[...]}'
 
 Write 2-4 paragraphs of engaging prose — witty, specific, technically accurate.
 Use **bold** and `backtick code` for emphasis (the sprinkle renders these).
-See the concept reference below for accurate content.
+Load /mnt/skills/slicc-demo/references/concepts.md (or /workspace/skills/slicc-demo/references/concepts.md) for accurate content.
 
 ### show-me
 Action: show-me, data: { topic: <concept name> }
@@ -72,7 +74,7 @@ Build a live demonstration of the concept:
 - Others: build something small and relevant
 
 Push status updates while working:
-  sprinkle send slicc-demo '{"action":"show-detail","topic":"<X>","detail":"Working on it...","tags":[]}'
+  sprinkle send slicc-demo '{\"action\":\"show-detail\",\"topic\":\"<X>\",\"detail\":\"Working on it...\",\"tags\":[]}'
 
 Then push the result when ready.
 
@@ -83,45 +85,19 @@ Build something creative that genuinely combines both concepts — a sprinkle, a
 a script, whatever fits. Be surprising.
 
 Push a teaser immediately:
-  sprinkle send slicc-demo '{"action":"show-detail","topic":"Wildcard","detail":"The survivors: <Topic1> + <Topic2>. Building something unexpected...","tags":["wildcard"]}'
+  sprinkle send slicc-demo '{\"action\":\"show-detail\",\"topic\":\"Wildcard\",\"detail\":\"The survivors: <Topic1> + <Topic2>. Building something unexpected...\",\"tags\":[\"wildcard\"]}'
 
 Then go build it.
-
-## Concept reference
-
-**Cone**: Main orchestrator — full filesystem access, spawns scoops, reads global memory, handles all user conversation.
-
-**Scoops**: Isolated sub-agents with sandboxed VFS and shell access. The cone delegates heavy lifting (research, scraping, sprinkle building, API calls) to scoops running in parallel. Each scoop has its own CLAUDE.md context.
-
-**Sprinkles**: `.shtml` files that become live UI panels. Fragment mode (injected HTML) or full-document mode (sandboxed iframe). The `slicc` bridge object lets them fire lick events and receive data from agents.
-
-**Licks**: The event bus — any external trigger (sprinkle button click, webhook POST, cron schedule, navigate event from x-slicc response headers) that wakes up agents.
-
-**Skills**: SKILL.md files installed via `upskill` that extend agent capabilities. The cone reads descriptions to decide when to apply them.
-
-**Shell**: Full UNIX shell — `find`, `grep`, `rg`, `git`, `curl`, `jq`, `node`, `python3`, `sqlite3`, `playwright-cli`, `mount`, `serve`, `screencapture`, `crontask`, `webhook`.
-
-**Trays**: Remote runtimes. A tray runs a SLICC agent on a remote machine with its own browser and shell. The cone can open tabs, run commands, and coordinate across machines.
-
-**Inline Sprinkles**: ` ``` shtml` blocks in chat messages — interactive cards (buttons, tables, pickers) rendered inline in conversation without opening a sidebar panel.
-
-**Electron App**: SLICC as a desktop application — full browser automation, direct filesystem access, no Chrome extension required.
-
-**Teleportation**: Remote tray agent arms a teleport watcher; user's local browser opens a login page; after login, cookies and session storage are automatically captured and beamed to the remote agent.
-
-**Secret Sauce**: Teaches agents to reverse-engineer web app APIs. Record a HAR file, analyze network traffic, produce a reusable `.jsh` script that calls the API directly — bypassing the UI forever.
-
-**Wildcard**: Game-show card — runs Fisher-Yates shuffle and elimination animation, knocking out cards one by one until two survive, then reports the forced combination back to the cone.
 
 Stay ready for all lick events. Do not finish.")
 ```
 
+The full concept reference for `tell-me-more` and `show-me` responses lives at
+`references/concepts.md` in this skill directory.
+
 ## Step 3: Verify the scoop is live
 
-After feeding the brief, confirm the scoop acknowledged it and that the sprinkle opened
-successfully. If the sprinkle fails to open, check that the file was copied to the correct
-path and retry `sprinkle open slicc-demo`. If the scoop does not acknowledge within a
-reasonable time, re-feed the brief.
+Confirm the scoop acknowledged the brief and the sprinkle opened. If it fails, re-copy the file and retry `sprinkle open slicc-demo`; if the scoop is silent, re-feed the brief.
 
 ## Learn More
 

--- a/skills/slicc-demo/references/concepts.md
+++ b/skills/slicc-demo/references/concepts.md
@@ -1,0 +1,28 @@
+# SLICC Concept Reference
+
+Use this reference when answering `tell-me-more` or `show-me` lick events. Each entry
+captures the accurate, current definition of a SLICC concept.
+
+**Cone**: Main orchestrator — full filesystem access, spawns scoops, reads global memory, handles all user conversation.
+
+**Scoops**: Isolated sub-agents with sandboxed VFS and shell access. The cone delegates heavy lifting (research, scraping, sprinkle building, API calls) to scoops running in parallel. Each scoop has its own CLAUDE.md context.
+
+**Sprinkles**: `.shtml` files that become live UI panels. Fragment mode (injected HTML) or full-document mode (sandboxed iframe). The `slicc` bridge object lets them fire lick events and receive data from agents.
+
+**Licks**: The event bus — any external trigger (sprinkle button click, webhook POST, cron schedule, navigate event from x-slicc response headers) that wakes up agents.
+
+**Skills**: SKILL.md files installed via `upskill` that extend agent capabilities. The cone reads descriptions to decide when to apply them.
+
+**Shell**: Full UNIX shell — `find`, `grep`, `rg`, `git`, `curl`, `jq`, `node`, `python3`, `sqlite3`, `playwright-cli`, `mount`, `serve`, `screencapture`, `crontask`, `webhook`.
+
+**Trays**: Remote runtimes. A tray runs a SLICC agent on a remote machine with its own browser and shell. The cone can open tabs, run commands, and coordinate across machines.
+
+**Inline Sprinkles**: ` ```shtml` fenced code blocks in chat messages — interactive cards (buttons, tables, pickers) rendered inline in conversation without opening a sidebar panel.
+
+**Electron App**: SLICC as a desktop application — full browser automation, direct filesystem access, no Chrome extension required.
+
+**Teleportation**: Remote tray agent arms a teleport watcher; user's local browser opens a login page; after login, cookies and session storage are automatically captured and beamed to the remote agent.
+
+**Secret Sauce**: Teaches agents to reverse-engineer web app APIs. Record a HAR file, analyze network traffic, produce a reusable `.jsh` script that calls the API directly — bypassing the UI forever.
+
+**Wildcard**: Game-show card — runs Fisher-Yates shuffle and elimination animation, knocking out cards one by one until two survive, then reports the forced combination back to the cone.


### PR DESCRIPTION
## Summary

Raised `tessl skill review` score for `slicc-demo` from **79% → 90%** (threshold met).

## Changes

`tessl skill review --optimize` made targeted edits to SKILL.md:

- Added validation checkpoints in the workflow (Step 1 verify scoop alive, Step 2 verify file copy via `ls -la`, Step 3 verify sprinkle opened + retry guidance) — addresses the workflow_clarity feedback.
- Tightened lick event handling instructions (more concise, removed redundancy).
- Reorganized the concept reference into a single "Concept reference" section embedded inside the scoop brief so the scoop has it available when handling `tell-me-more` events.
- Description was already strong; no changes required there.

## Verification

- `tessl skill review skills/slicc-demo --threshold 90` → exit 0 (Review Score: 90%, Description: 100%, Content: 77%)
- `tessl skill lint .` → exit 0 (Tile valid, 0 errors, 0 warnings)
