### PR TITLE
improve(monday): raise tessl review score to ≥90%

### DIFF
--- a/skills/monday/SKILL.md
+++ b/skills/monday/SKILL.md
@@ -18,7 +18,7 @@ Cross-tool inbox aggregator. Runs each available source skill's `monday` sub-com
 in parallel, merges the JSON results, optionally rates each item with an AI agent,
 and prints a sorted JSON array on stdout. Progress messages go to stderr.
 
-**Source skills:** `gmail` · `slack` · `teams` · `outlook` · `github` (as `gh`) · `servicenow` — each must be installed separately and expose its own `<cmd> monday` sub-command.
+**Source skills:** `gmail` · `slack` · `teams` · `outlook` · `github` (as `gh`) · `servicenow` — each must be installed separately and expose its own `[cmd] monday` sub-command.
 
 ## Quick start
 
@@ -40,10 +40,10 @@ monday gh --rate-importance 8-3 --rate-model claude-haiku-4-5 --rate-context /wo
 
 The `monday` command executes the following steps in order:
 
-1. **Discover sources** — with no positional args, run `which <cmd>` for each name in `KNOWN_COMMANDS` and keep those found on PATH; otherwise use the names supplied as positional args.
-2. **Invoke in parallel** — call `<cmd> monday --limit N --depth N --date Nd` for every discovered source concurrently.
+1. **Discover sources** — with no positional args, run `which [cmd]` for each name in `KNOWN_COMMANDS` and keep those found on PATH; otherwise use the names supplied as positional args.
+2. **Invoke in parallel** — call `[cmd] monday --limit N --depth N --date Nd` for every discovered source concurrently.
 3. **Collect and validate JSON** — read each source's stdout; any source that exits non-zero, produces empty output, or emits invalid JSON is logged to stderr and dropped. Aggregation continues with remaining sources.
-4. **Deduplicate by `id`** — merge all item arrays; when two items share the same `id`, keep the one with the later `ts`.
+4. **Deduplicate by `id`** — merge all item arrays in source order; when two items share the same `id`, the first occurrence wins and later duplicates are dropped (so positional arg order determines precedence for overlapping sources).
 5. **Optionally rate** — if any `--rate-*` flag is set, submit each item to the rating agent (model: `--rate-model`; optional context: `--rate-context`) to assign `importance`, `urgency`, and `summary` fields. Rating failures fall back to the unrated item; aggregation still completes.
 6. **Sort and output** — if rated, sort by `urgency × importance` descending (ties broken by `ts` descending); otherwise sort by `ts` descending. Write the final JSON array to stdout.
 
@@ -66,10 +66,10 @@ the known source list and uses whichever are found on PATH.
 
 ## Source protocol
 
-A command is "monday-compatible" when it accepts `<cmd> monday --limit N --depth N --date Nd` and writes a JSON array of items to stdout. Each item must include `id` (stable unique string for deduplication), `ts` (ISO timestamp for sorting), and any other fields (title, url, participants, body, etc.) which are passed through unchanged.
+A command is "monday-compatible" when it accepts `[cmd] monday --limit N --depth N --date Nd` and writes a JSON array of items to stdout. Each item must include `id` (stable unique string for deduplication), `ts` (ISO timestamp for sorting), and any other fields (title, url, participants, body, etc.) which are passed through unchanged.
 
 To add a new source, implement the protocol above and invoke it explicitly:
-`monday <newcmd> gh slack`. To register it for auto-discovery, add the command name
+`monday [newcmd] gh slack`. To register it for auto-discovery, add the command name
 to the `KNOWN_COMMANDS` list in the aggregator script.
 
 ## Output

--- a/skills/monday/SKILL.md
+++ b/skills/monday/SKILL.md
@@ -3,10 +3,10 @@ name: monday
 description: >-
   Aggregate and prioritize inbox items from multiple sources (Gmail, Slack, Teams,
   Outlook, GitHub, ServiceNow) into a single ranked list. Acts as a dispatcher: each
-  source skill exposes a `<cmd> monday` sub-command that returns JSON items, and the
+  source skill exposes a `[cmd] monday` sub-command that returns JSON items, and the
   `monday` command merges, deduplicates, optionally rates with an AI model
-  (importance × urgency), and sorts them. Use when the user asks "what should I work
-  on", "Monday morning triage", "what needs my attention", "show me my inbox",
+  (importance times urgency), and sorts them. Use when the user asks "what should I
+  work on", "Monday morning triage", "what needs my attention", "show me my inbox",
   "rank my todos", "what's urgent across all my tools", or for weekly/daily triage
   across email, chat, tickets, and pull requests.
 allowed-tools: bash
@@ -17,6 +17,8 @@ allowed-tools: bash
 Cross-tool inbox aggregator. Runs each available source skill's `monday` sub-command
 in parallel, merges the JSON results, optionally rates each item with an AI agent,
 and prints a sorted JSON array on stdout. Progress messages go to stderr.
+
+**Source skills:** `gmail` · `slack` · `teams` · `outlook` · `github` (as `gh`) · `servicenow` — each must be installed separately and expose its own `<cmd> monday` sub-command.
 
 ## Quick start
 
@@ -33,6 +35,17 @@ monday --rate-importance 9-1 --rate-urgency 8-1 --rate-summary 500
 # Rate with a specific model and a knowledge-base context directory
 monday gh --rate-importance 8-3 --rate-model claude-haiku-4-5 --rate-context /workspace/kb
 ```
+
+## Aggregation pipeline
+
+The `monday` command executes the following steps in order:
+
+1. **Discover sources** — with no positional args, run `which <cmd>` for each name in `KNOWN_COMMANDS` and keep those found on PATH; otherwise use the names supplied as positional args.
+2. **Invoke in parallel** — call `<cmd> monday --limit N --depth N --date Nd` for every discovered source concurrently.
+3. **Collect and validate JSON** — read each source's stdout; any source that exits non-zero, produces empty output, or emits invalid JSON is logged to stderr and dropped. Aggregation continues with remaining sources.
+4. **Deduplicate by `id`** — merge all item arrays; when two items share the same `id`, keep the one with the later `ts`.
+5. **Optionally rate** — if any `--rate-*` flag is set, submit each item to the rating agent (model: `--rate-model`; optional context: `--rate-context`) to assign `importance`, `urgency`, and `summary` fields. Rating failures fall back to the unrated item; aggregation still completes.
+6. **Sort and output** — if rated, sort by `urgency × importance` descending (ties broken by `ts` descending); otherwise sort by `ts` descending. Write the final JSON array to stdout.
 
 ## Flags
 
@@ -53,69 +66,47 @@ the known source list and uses whichever are found on PATH.
 
 ## Source protocol
 
-A command is "monday-compatible" when it accepts:
+A command is "monday-compatible" when it accepts `<cmd> monday --limit N --depth N --date Nd` and writes a JSON array of items to stdout. Each item must include `id` (stable unique string for deduplication), `ts` (ISO timestamp for sorting), and any other fields (title, url, participants, body, etc.) which are passed through unchanged.
 
-```
-<cmd> monday --limit N --depth N --date Nd
-```
-
-and writes a JSON array of items to stdout. Each item should include:
-
-- `id` — stable unique string (used for deduplication)
-- `ts` — ISO timestamp of last activity (used for sorting when not rated)
-- arbitrary other fields (title, url, participants, body, etc.) — passed through
-
-Sources in this skill collection that implement this protocol: `gmail`, `slack`,
-`teams`, `outlook`, `github` (as `gh`), `servicenow`.
+To add a new source, implement the protocol above and invoke it explicitly:
+`monday <newcmd> gh slack`. To register it for auto-discovery, add the command name
+to the `KNOWN_COMMANDS` list in the aggregator script.
 
 ## Output
 
-A single JSON array on stdout. When `--rate-*` flags are set, each item is
-augmented with `importance`, `urgency`, and `summary` fields and the array is
-sorted by `urgency × importance` descending (ties broken by `ts` descending).
-Without rating, items are sorted by `ts` descending.
+A single JSON array on stdout. Sorting and rating augmentation follow pipeline steps 5–6.
+
+**Unrated item example:**
+```json
+[
+  {
+    "id": "gh-pr-4821",
+    "ts": "2025-07-14T09:12:00Z",
+    "source": "gh",
+    "title": "Fix race condition in auth middleware",
+    "url": "https://github.com/org/repo/pull/4821",
+    "participants": ["alice", "bob"]
+  }
+]
+```
+
+**Rated item example** (with `--rate-importance 9-1 --rate-urgency 8-1 --rate-summary 200`):
+```json
+[
+  {
+    "id": "gh-pr-4821",
+    "ts": "2025-07-14T09:12:00Z",
+    "source": "gh",
+    "title": "Fix race condition in auth middleware",
+    "url": "https://github.com/org/repo/pull/4821",
+    "participants": ["alice", "bob"],
+    "importance": 8,
+    "urgency": 7,
+    "summary": "Security-critical PR awaiting your review; blocks the 2.4 release."
+  }
+]
+```
 
 ```bash
 monday gh slack --date 2d | jq '.[0:5] | .[] | {id, ts, title}'
 ```
-
-## Presenting results to the user
-
-After running `monday`, present a concise prioritized view:
-
-1. **Top action items** — the first 5–10 items from the sorted output. For each:
-   show source, title, who acted last, and a one-line "next action" (reply,
-   review, respond, close, etc.).
-2. **Counts by source** — e.g. "12 GitHub, 7 Slack, 3 ServiceNow".
-3. **Offer to help** with the top items: "Want me to draft a reply to X?" or
-   "Should I open PR #N for review?".
-
-When `--rate-summary` was used, lead with each item's `summary` field — it's
-already condensed for presentation.
-
-## Adding a new source
-
-Any CLI can join the dispatcher by implementing a `monday` sub-command that:
-
-1. Accepts `--limit`, `--depth`, `--date` flags
-2. Reads the user's data for that window
-3. Writes a JSON array (with at least `id` and `ts` per item) to stdout
-4. Exits 0 on success
-
-Then add the command name to the `KNOWN_COMMANDS` array in `scripts/monday.jsh`,
-or just invoke it explicitly: `monday <newcmd> gh slack`.
-
-## Failure modes
-
-- A source that exits non-zero, returns empty stdout, or returns invalid JSON is
-  logged to stderr and skipped — `monday` always finishes and returns whatever it
-  could collect.
-- Rating failures fall back to unrated items; the aggregation still completes.
-
-## Inspiration
-
-The ranking idea is borrowed from
-[`ai-ecoverse/gh-monday`](https://github.com/ai-ecoverse/gh-monday) (a `gh`
-extension that ranks GitHub work by who acted last). This skill generalizes the
-same "show me what needs attention" concept across every tool that publishes a
-`monday` sub-command.


### PR DESCRIPTION
Raises tessl review score for the `monday` skill from 18% (failing deterministic validation) to 90%.

## Changes
- **Removed XML tags from description**: replaced `<cmd>` placeholder with `[cmd]` to satisfy the deterministic validator (description field must not contain XML tags).
- **Applied `tessl skill review --optimize`**: restructured SKILL.md to add an explicit 6-step aggregation pipeline, consolidated source-protocol guidance, added unrated/rated JSON output examples, and removed lower-value sections (Inspiration, redundant prose).
- **Fixed broken relative links**: optimize introduced links to non-existent sibling skill files; converted the source-skills listing to plain code-fenced names so `tessl skill lint` passes.

## Scores
- Before: **18%** (failed deterministic validation)
- After: **90%** (Description 100%, Content 85%)

## Gates
- `tessl skill review skills/monday --threshold 90`: exit 0 ✅
- `tessl skill lint .`: exit 0 ✅
