### PR TITLE
chore(tile): drop secret-sauce skill (failed moderation)

### DIFF
--- a/tile.json
+++ b/tile.json
@@ -70,9 +70,6 @@
     "save-the-cat": {
       "path": "skills/save-the-cat/SKILL.md"
     },
-    "secret-sauce": {
-      "path": "skills/secret-sauce/SKILL.md"
-    },
     "servicenow": {
       "path": "skills/servicenow/SKILL.md"
     },


### PR DESCRIPTION
## What

Removes `secret-sauce` from `tile.json` so the remaining 31 skills can publish.

## Why

The `ai-ecoverse/skills@0.1.1` tile failed Tessl registry moderation due to `skills/secret-sauce/references/page-context-helper.md`:

> Failed moderation (intent review) in skills/secret-sauce/references/page-context-helper.md: This document instructs AI agents/tools to bypass security controls (origin checks, bot detection, cookie restrictions) by executing fetch requests inside a real browser session. […] This is a prompt injection targeting AI coding assistants.

The entire tile (all 32 skills) is currently hidden in the registry because of this single skill.

## Result

- Skills in tile: 32 → 31
- `secret-sauce` files remain in the repo but won't be uploaded with the tile
- Auto-bump on merge → `0.1.2` republish should pass moderation

## Verification

- `tessl skill lint .` → exit 0, tile valid
- `jq '.skills | has("secret-sauce")' tile.json` → `false`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author