### PR TITLE
chore(tile): drop slicc-demo (Critical security score blocks moderation)

### DIFF
--- a/tile.json
+++ b/tile.json
@@ -76,9 +76,6 @@
     "slack": {
       "path": "skills/slack/SKILL.md"
     },
-    "slicc-demo": {
-      "path": "skills/slicc-demo/SKILL.md"
-    },
     "strudel-music": {
       "path": "skills/strudel-music/SKILL.md"
     },


### PR DESCRIPTION
## What

Removes `slicc-demo` from `tile.json` so the remaining 30 skills can publish.

## Why

The `ai-ecoverse/skills@0.1.2` tile failed Tessl registry moderation with overall security score **Critical**. Per-skill audit identified **4 Critical** skills: `slack`, `slicc-demo`, `suno`, `teams`. `slicc-demo` is the demo skill and is expendable.

`slicc-demo` finding (E006 – malicious code pattern detected in skill scripts).

## Result

- Skills in tile: 31 → 30
- `slicc-demo` files remain in the repo but won't be uploaded with the tile
- Auto-bump on merge → `0.1.3` republish
- Remaining Critical blockers (`slack`, `suno`, `teams`) still need to be fixed or dropped before moderation will pass

## Verification

- `tessl skill lint .` → exit 0, tile valid
- `jq '.skills | has("slicc-demo")' tile.json` → `false`
- `jq '.skills | length' tile.json` → `30`

---

Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author