### PR TITLE
ci(publish): fetch latest before publishing so matrix jobs don't race

### DIFF
--- a/.github/workflows/tessl-publish-prerelease.yml
+++ b/.github/workflows/tessl-publish-prerelease.yml
@@ -31,6 +31,15 @@ jobs:
         tile: [basic, advanced]
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}
+
+      # Pick up any [skip ci] bump commit from a previous matrix job
+      # so our own push isn't rejected as non-fast-forward.
+      - name: Pull latest from branch
+        run: |
+          git fetch origin "${GITHUB_REF#refs/heads/}"
+          git reset --hard "origin/${GITHUB_REF#refs/heads/}"
 
       - uses: tesslio/patch-version-publish@v1
         with:

--- a/.github/workflows/tessl-publish.yml
+++ b/.github/workflows/tessl-publish.yml
@@ -27,6 +27,15 @@ jobs:
         tile: [basic, advanced]
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}
+
+      # Pick up any [skip ci] bump commit from a previous matrix job
+      # so our own push isn't rejected as non-fast-forward.
+      - name: Pull latest from branch
+        run: |
+          git fetch origin "${GITHUB_REF#refs/heads/}"
+          git reset --hard "origin/${GITHUB_REF#refs/heads/}"
 
       - uses: tesslio/patch-version-publish@v1
         with:


### PR DESCRIPTION
## Problem

After #112 split publishing into a `basic` + `advanced` matrix, both jobs push a `[skip ci]` version-bump commit to the same branch. The second job (advanced) is checked out at the workflow trigger SHA, so when the first job (basic) pushes its bump, the second job's push is rejected as non-fast-forward and the publish action exits 1 with no useful output.

Seen in run [26593130744](https://github.com/ai-ecoverse/skills/actions/runs/26593130744): basic published `ai-ecoverse/skills@0.1.4` cleanly, advanced failed silently. (`ai-ecoverse/advanced-skills@0.1.0` was then published manually.)

## Fix

Between checkout and the publish action, force-reset the working tree to current branch HEAD on origin, so the second matrix job picks up the first job's bump commit:

```yaml
- uses: actions/checkout@v6
  with:
    ref: ${{ github.ref }}
- name: Pull latest from branch
  run: |
    git fetch origin "${GITHUB_REF#refs/heads/}"
    git reset --hard "origin/${GITHUB_REF#refs/heads/}"
```

Applied to both `tessl-publish.yml` and `tessl-publish-prerelease.yml`.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author