### PR TITLE
fix(ci): dereference symlinks before tessl lint (tessl 0.81+)

### DIFF
--- a/.github/workflows/tessl-lint.yml
+++ b/.github/workflows/tessl-lint.yml
@@ -67,7 +67,7 @@ jobs:
         if: steps.detect.outputs.scope == 'full'
         run: |
           # tessl >=0.81 rejects symlinks for security. The repo uses symlinks
-          # in tiles/*/skills/ pointing to ../../skills/*. Dereference them into
+          # in tiles/*/skills/ pointing to ../../../skills/*. Dereference them into
           # a concrete temp copy before linting.
           for t in ${{ steps.detect.outputs.tiles }}; do
             echo "::group::Lint tile $t"

--- a/.github/workflows/tessl-lint.yml
+++ b/.github/workflows/tessl-lint.yml
@@ -66,9 +66,14 @@ jobs:
       - name: Lint full tile(s)
         if: steps.detect.outputs.scope == 'full'
         run: |
+          # tessl >=0.81 rejects symlinks for security. The repo uses symlinks
+          # in tiles/*/skills/ pointing to ../../skills/*. Dereference them into
+          # a concrete temp copy before linting.
           for t in ${{ steps.detect.outputs.tiles }}; do
             echo "::group::Lint tile $t"
-            tessl skill lint "tiles/$t"
+            TMP=$(mktemp -d)
+            cp -rL "tiles/$t" "$TMP/$t"
+            tessl skill lint "$TMP/$t"
             echo "::endgroup::"
           done
 
@@ -103,7 +108,7 @@ jobs:
             mkdir -p "$TMP/skills"
             SKILLS_JSON="{}"
             for skill in ${SUBSET[$tile]}; do
-              ln -sfn "$PWD/skills/$skill" "$TMP/skills/$skill"
+              cp -rL "$PWD/skills/$skill" "$TMP/skills/$skill"
               SKILLS_JSON=$(echo "$SKILLS_JSON" | jq --arg k "$skill" \
                 '. + {($k): {"path": ("skills/" + $k + "/SKILL.md")}}')
             done


### PR DESCRIPTION
tessl 0.81+ rejects symlinks in tile packages for security. The repo uses symlinks in tiles/*/skills/ pointing to ../../../skills/* for DRY. This breaks full-tile lint (triggered when tile.json changes) for all 30 skills. Fix: cp -rL into a temp dir before linting, in both full-tile and subset paths.