### PR TITLE
feat(jira): Add JIRA Skill

### DIFF
--- a/skills/jira/SKILL.md
+++ b/skills/jira/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: jira
+description: |
+  Use this when interacting with Jira — fetching issues, searching by JQL,
+  reading comments, or pulling issue detail to use in other workflows. Uses
+  the Jira tab open in the browser for auth (SSO session, no token needed).
+  Activate on any mention of Jira, issue keys (e.g. PROJ-123), JQL queries, or
+  requests to read/find/list Jira tickets.
+allowed-tools: bash
+---
+
+# Jira
+
+Direct API access to any Jira instance via the browser's SSO session. Uses the
+Jira tab open in the browser for auth — no token setup needed.
+
+## Quick start
+
+```bash
+jira detect                                          # Find Jira tab — confirm URL first
+jira whoami                                          # Verify auth is working
+jira get PROJ-123                                    # Fetch a single issue with full detail
+jira search "project=PROJ ORDER BY updated DESC"     # JQL search (up to 50 results)
+jira search "project=PROJ AND status=Open"           # Filter by status
+jira comments PROJ-123                               # Fetch all comments on an issue
+```
+
+## Authentication
+
+Auth is handled via the browser's SSO session. All API calls are made from within
+the Jira page context using `playwright-cli eval` with `credentials: 'include'`,
+so SSO cookies are sent automatically — no token extraction needed.
+
+**Requirements:**
+- A Jira tab must be open in the browser
+- You must be logged in to that Jira instance
+
+If you get auth errors (401), refresh the Jira tab, log in again, and retry.
+
+## URL detection
+
+The skill auto-detects the Jira base URL by scanning open browser tabs for any
+URL containing `jira`. Always run `jira detect` first in a new session or when
+switching Jira instances. **The user must confirm the detected URL is correct
+before proceeding with other commands.**
+
+If multiple Jira tabs are open, the first match is used. Close unwanted tabs or
+note which workspace you're targeting.
+
+## Commands
+
+### `jira detect`
+
+Scans open browser tabs for a Jira instance and prints the detected base URL.
+
+```
+Found Jira tab: https://jira.example.com
+Please confirm this is the correct Jira instance before proceeding.
+```
+
+### `jira whoami`
+
+Confirms the SSO session is active. Prints the logged-in user's display name and email.
+
+```
+Authenticated as: Jane Smith (jane@example.com)
+```
+
+### `jira get <issue-key>`
+
+Fetches a single issue with full detail: summary, type, status, assignee, reporter,
+components, labels, fix versions, and description.
+
+```bash
+jira get PROJ-123
+jira get PROJ-456
+```
+
+**Example output:**
+```
+PROJ-123: Add dark mode support
+  Type:        Story
+  Status:      In Progress
+  Assignee:    Jane Smith
+  Reporter:    John Doe
+  Created:     2025-08-18
+  Updated:     2026-04-02
+  Components:  Frontend
+  Fix Versions: v1.2
+
+  Description:
+    ...
+```
+
+### `jira search "<jql>"`
+
+Runs a JQL query and returns matching issues. Returns up to 50 results showing
+key, summary, status, assignee, and issue type.
+
+```bash
+jira search "project=PROJ ORDER BY updated DESC"
+jira search "project=PROJ AND status=Open"
+jira search "project=PROJ AND assignee=currentUser()"
+jira search "project=PROJ AND fixVersion='v1.2'"
+jira search "project=PROJ AND component='Frontend'"
+```
+
+**Example output:**
+```
+3 issue(s) found (showing 3):
+
+  PROJ-124: Improve search performance [In Review]
+  PROJ-123: Add dark mode support [In Progress]
+  PROJ-100: Fix broken pagination [Resolved]
+```
+
+**Note:** Results are capped at 50. For larger result sets, add filters to narrow
+the query (e.g. `AND status=Open`, `AND updated >= -30d`).
+
+### `jira comments <issue-key>`
+
+Fetches all comments on an issue with author, date, and body text.
+
+```bash
+jira comments PROJ-123
+```
+
+**Example output:**
+```
+Comments on PROJ-123 (2):
+
+  [2025-08-18] John Doe:
+    Flagging this for design review before implementation.
+
+  [2025-09-23] Jane Smith:
+    Design approved — moving to development.
+```
+
+## Using with other skills
+
+When building pages from Jira content, use `jira get` to pull the full issue and
+`jira comments` for additional context. The `.jsh` script outputs plain text
+suitable for use in prompts or piped to other commands.
+
+### Output format — Jira wiki markup
+
+The `description` and comment `body` fields are returned in **Jira wiki markup**,
+not plain text or Markdown. Common patterns:
+
+| Jira markup | Meaning |
+|---|---|
+| `*text*` | Bold |
+| `_text_` | Italic |
+| `{{text}}` | Inline code |
+| `[label\|url]` | Hyperlink |
+| `{color:#hex}text{color}` | Colored text (usually discard) |
+| `{*}text{*}` | Bold (alternate form) |
+| `# item` | Ordered list item |
+| `- item` | Unordered list item |
+| `\r\n` | Windows line endings |
+
+When consuming this output to generate DA pages or other content, strip the markup
+to plain text or convert to Markdown/HTML as appropriate for the target format.
+
+## Common errors
+
+| Error | Cause | Fix |
+|---|---|---|
+| `No Jira tab found` | No browser tab with `jira` in the URL | Open Jira in your browser |
+| `API error 401` | SSO session expired | Refresh the Jira tab, log in again |
+| `eval failed` | Jira tab navigated away or closed | Check `playwright-cli tab-list` |
+
+## SSO Jira instances
+
+For corporate SSO-protected Jira instances (no personal API tokens available):
+- Uses Jira Server/Data Center REST API (`/rest/api/2/`) not Jira Cloud
+- Standard field names (`summary`, `description`, `status`, `assignee`) work
+  reliably; custom fields (`customfield_XXXXX`) vary by instance
+- Session cookies are scoped to the corp domain; direct fetch from localhost is
+  rejected — page-context eval is required (already the default approach)
+
+---
+
+> **TODO:** Revisit and tighten this documentation after real use. Add examples
+> of JQL queries that proved useful, output patterns that needed cleanup, and any
+> edge cases encountered.

--- a/skills/jira/jira.jsh
+++ b/skills/jira/jira.jsh
@@ -1,0 +1,199 @@
+// jira.jsh — Jira CLI via browser SSO session
+// Usage: jira <command> [args]
+//   jira detect
+//   jira whoami
+//   jira get <issue-key>
+//   jira search "<jql>"
+//   jira comments <issue-key>
+
+// --- Tab management ---
+
+let _tabId = null;
+let _jiraBase = null;
+
+async function findJiraTab() {
+  if (_tabId) return _tabId;
+  const list = await exec('playwright-cli tab-list');
+  if (list.exitCode !== 0) {
+    console.error('Error: Failed to list browser tabs.');
+    if (list.stderr) console.error(list.stderr.trim());
+    process.exit(1);
+  }
+  const lines = list.stdout.split('\n');
+  for (const line of lines) {
+    if (line.toLowerCase().includes('jira')) {
+      const m = line.match(/^\[([^\]]+)\]/);
+      const urlMatch = line.match(/https?:\/\/\S+/);
+      if (m && urlMatch) {
+        _tabId = m[1];
+        _jiraBase = urlMatch[0].match(/^https?:\/\/[^\/]+/)[0];
+        return _tabId;
+      }
+    }
+  }
+  console.error('Error: No Jira tab found. Open Jira in your browser and try again.');
+  process.exit(1);
+}
+
+// --- Eval helper ---
+// Writes JS to a temp file, evals in the Jira tab, returns parsed JSON.
+
+async function evalInJiraTab(expr, { fatal = true } = {}) {
+  const tabId = await findJiraTab();
+  const tmpFile = '/shared/.jira_eval_' + Date.now() + '.js';
+  await fs.writeFile(tmpFile, expr.trim());
+  const result = await exec(`playwright-cli eval-file ${tmpFile} --tab=${tabId}`);
+  await fs.rm(tmpFile).catch(async () => {
+    await fs.writeFile(tmpFile, '').catch(() => {});
+  });
+
+  if (result.exitCode !== 0) {
+    if (!fatal) return null;
+    console.error('Eval failed:', result.stderr);
+    process.exit(1);
+  }
+
+  let data;
+  try {
+    const stdout = result.stdout.trim();
+    data = JSON.parse(stdout);
+    if (typeof data === 'string') data = JSON.parse(data);
+  } catch (e) {
+    if (!fatal) return null;
+    console.error('Failed to parse API response:', result.stdout.substring(0, 200));
+    process.exit(1);
+  }
+
+  return data;
+}
+
+// --- API helper ---
+
+async function jiraFetch(path) {
+  await findJiraTab();
+  const url = _jiraBase + path;
+  const expr = `
+(async () => {
+  const r = await fetch(${JSON.stringify(url)}, { credentials: 'include' });
+  if (!r.ok) return JSON.stringify({ __error: r.status });
+  return r.text();
+})()
+  `.trim();
+  const data = await evalInJiraTab(expr);
+  if (data && data.__error) {
+    console.error(`API error ${data.__error}. Is your Jira session active?`);
+    process.exit(1);
+  }
+  return data;
+}
+
+// --- Formatters ---
+
+function fmtDate(d) {
+  return d ? d.slice(0, 10) : '';
+}
+
+function stripWiki(text) {
+  if (!text) return '';
+  return text
+    .replace(/\r\n/g, '\n')
+    .replace(/\{color:[^}]+\}([\s\S]*?)\{color\}/g, '$1')
+    .replace(/\{\*\}([\s\S]*?)\{\*\}/g, '$1')
+    .replace(/\*([^*\n]+)\*/g, '$1')
+    .replace(/_([^_\n]+)_/g, '$1')
+    .replace(/\{\{([^}]+)\}\}/g, '$1')
+    .replace(/\[([^\|\]]+)\|[^\]]+\]/g, '$1')
+    .replace(/^\s*[#\-]\s+/gm, '')
+    .trim();
+}
+
+// --- Commands ---
+
+async function detect() {
+  await findJiraTab();
+  console.log(`Found Jira tab: ${_jiraBase}`);
+  console.log('Please confirm this is the correct Jira instance before proceeding.');
+}
+
+async function whoami() {
+  const data = await jiraFetch('/rest/api/2/myself');
+  console.log(`Authenticated as: ${data.displayName} (${data.emailAddress})`);
+}
+
+async function get(key) {
+  if (!key) { console.error('Usage: jira get <issue-key>'); process.exit(1); }
+  const data = await jiraFetch(`/rest/api/2/issue/${key}`);
+  const f = data.fields;
+  const out = [
+    `${data.key}: ${f.summary}`,
+    `  Type:        ${f.issuetype?.name || ''}`,
+    `  Status:      ${f.status?.name || ''}`,
+    `  Assignee:    ${f.assignee?.displayName || 'Unassigned'}`,
+    `  Reporter:    ${f.reporter?.displayName || ''}`,
+    `  Created:     ${fmtDate(f.created)}`,
+    `  Updated:     ${fmtDate(f.updated)}`,
+  ];
+  if (f.components?.length) out.push(`  Components:  ${f.components.map(c => c.name).join(', ')}`);
+  if (f.fixVersions?.length) out.push(`  Fix Versions: ${f.fixVersions.map(v => v.name).join(', ')}`);
+  if (f.labels?.length) out.push(`  Labels:      ${f.labels.join(', ')}`);
+  out.push('', '  Description:');
+  if (f.description) {
+    stripWiki(f.description).split('\n').forEach(l => out.push(`    ${l}`));
+  } else {
+    out.push('    (none)');
+  }
+  console.log(out.join('\n'));
+}
+
+async function search(jql) {
+  if (!jql) { console.error('Usage: jira search "<jql>"'); process.exit(1); }
+  const encoded = encodeURIComponent(jql);
+  const data = await jiraFetch(`/rest/api/2/search?jql=${encoded}&maxResults=50&fields=summary,status,assignee,issuetype`);
+  const issues = data.issues || [];
+  console.log(`${data.total} issue(s) found (showing ${issues.length}):\n`);
+  issues.forEach(i => {
+    const status = i.fields.status?.name || '';
+    console.log(`  ${i.key}: ${i.fields.summary} [${status}]`);
+  });
+}
+
+async function comments(key) {
+  if (!key) { console.error('Usage: jira comments <issue-key>'); process.exit(1); }
+  const data = await jiraFetch(`/rest/api/2/issue/${key}/comment`);
+  const items = data.comments || [];
+  console.log(`Comments on ${key} (${items.length}):\n`);
+  items.forEach(c => {
+    console.log(`  [${fmtDate(c.created)}] ${c.author?.displayName || 'Unknown'}:`);
+    stripWiki(c.body).split('\n').slice(0, 20).forEach(l => console.log(`    ${l}`));
+    console.log('');
+  });
+}
+
+// --- Main ---
+
+const rawArgs = process.argv.slice(2);
+const [cmd, ...cmdArgs] = rawArgs;
+
+if (!cmd || cmd === 'help' || cmd === '--help') {
+  console.log('Jira CLI — interact with Jira via the browser SSO session.\n');
+  console.log('Usage: jira <command> [args]\n');
+  console.log('Commands:');
+  console.log('  detect                        Find the Jira tab and confirm the instance URL');
+  console.log('  whoami                        Verify auth — prints logged-in user');
+  console.log('  get <issue-key>               Fetch a single issue with full detail');
+  console.log('  search "<jql>"                Run a JQL query (up to 50 results)');
+  console.log('  comments <issue-key>          Fetch all comments on an issue');
+  process.exit(0);
+}
+
+switch (cmd) {
+  case 'detect':   await detect(); break;
+  case 'whoami':   await whoami(); break;
+  case 'get':      await get(cmdArgs[0]); break;
+  case 'search':   await search(cmdArgs.join(' ')); break;
+  case 'comments': await comments(cmdArgs[0]); break;
+  default:
+    console.error(`Unknown command: ${cmd}`);
+    console.error('Run "jira help" for usage.');
+    process.exit(1);
+}


### PR DESCRIPTION
 ## Adds a `jira` skill for reading Jira issues via browser SSO

  **What this does:** Adds a new skill that lets you interact with any Jira instance using the SSO session from an already-open browser tab — no API token setup required.

  **Files added:**
  - `skills/jira/SKILL.md` — skill definition and documentation
  - `skills/jira/jira.jsh` — CLI script that drives the Jira REST API via `playwright-cli eval`

  **Commands supported:**
  - `jira detect` — finds the open Jira tab and confirms the base URL
  - `jira whoami` — verifies the SSO session is active
  - `jira get <key>` — fetches a single issue with full detail (type, status, assignee, description, etc.)
  - `jira search "<jql>"` — runs a JQL query, returns up to 50 results
  - `jira comments <key>` — fetches all comments on an issue

  **Auth approach:** All API calls run in the Jira page context via `playwright-cli eval-file` with `credentials: 'include'`, so SSO cookies are sent automatically. Targets Jira Server/Data Center REST API (`/rest/api/2/`).

  **Notable details:**
  - Descriptions and comments are returned in Jira wiki markup; the script includes a `stripWiki()` helper to clean it up for use in prompts
  - Results are capped at 50 for `search` — JQL filters are the recommended way to narrow large result sets
  - There's a TODO in the docs to tighten the skill after real-world use
