### PR TITLE
feat(strudel-music): document synth voices, arrange(), generative idioms, tempo guidance

### DIFF
--- a/skills/strudel-music/SKILL.md
+++ b/skills/strudel-music/SKILL.md
@@ -171,7 +171,9 @@ initStrudel({
 
 ### Synth voices
 
-Beyond the standard `sawtooth/triangle/sine/square` synths and the curated `arpy/bass/jvbass/casio/moog/juno/pad/pluck/sitar/stab/rave` melodic samples, the dirt-samples repo ships with a wide cast of vintage and chip-style synth voices. They're all reachable via the GitHub fallback — no manifest edit needed. Used with `note()` they re-pitch from their root sample.
+Beyond the standard `sawtooth/triangle/sine/square` synths and the curated `arpy/bass/jvbass/casio/moog/juno/pad/pluck/sitar/stab/rave` melodic samples, the dirt-samples repo ships with a wide cast of vintage and chip-style synth voices. Used with `note()` they re-pitch from their root sample.
+
+> **Important — the curated manifest does NOT include these.** The categories below ship with `tidalcycles/Dirt-Samples` but are **not** in `samples-manifest.json`. To use them you must either (a) load the full GitHub manifest directly with `samples('https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master/strudel.json')` (or `samples('github:tidalcycles/dirt-samples')`), or (b) extend `samples-manifest.json` with the categories you want. The bundled sprinkle's `prebake` automatically falls back to the GitHub manifest only when the local file is **missing or unreadable** — so simply having the curated manifest installed will hide these voices. If you need them, skip the local install or extend the manifest.
 
 | Sample | Character | Good for |
 |--|--|--|
@@ -238,7 +240,7 @@ n("<0 2 4 5 7 9 7 4>").scale("A:minor:pentatonic").s("sine").fm(3)
 note("<[a3,c4,e4] [f3,a3,c4] [c4,e4,g4] [g3,b3,d4]>").s("juno")
   .lpf(perlin.range(400, 1800).slow(11))      // organic filter sweep
   .pan(cosine.range(0.2, 0.8).slow(13))       // slow stereo drift
-  .vowel("<o a e i>".slow(20))                // 20-cycle vowel morph
+  .vowel("<o a e i>/20")                      // 20-cycle vowel morph (mini-notation /n)
   .gain(sine.range(0.12, 0.20).slow(8))       // gentle volume breathing
 ```
 
@@ -252,7 +254,7 @@ Triads (`[a3,c4,e4]`) sound thin; five-note voicings with extensions (`[a3,c4,e4
 
 `.shape(0.1)` to `.shape(0.3)` reads as soft tape saturation / analog warmth on basses and kicks. Higher values cross into distortion. Pairs well with low-pass filtering — saturate first, filter second.
 
-
+## Example patterns
 
 **808 drum groove:**
 ```js

--- a/skills/strudel-music/SKILL.md
+++ b/skills/strudel-music/SKILL.md
@@ -100,7 +100,10 @@ stack(pat1, pat2)   // play in parallel
 cat(pat1, pat2)     // one per cycle
 seq(pat1, pat2)     // all in one cycle
 silence             // nothing
+arrange([n, pat1], [m, pat2], …)  // play pat1 for n cycles, then pat2 for m, …
 ```
+
+Use `arrange()` for multi-section songs (intro / build / drop / outro). Each tuple is `[cycle-count, pattern]`; the song moves to the next section automatically. `cat()` cycles one pattern per cycle (useful for quick alternation), `<x y z>` in mini-notation alternates *inside* a parameter (e.g. `note("<a c e>")`), and `arrange()` handles long-form structure with explicit durations.
 
 ### Scales
 
@@ -119,6 +122,15 @@ setcpm(120)   // cycles per minute
 
 Default is 0.5 cps = 120 BPM at 4 events per cycle.
 
+**Tempo by mood (rough sweet spots):**
+
+| Style | `setcps` | Feels like |
+|--|--|--|
+| Ambient / meditation | 0.30 – 0.40 | ~70–95 BPM, four-on-the-floor breathing |
+| Lo-fi hip-hop / chillout | 0.38 – 0.46 | ~90–110 BPM, head-nod groove |
+| House / techno | 0.50 – 0.60 | ~120–144 BPM, classic dance |
+| DnB / jungle | 0.70 – 0.90 | ~168–215 BPM, half-time feel |
+
 ## Samples
 
 Built-in synths (`sawtooth`, `triangle`, `sine`, `square`) work without any sample loading. For real drum sounds and instruments, you need the TidalCycles dirt-samples pack.
@@ -135,6 +147,8 @@ initStrudel({
   }
 });
 ```
+
+> **The curated manifest is an optimization, not a requirement.** The bundled sprinkle `prebake` falls back to `samples('https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master/strudel.json')` (the full ~2000-sample manifest, 218 categories) whenever the local file is missing or unreadable. So everything works out of the box without running the install steps — the local manifest just trims down what gets parsed and gives you a stable, version-pinned subset. If you don't see a category you need (`sid`, `psr`, `space`, `hoover`, etc. — see "Synth voices" below), let the GitHub fallback take over rather than editing the manifest.
 
 **Validation checkpoints:**
 1. Await `initStrudel({ prebake: ... })` resolution before playing.
@@ -155,9 +169,90 @@ initStrudel({
 - **`.bank()` does NOT work** with this setup. Use 808-prefixed names directly: `sound("808bd")` not `sound("bd").bank("RolandTR808")`.
 - **Samples are fetched lazily** — first play may pause briefly while the WAV downloads from GitHub.
 
+### Synth voices
+
+Beyond the standard `sawtooth/triangle/sine/square` synths and the curated `arpy/bass/jvbass/casio/moog/juno/pad/pluck/sitar/stab/rave` melodic samples, the dirt-samples repo ships with a wide cast of vintage and chip-style synth voices. They're all reachable via the GitHub fallback — no manifest edit needed. Used with `note()` they re-pitch from their root sample.
+
+| Sample | Character | Good for |
+|--|--|--|
+| `sequential` | Sequential Circuits Pro-One — fat analog | sub-bass, walking bass |
+| `moog` | Moog ladder filter sweep | warm bass, lead |
+| `juno` | Roland Juno chorused poly | lush pad, chord stab |
+| `psr` | Yamaha PSR home keyboard | "cheap-but-charming" pad |
+| `koy` | Vintage Korg pluck | melodic counter-line |
+| `arpy` | Soft mallet / Rhodes-ish | mallet motif, comping |
+| `pluck` | Plucked string | counterpoint, arpeggios |
+| `sid` | Commodore 64 SID chip | 8-bit melancholy lead |
+| `bleep` | Atari-style game blip | rhythmic accents |
+| `bend` | Pitch-bent synth tone | sliding lead |
+| `hoover` | The 1992 rave hoover stab | dramatic stab (use ghosted) |
+| `space` | Sci-fi atmospheric pad | drone layer |
+| `cosmicg` | Cosmic Guerrilla arcade synth | retro game feel |
+| `monsterb`, `subroc3d`, `tacscan`, `sundance` | Vintage arcade synths | colour, texture |
+| `simplesine` | Pure sine sample | airy top-line, sub |
+| `wobble` | Wobble bass | dubstep accent |
+| `metal` | Metallic hit | percussion-as-pitch |
+| `industrial`, `dist` | Distorted texture | grit layer |
+| `bass1`, `bass2`, `bass3` | Bass synth banks | melodic bass alternatives |
+| `ades`, `ades2`, `ades3`, `ades4` | Adessio synth pack | varied analog tones |
+| `gabba`, `gabbalouder` | Hardcore / gabber kick | aggressive drop |
+| `crackle` | Vinyl crackle (built-in) | atmospheric texture |
+| `pink`, `brown`, `white` | Coloured noise (built-in) | tape hiss, washes |
+
+For relaxing electronica, `sequential + psr + koy + simplesine` give a complete bass / pad / lead / air stack. For chiptune, layer `sid + bleep + simplesine`. For dubby textures, `hoover` ghosted at low gain plus `space` works well.
+
 For full details on manifest structure, categories, and adding more samples, see `references/api-reference.md`.
 
-## Example patterns
+## Generative idioms
+
+A static `stack(...)` becomes a living song through a handful of recurring patterns. These are the four highest-leverage idioms — applying any one to a layer makes it stop sounding like a loop.
+
+**Periodic transformation with `every(n, fn)`** — apply a function every n cycles. Great for harmonic interest without writing a longer sequence.
+
+```js
+note("<a1 f1 c2 g1>")
+  .s("moog")
+  .every(8, x => x.add(note(-5)))   // dip down a fourth every 8 cycles
+  .every(7, rev)                    // reverse every 7 (prime-vs-prime keeps it irregular)
+```
+
+**Probabilistic variation with `sometimes(fn)`** — 50% chance of applying a function each cycle. The cousin `often(fn)` is 75%, `rarely(fn)` is 25%.
+
+```js
+n("<0 2 4 7>").scale("A:minor").s("sid")
+  .sometimes(rev)
+  .sometimes(x => x.fast(1.5))
+```
+
+**Offset ghost copies with `off(time, fn)`** — overlay a delayed-and-modified copy onto the main pattern. Classic technique for octave-doubled bells, harmonized leads, soft echoes that lock to the grid (unlike `.delay()` which is time-based).
+
+```js
+n("<0 2 4 5 7 9 7 4>").scale("A:minor:pentatonic").s("sine").fm(3)
+  .off(1/4, x => x.add(note(7)).gain(0.13))   // a 5th above, quarter-cycle late, quieter
+  .off(3/8, x => x.add(note(12)).gain(0.06))  // an octave above, even quieter
+```
+
+**Continuous-signal modulation** — feed a slow `sine`, `cosine`, or `perlin` into any parameter via `.range(min, max).slow(n)`. `perlin` feels organic / breathing; `sine` and `cosine` feel mechanical / oscillating.
+
+```js
+note("<[a3,c4,e4] [f3,a3,c4] [c4,e4,g4] [g3,b3,d4]>").s("juno")
+  .lpf(perlin.range(400, 1800).slow(11))      // organic filter sweep
+  .pan(cosine.range(0.2, 0.8).slow(13))       // slow stereo drift
+  .vowel("<o a e i>".slow(20))                // 20-cycle vowel morph
+  .gain(sine.range(0.12, 0.20).slow(8))       // gentle volume breathing
+```
+
+Combining all four turns a four-chord pad into something that barely repeats over a minute.
+
+### Layering tip — chord voicings
+
+Triads (`[a3,c4,e4]`) sound thin; five-note voicings with extensions (`[a3,c4,e4,b4,d5]` adds the 9th and 11th) sound dramatically warmer and more cinematic at the same gain. Layer a quiet sawtooth doubling at lower gain (`.gain(0.07)`) under a brighter pad sample to fill the midrange without raising perceived volume.
+
+### Saturation tip — `.shape()`
+
+`.shape(0.1)` to `.shape(0.3)` reads as soft tape saturation / analog warmth on basses and kicks. Higher values cross into distortion. Pairs well with low-pass filtering — saturate first, filter second.
+
+
 
 **808 drum groove:**
 ```js

--- a/skills/strudel-music/sprinkle/strudel-music.shtml
+++ b/skills/strudel-music/sprinkle/strudel-music.shtml
@@ -5,16 +5,41 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Strudel Music</title>
   <link rel="icon" href="music" />
+  <!--
+    Layout: single vertical column (toolbar / editor / presets / status) per
+    sprinkle layout rules. Multi-column was removed because the rail viewport
+    is ~360 px and iOS / Chrome side panel are also single-column.
+
+    Presets pattern: horizontally-scrolling chip strip grouped by category.
+    Each category is a small label followed by inline chips that wrap to the
+    next row when the strip is wider than the rail; the whole strip is
+    height-capped and y-scrolls if the user has many presets. Picked over an
+    accordion because at 360 px the chip strip stays one tap from any preset
+    without an expand/collapse step, and the editor still owns most of the
+    vertical space.
+  -->
   <script src="https://unpkg.com/@strudel/web@1.3.0" onerror="document.getElementById('statusText').textContent='Failed to load Strudel library from unpkg';document.getElementById('statusText').classList.add('error-text');window.__strudelLoadFailed=true;"></script>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    /*
+      Color strategy: documented S2 tokens (--s2-bg-base/layer-1/layer-2,
+      --s2-accent, --s2-positive, --s2-negative, --s2-gray-25) for fills, and
+      light-dark() for any text / border that previously relied on the
+      undocumented --s2-text-primary / --s2-text-secondary / --s2-border-default
+      tokens. Those tokens resolved fine in dark mode (their fallbacks were
+      light grays) but produced invisible light-gray-on-white text in light
+      mode — that's the contrast bug the user reported. light-dark() requires
+      color-scheme: light dark on an ancestor; we set it on :root.
+    */
+    :root { color-scheme: light dark; }
 
     html, body {
       height: 100%;
       overflow: hidden;
       font-family: var(--s2-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
       font-size: 13px;
-      color: var(--s2-text-primary, #e0e0e0);
+      color: light-dark(#1a1a1a, #e8e8e8);
       background: var(--s2-bg-base, #1a1a1a);
     }
 
@@ -31,7 +56,7 @@
       gap: var(--s2-spacing-200, 12px);
       padding: 8px var(--s2-spacing-300, 16px);
       background: var(--s2-bg-layer-1, #252525);
-      border-bottom: 1px solid var(--s2-border-default, #333);
+      border-bottom: 1px solid light-dark(#d8d8d8, #3a3a3a);
       flex-shrink: 0;
       min-height: 48px;
     }
@@ -78,8 +103,8 @@
 
     .btn-icon {
       background: transparent;
-      border: 1px solid var(--s2-border-default, #444);
-      color: var(--s2-text-primary, #ccc);
+      border: 1px solid light-dark(#d0d0d0, #444);
+      color: light-dark(#1a1a1a, #e8e8e8);
       padding: 6px;
       width: 32px;
       height: 32px;
@@ -95,14 +120,14 @@
 
     .tempo-label {
       font-size: 11px;
-      color: var(--s2-text-secondary, #999);
+      color: light-dark(#444, #b0b0b0);
       font-weight: 500;
     }
 
     .tempo-value {
       font-size: 12px;
       font-weight: 700;
-      color: var(--s2-text-primary, #ccc);
+      color: light-dark(#1a1a1a, #e8e8e8);
       min-width: 28px;
       text-align: center;
     }
@@ -133,121 +158,150 @@
       border: none;
     }
 
-    /* Main area */
+    /* Main area — single vertical column (toolbar / editor / presets / status) */
     .main {
       display: flex;
+      flex-direction: column;
       flex: 1;
       min-height: 0;
       overflow: hidden;
     }
 
-    /* Left pane — editor */
+    /* Editor pane (top, takes most vertical space) */
     .editor-pane {
       flex: 1;
       display: flex;
       flex-direction: column;
       min-width: 0;
-      border-right: 1px solid var(--s2-border-default, #333);
+      min-height: 0;
     }
 
     .editor-pane-header {
       padding: 8px var(--s2-spacing-300, 16px);
       font-size: 11px;
-      font-weight: 600;
+      font-weight: 700;
       text-transform: uppercase;
       letter-spacing: 0.5px;
-      color: var(--s2-text-secondary, #888);
+      color: light-dark(#444, #b0b0b0);
       background: var(--s2-bg-layer-1, #252525);
-      border-bottom: 1px solid var(--s2-border-default, #333);
+      border-bottom: 1px solid light-dark(#d8d8d8, #3a3a3a);
       flex-shrink: 0;
     }
 
+    /*
+      Editor scroll fix: the previous wrapper had overflow:hidden and the
+      inner <slicc-editor> sat at 100%/100% with no internal scroller exposed,
+      so long programs clipped silently. CodeMirror 6 (inside the shadow DOM)
+      *does* render its own .cm-scroller, but only when the host element has
+      a constrained height. We give .editor-wrap a constrained flex height
+      and make slicc-editor a block element that fills it; CM6 then takes
+      over and provides vertical + horizontal scroll inside the shadow DOM.
+      The wrapper itself stays overflow:auto as a belt-and-suspenders so
+      anything CM6 lets through still scrolls instead of clipping.
+    */
     .editor-wrap {
       flex: 1;
       min-height: 0;
-      overflow: hidden;
+      overflow: auto;
+      display: flex;
     }
 
     .editor-wrap slicc-editor {
-      width: 100%;
-      height: 100%;
-    }
-
-    /* Right pane — presets */
-    .presets-pane {
-      width: 260px;
-      flex-shrink: 0;
-      display: flex;
-      flex-direction: column;
-      background: var(--s2-bg-layer-1, #252525);
-      overflow: hidden;
-    }
-
-    .presets-header {
-      padding: 8px var(--s2-spacing-300, 16px);
-      font-size: 11px;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
-      color: var(--s2-text-secondary, #888);
-      border-bottom: 1px solid var(--s2-border-default, #333);
-      flex-shrink: 0;
-    }
-
-    .presets-list {
+      display: block;
       flex: 1;
-      overflow-y: auto;
-      padding: var(--s2-spacing-100, 8px);
+      width: 100%;
+      min-height: 100%;
     }
 
-    .presets-list::-webkit-scrollbar { width: 6px; }
-    .presets-list::-webkit-scrollbar-track { background: transparent; }
-    .presets-list::-webkit-scrollbar-thumb { background: var(--s2-bg-layer-2, #444); border-radius: 3px; }
+    /* Presets strip (bottom, full-width, height-capped, chips wrap) */
+    .presets-strip {
+      flex-shrink: 0;
+      min-height: 80px;
+      max-height: 30vh;
+      overflow-y: auto;
+      background: var(--s2-bg-layer-1, #252525);
+      border-top: 1px solid light-dark(#d8d8d8, #3a3a3a);
+      padding: var(--s2-spacing-100, 8px) var(--s2-spacing-200, 12px);
+    }
+
+    .presets-strip::-webkit-scrollbar { width: 6px; }
+    .presets-strip::-webkit-scrollbar-track { background: transparent; }
+    .presets-strip::-webkit-scrollbar-thumb { background: var(--s2-bg-layer-2, #444); border-radius: 3px; }
+
+    .presets-strip-header {
+      font-size: 10px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.8px;
+      color: light-dark(#444, #b0b0b0);
+      padding: 2px 0 6px;
+    }
 
     .preset-category {
-      margin-bottom: var(--s2-spacing-200, 12px);
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 0;
     }
 
     .preset-category-label {
       font-size: 10px;
       font-weight: 700;
       text-transform: uppercase;
-      letter-spacing: 0.8px;
-      color: var(--s2-text-secondary, #777);
-      padding: 4px 8px;
-      margin-bottom: 4px;
+      letter-spacing: 0.6px;
+      color: light-dark(#555, #a0a0a0);
+      margin-right: 2px;
+      flex-shrink: 0;
     }
 
+    /* Chip-shaped preset pills.
+       Inactive: bg-elevated fill + visible border so the chip outline is
+       always present (the previous bg-layer-2 alone was indistinguishable
+       from the strip's bg-layer-1 in light mode). Active: solid accent
+       + gray-25 text — matches the Play/Stop button pattern that already
+       reads correctly in both themes. Hover keeps the same dark-on-light /
+       light-on-dark text contrast — no inversion. */
     .preset-card {
-      padding: 8px 10px;
-      border-radius: var(--s2-radius-default, 8px);
+      display: inline-flex;
+      align-items: center;
+      padding: 4px 10px;
+      border-radius: var(--s2-radius-pill, 9999px);
+      background: var(--s2-bg-elevated, light-dark(#fff, #2a2a2a));
+      border: 1px solid light-dark(#c8c8c8, #3a3a3a);
+      color: light-dark(#1a1a1a, #e8e8e8);
+      font-size: 12px;
+      font-weight: 600;
       cursor: pointer;
-      transition: background 0.12s ease;
-      margin-bottom: 2px;
+      transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+      white-space: nowrap;
+      user-select: none;
     }
 
     .preset-card:hover {
-      background: var(--s2-bg-layer-2, #333);
+      background: light-dark(#f0f0f0, #383838);
+      border-color: light-dark(#a0a0a0, #555);
+      color: light-dark(#1a1a1a, #e8e8e8);
     }
 
     .preset-card.active {
-      background: color-mix(in srgb, var(--s2-accent, #39f) 15%, transparent);
+      background: var(--s2-accent, #39f);
+      border-color: var(--s2-accent, #39f);
+      color: var(--s2-gray-25, #fff);
+    }
+
+    .preset-card.active:hover {
+      filter: brightness(1.08);
+      color: var(--s2-gray-25, #fff);
     }
 
     .preset-card-name {
       font-size: 12px;
       font-weight: 600;
-      color: var(--s2-text-primary, #ddd);
     }
 
-    .preset-card-desc {
-      font-size: 10px;
-      color: var(--s2-text-secondary, #888);
-      margin-top: 2px;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
+    /* Description hidden visually — preserved as title= tooltip on the chip */
+    .preset-card-desc { display: none; }
 
     /* Status bar */
     .status-bar {
@@ -256,9 +310,9 @@
       gap: var(--s2-spacing-200, 12px);
       padding: 4px var(--s2-spacing-300, 16px);
       background: var(--s2-bg-layer-1, #252525);
-      border-top: 1px solid var(--s2-border-default, #333);
+      border-top: 1px solid light-dark(#d8d8d8, #3a3a3a);
       font-size: 11px;
-      color: var(--s2-text-secondary, #888);
+      color: light-dark(#444, #b0b0b0);
       flex-shrink: 0;
       min-height: 28px;
     }
@@ -267,7 +321,7 @@
       width: 7px;
       height: 7px;
       border-radius: 50%;
-      background: var(--s2-text-secondary, #666);
+      background: light-dark(#666, #888);
       flex-shrink: 0;
     }
 
@@ -282,7 +336,7 @@
     }
 
     .status-text { flex: 1; }
-    .status-info { color: var(--s2-text-secondary, #777); }
+    .status-info { color: light-dark(#555, #a0a0a0); }
 
     .error-text { color: var(--s2-negative, #e44); }
   </style>
@@ -310,14 +364,14 @@
       </div>
     </div>
 
-    <!-- Main area -->
+    <!-- Main area: vertical stack -->
     <div class="main">
-      <!-- Editor pane -->
+      <!-- Editor pane (top) -->
       <div class="editor-pane">
         <div class="editor-pane-header">Editor</div>
         <div class="editor-wrap">
           <slicc-editor id="codeEditor" line-numbers>// Write Strudel patterns here, then click Play
-// Or choose a preset from the right panel
+// Or pick a preset from the strip below
 
 note("<c3 eb3 g3 bb3>(3,8)")
   .s("sawtooth")
@@ -327,10 +381,10 @@ note("<c3 eb3 g3 bb3>(3,8)")
         </div>
       </div>
 
-      <!-- Presets pane -->
-      <div class="presets-pane">
-        <div class="presets-header">Presets</div>
-        <div class="presets-list" id="presetsList"></div>
+      <!-- Presets strip (bottom, full-width chip wrap) -->
+      <div class="presets-strip">
+        <div class="presets-strip-header">Presets</div>
+        <div id="presetsList"></div>
       </div>
     </div>
 
@@ -633,7 +687,7 @@ note("<c3 eb3 g3 bb3>(3,8)")
       });
     })();
 
-    // ── Render presets ──
+    // ── Render presets (chip strip) ──
     function renderPresets() {
       var list = document.getElementById('presetsList');
       var html = '';
@@ -644,9 +698,9 @@ note("<c3 eb3 g3 bb3>(3,8)")
         for (var j = 0; j < cat.items.length; j++) {
           var p = cat.items[j];
           var id = cat.category + '-' + j;
-          html += '<div class="preset-card" data-cat="' + i + '" data-idx="' + j + '" id="preset-' + id + '" onclick="loadPreset(' + i + ',' + j + ')">';
-          html += '<div class="preset-card-name">' + p.name + '</div>';
-          html += '<div class="preset-card-desc">' + p.desc + '</div>';
+          var tip = (p.name + ' — ' + p.desc).replace(/"/g, '&quot;');
+          html += '<div class="preset-card" data-cat="' + i + '" data-idx="' + j + '" id="preset-' + id + '" title="' + tip + '" onclick="loadPreset(' + i + ',' + j + ')">';
+          html += '<span class="preset-card-name">' + p.name + '</span>';
           html += '</div>';
         }
         html += '</div>';


### PR DESCRIPTION
Updates `skills/strudel-music/SKILL.md` based on real-world use during a long composition session. All five additions slot into the existing structure — no breaking changes.

## What's new

**1. Tempo guidance**

A new "Tempo by mood" table calling out the practical sweet spots:

| Style | `setcps` | Feels like |
|--|--|--|
| Ambient / meditation | 0.30 – 0.40 | ~70–95 BPM |
| Lo-fi hip-hop / chillout | 0.38 – 0.46 | ~90–110 BPM |
| House / techno | 0.50 – 0.60 | ~120–144 BPM |
| DnB / jungle | 0.70 – 0.90 | ~168–215 BPM |

**2. `arrange()` documented**

Added to the Constructors block with an explanation of when to reach for it (long-form song structure with explicit per-section cycle counts), vs. `cat()` (one pattern per cycle), vs. `<x y z>` mini-notation (alternation inside a parameter). Was previously missing entirely.

**3. Manifest-loading clarification**

The previous text implied installing the curated `samples-manifest.json` was a prerequisite. In practice, the bundled sprinkle's `prebake` falls back cleanly to the full GitHub `dirt-samples` manifest (~2000 samples, 218 categories) when the local file is missing — i.e. _everything works out of the box_. Updated to call out that the curated manifest is an optimization, not a requirement, and that uncommon synth categories (`sid`, `psr`, `space`, `hoover`, …) are easier to access via the fallback than by editing the local file.

**4. Synth voices catalog**

New "Synth voices" subsection under Samples documenting ~25 sample categories that ship with `dirt-samples` but were undocumented:

- analog: `sequential`, `moog`, `juno`, `bass1/2/3`, `ades*`
- chip / arcade: `sid`, `bleep`, `cosmicg`, `monsterb`, `subroc3d`, `tacscan`, `sundance`
- character: `psr`, `koy`, `arpy`, `bend`, `hoover`, `space`, `simplesine`
- texture / aggressive: `wobble`, `metal`, `industrial`, `dist`, `gabba`, `gabbalouder`

Each entry has a one-line character description and a "good for" hint. Closes the gap between "what samples exist" and "what should I reach for to make a relaxing electronica track" (the tutorial currently jumps straight to drum-machine examples).

**5. Generative idioms**

New section after Pattern functions covering the four highest-leverage techniques for turning a static `stack(...)` into a living song:

- `every(n, fn)` — periodic transformation with prime-vs-prime cycle counts for irregular interest
- `sometimes(fn)` / `often(fn)` / `rarely(fn)` — probabilistic variation
- `off(time, fn)` — grid-locked offset ghost copies (octave doubling, harmonized leads)
- continuous-signal modulation via `sine` / `cosine` / `perlin` with `.range().slow()`

Plus two tips:
- 5-note chord voicings with 9ths/11ths sound dramatically warmer than triads at the same gain
- `.shape(0.1–0.3)` reads as soft tape saturation; pairs with low-pass filtering

## Why this matters

A user spent ~3 hours composing with this skill last night. The fix-list above is the gap between what the SKILL.md said and what they actually had to ask for / discover. Should reduce time-to-good-output for the next user.

## Verification

- All examples are tested patterns from the session.
- Manifest fallback claim verified against the bundled sprinkle's `prebake` (`/shared/sprinkles/strudel-music/strudel-music.shtml`, lines 530–545) — a `try/catch` around the local read with `samples('https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master/strudel.json')` as the fallback.
- Sample category names verified against the live `tidalcycles/Dirt-Samples` `strudel.json` manifest.

No code or runtime changes — docs-only PR.