### PR TITLE
ci(publish): dereference symlinks for tessl >=0.81 compatibility

### DIFF
--- a/.github/workflows/tessl-publish-prerelease.yml
+++ b/.github/workflows/tessl-publish-prerelease.yml
@@ -37,4 +37,9 @@ jobs:
           NAME=$(jq -r .name "$TILE/tile.json")
           VERSION=$(jq -r .version "$TILE/tile.json")
           echo "Publishing $NAME@$VERSION from $TILE"
-          tessl tile publish "$TILE"
+          # tessl >=0.81 rejects symlinks for security. Dereference the tile
+          # into a concrete temp copy (mirrors tessl-lint.yml) so the published
+          # tile ships real files instead of rejected symlinks.
+          TMP=$(mktemp -d)
+          cp -rL "$TILE" "$TMP/${{ matrix.tile }}"
+          tessl tile publish "$TMP/${{ matrix.tile }}"

--- a/.github/workflows/tessl-publish.yml
+++ b/.github/workflows/tessl-publish.yml
@@ -37,6 +37,24 @@ jobs:
           git fetch origin "${GITHUB_REF#refs/heads/}"
           git reset --hard "origin/${GITHUB_REF#refs/heads/}"
 
+      - name: Dereference skill symlinks
+        run: |
+          # tessl >=0.81 rejects symlinks for security. The repo uses symlinks
+          # in tiles/*/skills/ pointing to ../../../skills/*. Replace each
+          # top-level symlink with a real copy of its target, in place, so the
+          # published manifest ships concrete files. Done in-place (not a temp
+          # dir) so the action's tile.json commit-back still targets the repo.
+          SKILLS_DIR="tiles/${{ matrix.tile }}/skills"
+          if [ -d "$SKILLS_DIR" ]; then
+            for link in "$SKILLS_DIR"/*; do
+              if [ -L "$link" ]; then
+                target=$(readlink -f "$link")
+                rm "$link"
+                cp -rL "$target" "$link"
+              fi
+            done
+          fi
+
       - uses: tesslio/patch-version-publish@v1
         with:
           token: ${{ secrets.TESSLIO_TOKEN }}


### PR DESCRIPTION
## Problem

The `Tessl Tile Publish` workflow fails at `tessl tile publish tiles/basic` with:

> ✘ Plugin manifest references symlinks (excluded for security…)

tessl >=0.81 refuses to publish the symlinks under `tiles/*/skills/*` that point to `../../../skills/*`. These symlinks are intentional — they keep skills as a single source of truth under `/skills`.

## Fix

Apply the symlink-dereference pattern already used in `tessl-lint.yml` (`cp -rL`) to the two publish workflows, materializing real copies in CI while keeping the symlinks committed in the repo.

- **`tessl-publish.yml`**: new in-place dereference step (`readlink -f` + `rm` + `cp -rL`) inserted between *Pull latest from branch* and `tesslio/patch-version-publish@v1`. In-place is required so the action's `tile.json` version bump still commits back to the real repo path; the dereferenced skill dirs are never staged.
- **`tessl-publish-prerelease.yml`**: publishes from a `cp -rL` temp copy, mirroring the lint workflow.

## Verification

- Both workflow YAMLs parse cleanly; shellcheck clean on the new scripts.
- All 30 `tiles/*/skills/*` entries remain committed symlinks (mode `120000`); only the two workflow files changed.
- `tessl-lint.yml` / `tessl-review.yml` untouched.

Merging to `main` will re-trigger the publish workflow, which should now succeed.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author