### PR TITLE
feat(speck): new skill for SLICC to spot-edit elements on HTML pages

### DIFF
--- a/skills/speck/SKILL.md
+++ b/skills/speck/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: speck
+description: |
+  Use this when the user wants to annotate, inspect, or leave element-level
+  feedback on a local HTML page served in a browser tab. Injects a hover-highlight
+  + click-to-annotate interaction into the target page. Annotations are sent as
+  licks to a scoop that applies the user's instructions as AI-driven edits to the
+  HTML. Use when the user says "annotate this page", "let me mark up elements",
+  "add speck", "inspect elements with notes", or "inject speck".
+allowed-tools: bash
+---
+
+# speck
+
+Inject an element-level annotation layer into any local HTML page currently open
+in a browser tab. Once active, hovering highlights elements with a coloured
+border; clicking locks the selection and opens a text input where the user can
+type an instruction for that element. On submit, the instruction is sent as a
+webhook lick to a `speck-worker` scoop that applies the edit to the underlying
+HTML file, reloads the page, and re-injects speck for continuous editing.
+
+## Setup (cone responsibilities)
+
+Before speck can work end-to-end, the cone must ensure:
+
+1. **A `speck-worker` scoop exists** with `/tmp/` write access:
+   ```
+   scoop_scoop("speck-worker", writablePaths=["/scoops/speck-worker-scoop/", "/shared/", "/tmp/"])
+   ```
+2. **The scoop has standing instructions** (via `feed_scoop`) to:
+   - Read the target file
+   - Locate the element by selector/snippet
+   - Apply the user's instruction as an edit
+   - Reload the tab via `playwright-cli goto <preview-url> --tab <tabId>`
+   - Re-inject speck via `speck inject <tabId> --file <filePath>`
+3. **A single webhook named `speck-lick`** routes to the scoop. The `speck inject`
+   command creates this automatically if it doesn't exist.
+
+## Commands
+
+```bash
+speck inject <tabId> [--file <path>]   # Inject + wire webhook for live edits
+speck collect <tabId>                  # Retrieve annotations as JSON
+speck remove <tabId>                   # Remove overlay + cleanup state
+```
+
+The `--file` flag tells the speck-worker scoop which HTML file to edit. Without
+it, annotations are collected locally but not applied.
+
+## How it works
+
+1. **Hover**: elements receive an orange outline (3px solid #FF6B35) with a soft
+   glow on mouseover.
+2. **Click**: locks the highlight and shows a fixed-position dark input tooltip
+   below the element.
+3. **Enter**: submits the instruction — POSTs to the `speck-lick` webhook which
+   routes to the `speck-worker` scoop. The tooltip flashes green to confirm.
+4. **Escape**: dismisses without submitting. Click elsewhere also dismisses.
+5. **Scoop execution**: the scoop edits the file, reloads the page, and
+   re-injects speck so the user can keep annotating without interruption.
+
+### Webhook payload shape
+
+```json
+{
+  "action": "element-instruction",
+  "data": {
+    "instruction": "make this text larger",
+    "element": {
+      "tag": "h2",
+      "class": "section-title",
+      "text": "Latest News",
+      "selector": "section:nth-of-type(3) > h2",
+      "outerSnippet": "<h2 class=\"section-title\">Latest News</h2>"
+    },
+    "file": "/shared/stardust/prototype/index.html",
+    "tabId": "1218556234",
+    "timestamp": 1717300000000
+  }
+}
+```
+
+## Progress feedback
+
+The cone sends a chat message when the speck-worker scoop completes each edit,
+summarizing what was applied. This gives the user immediate feedback in the
+conversation without needing a separate UI panel.
+
+## Key design decisions
+
+- **Single webhook**: `speck inject` reuses a single webhook named `speck-lick`
+  rather than creating one per tab/injection. This prevents duplicate webhook
+  accumulation.
+- **Re-injection after edit**: the scoop MUST re-inject speck after reloading
+  the page, otherwise the overlay is lost.
+- **No sprinkle UI**: progress is shown via chat messages from the cone. A
+  sprinkle panel was tried but the rail icon cannot show dynamic status, making
+  it less useful than inline chat feedback.
+- **Preview pages only**: the injection uses `playwright-cli eval` on the
+  extension's preview service worker pages. Remote/third-party pages will block
+  it via CSP.
+- **`/tmp/` write access**: the scoop needs `/tmp/` to run `speck inject`
+  (which writes a temp file for playwright-cli eval). Include it in
+  `writablePaths` when creating the scoop.
+
+## Cone workflow on scoop completion
+
+When the cone receives `[@speck-worker-scoop completed]`:
+1. Read the notification preview to see what was applied.
+2. Send a short chat message to the user: "Speck applied: <summary>"
+
+## Don't
+
+- Don't inject into remote/third-party pages (CSP will block it). Use only on
+  locally served or preview pages.
+- Don't call `speck inject` twice on the same tab without `speck remove` first —
+  you'll get duplicate listeners. (The script guards against this with an
+  `already injected` check, but avoid it anyway.)
+- Don't create multiple webhooks — `speck inject` looks for an existing
+  `speck-lick` webhook before creating one.
+- Don't use shift-reload on the preview page — it bypasses the service worker
+  and gives ERR_FILE_NOT_FOUND. Use regular reload or `playwright-cli goto`.
+- Don't create a sprinkle for speck progress — it was tried and removed because
+  the rail icon can't show dynamic state.

--- a/skills/speck/speck.jsh
+++ b/skills/speck/speck.jsh
@@ -1,0 +1,97 @@
+// speck — element-level annotation layer for local HTML pages
+// Usage: speck inject <tabId> [--file <path>] | speck collect <tabId> | speck remove <tabId>
+
+const args = process.argv.slice(2);
+const command = args[0];
+const tabId = args[1];
+
+if (!command || (command !== '--help' && command !== '-h' && !tabId)) {
+  console.log(`speck — element annotation layer for local HTML pages
+
+Usage:
+  speck inject <tabId> [--file <path>]   Inject hover+input interaction (with live lick dispatch)
+  speck collect <tabId>                  Retrieve submitted annotations as JSON
+  speck remove <tabId>                   Remove the speck overlay from the page
+
+Options:
+  --file <path>    Path to the HTML file being annotated (enables AI-powered edits via licks)
+
+The tabId is the playwright-cli target ID for the tab (shown by 'serve' or 'playwright-cli open').`);
+  process.exit(command === '--help' || command === '-h' ? 0 : 1);
+}
+
+// Parse --file flag
+let filePath = null;
+const fileIdx = args.indexOf('--file');
+if (fileIdx !== -1 && args[fileIdx + 1]) {
+  filePath = args[fileIdx + 1];
+}
+
+if (command === 'inject') {
+  // Find or create a single webhook for speck (routes to speck-worker scoop)
+  let webhookUrl = '';
+  const listResult = await exec('webhook list');
+  const existingMatch = listResult.stdout.match(/speck-lick\s+(https:\/\/\S+)/);
+  
+  if (existingMatch) {
+    webhookUrl = existingMatch[1];
+  } else {
+    const webhookResult = await exec('webhook create --scoop speck-worker --name speck-lick');
+    if (webhookResult.exitCode === 0) {
+      const urlMatch = webhookResult.stdout.match(/URL:\s+(https:\/\/\S+)/);
+      if (urlMatch) webhookUrl = urlMatch[1];
+    }
+  }
+
+  if (!webhookUrl) {
+    console.error('Failed to create or find speck webhook');
+    process.exit(1);
+  }
+
+  const INJECT_SCRIPT = `(function(){if(document.getElementById('speck-style'))return 'already injected';var WEBHOOK_URL=${JSON.stringify(webhookUrl)};var FILE_PATH=${JSON.stringify(filePath || '')};var TAB_ID=${JSON.stringify(tabId)};var style=document.createElement('style');style.id='speck-style';style.textContent='#speck-highlight{position:fixed;top:0;left:0;width:0;height:0;border:2px solid oklch(60% 0.25 350);border-radius:3px;pointer-events:none;z-index:100001;box-sizing:border-box;display:none;opacity:0;transition:top 140ms cubic-bezier(0.22,1,0.36,1),left 140ms cubic-bezier(0.22,1,0.36,1),width 140ms cubic-bezier(0.22,1,0.36,1),height 140ms cubic-bezier(0.22,1,0.36,1),opacity 150ms ease}#speck-tag{position:fixed;background:oklch(15% 0.01 350);color:oklch(99% 0 0);font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:10px;font-weight:500;padding:2px 6px;border-radius:3px;z-index:100002;pointer-events:none;white-space:nowrap;display:none;letter-spacing:0.02em;transition:top 140ms cubic-bezier(0.22,1,0.36,1),left 140ms cubic-bezier(0.22,1,0.36,1),opacity 150ms ease}#speck-input-tooltip{position:fixed;z-index:100005;display:none;opacity:0;transform:translateY(6px);transition:opacity 0.25s cubic-bezier(0.22,1,0.36,1),transform 0.3s cubic-bezier(0.22,1,0.36,1);background:oklch(98% 0.005 350/0.92);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);border:1px solid oklch(90% 0.01 350/0.6);border-radius:10px;box-shadow:0 8px 32px oklch(0% 0 0/0.12),0 2px 8px oklch(0% 0 0/0.08);font-family:system-ui,-apple-system,sans-serif;font-size:13px;color:oklch(15% 0.01 350);padding:6px 10px;min-width:300px;flex-direction:column;gap:6px}#speck-input-tooltip input{background:oklch(99% 0 0);border:1px solid oklch(90% 0.01 350/0.6);border-radius:6px;color:oklch(15% 0.01 350);font-family:system-ui,-apple-system,sans-serif;font-size:13px;padding:5px 10px;outline:none;width:100%;box-sizing:border-box;transition:border-color 0.15s ease,box-shadow 0.15s ease}#speck-input-tooltip input:focus{border-color:oklch(60% 0.25 350);box-shadow:0 0 0 3px oklch(60% 0.25 350/0.15)}#speck-input-tooltip input::placeholder{color:oklch(55% 0 0)}#speck-input-tooltip .speck-hint{color:oklch(55% 0 0);font-size:11px}@media(prefers-color-scheme:dark){#speck-input-tooltip{background:oklch(20% 0.01 350/0.92);border-color:oklch(35% 0.01 350/0.6);color:oklch(90% 0 0)}#speck-input-tooltip input{background:oklch(25% 0.01 350);border-color:oklch(40% 0.01 350/0.6);color:oklch(95% 0 0)}#speck-input-tooltip input::placeholder{color:oklch(55% 0 0)}#speck-input-tooltip .speck-hint{color:oklch(55% 0 0)}}';document.head.appendChild(style);var hi=document.createElement('div');hi.id='speck-highlight';document.body.appendChild(hi);var tag=document.createElement('div');tag.id='speck-tag';document.body.appendChild(tag);var tooltip=document.createElement('div');tooltip.id='speck-input-tooltip';var inp=document.createElement('input');inp.type='text';inp.placeholder='Improve this element...';var hint=document.createElement('span');hint.className='speck-hint';hint.textContent='Enter to apply \\u00b7 Esc to cancel';tooltip.appendChild(inp);tooltip.appendChild(hint);document.body.appendChild(tooltip);var current=null;var locked=false;var SKIP=new Set(['html','head','body','script','style','link','meta','noscript','br','wbr']);window.__speckElementInstructions=window.__speckElementInstructions||[];function desc(el){var t=el.tagName.toLowerCase();if(el.id)return t+'#'+el.id;if(el.className&&typeof el.className==='string'){var c=el.className.trim().split(/\\s+/).slice(0,2).join('.');if(c)return t+'.'+c;}return t;}function getSelector(el){if(el.id)return'#'+el.id;var path=[];var node=el;while(node&&node!==document.body){var t=node.tagName.toLowerCase();var parent=node.parentElement;if(parent){var siblings=Array.from(parent.children).filter(function(c){return c.tagName===node.tagName});if(siblings.length>1){var idx=siblings.indexOf(node)+1;t+=':nth-of-type('+idx+')';}}path.unshift(t);node=parent;}return path.join(' > ');}function showHighlight(el){if(!el)return;var r=el.getBoundingClientRect();var wasHidden=hi.style.display==='none'||hi.style.opacity==='0';if(wasHidden){hi.style.transition='none';hi.style.top=(r.top-2)+'px';hi.style.left=(r.left-2)+'px';hi.style.width=(r.width+4)+'px';hi.style.height=(r.height+4)+'px';hi.style.display='block';void hi.offsetWidth;hi.style.transition='';hi.style.opacity='1';}else{hi.style.top=(r.top-2)+'px';hi.style.left=(r.left-2)+'px';hi.style.width=(r.width+4)+'px';hi.style.height=(r.height+4)+'px';hi.style.opacity='1';hi.style.display='block';}var tipTop=r.top-20;var tipY=tipTop<4?r.bottom+4:tipTop;var tipX=r.left;if(tipX<4)tipX=4;tag.textContent=desc(el);tag.style.top=tipY+'px';tag.style.left=tipX+'px';tag.style.display='block';tag.style.opacity='1';}function hideHighlight(){hi.style.opacity='0';hi.style.display='none';tag.style.display='none';}function onMouseOver(e){if(locked)return;var el=e.target;if(el===document.body||el===document.documentElement||SKIP.has(el.tagName.toLowerCase()))return;if(tooltip.contains(el)||hi===el||tag===el)return;current=el;showHighlight(el);}function onMouseOut(e){if(locked)return;if(!tooltip.contains(e.relatedTarget)&&e.relatedTarget!==hi&&e.relatedTarget!==tag){hideHighlight();current=null;}}function onClick(e){if(tooltip.contains(e.target))return;e.preventDefault();e.stopPropagation();if(locked&&current){hideHighlight();tooltip.style.opacity='0';tooltip.style.transform='translateY(6px)';setTimeout(function(){tooltip.style.display='none';},250);locked=false;current=null;return;}if(!current)return;locked=true;showHighlight(current);var rect=current.getBoundingClientRect();var barH=60;var gap=8;var top=rect.bottom+gap;if(top+barH+gap>window.innerHeight)top=rect.top-barH-gap;if(top<gap)top=gap;var left=rect.left+(rect.width-320)/2;if(left<10)left=10;if(left+320>window.innerWidth-10)left=window.innerWidth-330;tooltip.style.top=top+'px';tooltip.style.left=left+'px';tooltip.style.display='flex';requestAnimationFrame(function(){tooltip.style.opacity='1';tooltip.style.transform='translateY(0)';});inp.value='';inp.focus();}function onKeyDown(e){if(e.key==='Enter'&&inp.value.trim()){var instruction=inp.value.trim();var elTag=current?current.tagName.toLowerCase():'?';var elClass=current?current.className:'';var elText=current?current.textContent.slice(0,80).trim():'';var selector=current?getSelector(current):'';var outerSnippet=current?current.outerHTML.slice(0,300):'';var annotation={instruction:instruction,element:{tag:elTag,class:elClass,text:elText,selector:selector,outerSnippet:outerSnippet},file:FILE_PATH,tabId:TAB_ID,timestamp:Date.now()};window.__speckElementInstructions.push(annotation);if(WEBHOOK_URL){fetch(WEBHOOK_URL,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({action:'element-instruction',data:annotation})}).catch(function(){});}inp.style.borderColor='oklch(65% 0.2 145)';inp.style.boxShadow='0 0 0 3px oklch(65% 0.2 145/0.15)';setTimeout(function(){tooltip.style.opacity='0';tooltip.style.transform='translateY(6px)';setTimeout(function(){tooltip.style.display='none';inp.style.borderColor='';inp.style.boxShadow='';},250);hideHighlight();locked=false;current=null;},350);}if(e.key==='Escape'){tooltip.style.opacity='0';tooltip.style.transform='translateY(6px)';setTimeout(function(){tooltip.style.display='none';},250);hideHighlight();locked=false;current=null;}}document.addEventListener('mouseover',onMouseOver);document.addEventListener('mouseout',onMouseOut);document.addEventListener('click',onClick,true);inp.addEventListener('keydown',onKeyDown);window.__speckCleanup=function(){document.removeEventListener('mouseover',onMouseOver);document.removeEventListener('mouseout',onMouseOut);document.removeEventListener('click',onClick,true);inp.removeEventListener('keydown',onKeyDown);hi.remove();tag.remove();tooltip.remove();style.remove();delete window.__speckCleanup;delete window.__speckElementInstructions;};return 'speck injected (lick-enabled)'})()`;
+
+  const tmpFile = '/tmp/speck-eval-' + Date.now() + '.js';
+  await fs.writeFile(tmpFile, INJECT_SCRIPT);
+  const result = await exec(`playwright-cli eval "$(cat ${tmpFile})" --tab ${tabId}`);
+  await fs.rm(tmpFile);
+
+  if (result.exitCode !== 0) {
+    console.error('Failed:', result.stderr || result.stdout);
+    process.exit(1);
+  }
+  console.log(result.stdout.trim());
+  if (webhookUrl) {
+    console.log('Lick-enabled: annotations route to cone for progress + execution');
+    if (filePath) console.log(`File: ${filePath}`);
+  }
+
+} else if (command === 'collect') {
+  const COLLECT_SCRIPT = `JSON.stringify(window.__speckElementInstructions||[])`;
+  const tmpFile = '/tmp/speck-eval-' + Date.now() + '.js';
+  await fs.writeFile(tmpFile, COLLECT_SCRIPT);
+  const result = await exec(`playwright-cli eval "$(cat ${tmpFile})" --tab ${tabId}`);
+  await fs.rm(tmpFile);
+  if (result.exitCode !== 0) {
+    console.error('Failed:', result.stderr || result.stdout);
+    process.exit(1);
+  }
+  console.log(result.stdout.trim());
+
+} else if (command === 'remove') {
+  const REMOVE_SCRIPT = `(function(){if(window.__speckCleanup){window.__speckCleanup();return 'speck removed'}return 'speck not found on this page'})()`;
+  const tmpFile = '/tmp/speck-eval-' + Date.now() + '.js';
+  await fs.writeFile(tmpFile, REMOVE_SCRIPT);
+  const result = await exec(`playwright-cli eval "$(cat ${tmpFile})" --tab ${tabId}`);
+  await fs.rm(tmpFile);
+
+  if (result.exitCode !== 0) {
+    console.error('Failed:', result.stderr || result.stdout);
+    process.exit(1);
+  }
+  console.log(result.stdout.trim());
+
+} else {
+  console.error(`Unknown command: ${command}`);
+  console.log('Valid commands: inject, collect, remove');
+  process.exit(1);
+}


### PR DESCRIPTION
The 'speck'  skill injects an annotation layer into any local HTML page currently open. When overing over it this highlights the current element with a coloured border.
Clicking on a highlighted element opens a text input box where instructions to improve/change the current element can be typed in. These instructions are sent back to SLICC, which will then work on the improvements requested and update the HTML file. It will then reload the page to show the improvements.

Here's a little video of the skill in action (note the video has audio):

https://github.com/user-attachments/assets/55d2c85a-5d05-400b-9a98-9d7c01913489

