### PR TITLE
feat(jira): add create command with createmeta field discovery

### DIFF
--- a/skills/jira/SKILL.md
+++ b/skills/jira/SKILL.md
@@ -2,10 +2,10 @@
 name: jira
 description: |
   Use this when interacting with Jira — fetching issues, searching by JQL,
-  reading comments, or pulling issue detail to use in other workflows. Uses
-  the Jira tab open in the browser for auth (SSO session, no token needed).
-  Activate on any mention of Jira, issue keys (e.g. PROJ-123), JQL queries, or
-  requests to read/find/list Jira tickets.
+  reading comments, or creating new issues. Uses the Jira tab open in the
+  browser for auth (SSO session, no token needed). Activate on any mention of
+  Jira, issue keys (e.g. PROJ-123), JQL queries, or requests to
+  read/find/list/create Jira tickets.
 allowed-tools: bash
 ---
 
@@ -21,15 +21,18 @@ jira detect                                          # Find Jira tab — confirm
 jira whoami                                          # Verify auth is working
 jira get PROJ-123                                    # Fetch a single issue with full detail
 jira search "project=PROJ ORDER BY updated DESC"     # JQL search (up to 50 results)
-jira search "project=PROJ AND status=Open"           # Filter by status
 jira comments PROJ-123                               # Fetch all comments on an issue
+jira components PROJ                                 # List all components defined in a project
+jira types PROJ                                      # List all issue types available in a project
+jira labels PROJ                                     # List all labels in use in a project
+jira create --project PROJ --type Story --summary "My new story"
 ```
 
 ## Authentication
 
-Auth is handled via the browser's SSO session. All API calls are made from within
-the Jira page context using `playwright-cli eval` with `credentials: 'include'`,
-so SSO cookies are sent automatically — no token extraction needed.
+Auth is handled via the browser's SSO session. All API calls run inside the
+Jira tab's page context using `browser.fetch`, so SSO cookies are sent
+automatically — no token extraction needed.
 
 **Requirements:**
 - A Jira tab must be open in the browser
@@ -43,9 +46,6 @@ The skill auto-detects the Jira base URL by scanning open browser tabs for any
 URL containing `jira`. Always run `jira detect` first in a new session or when
 switching Jira instances. **The user must confirm the detected URL is correct
 before proceeding with other commands.**
-
-If multiple Jira tabs are open, the first match is used. Close unwanted tabs or
-note which workspace you're targeting.
 
 ## Commands
 
@@ -73,49 +73,17 @@ components, labels, fix versions, and description.
 
 ```bash
 jira get PROJ-123
-jira get PROJ-456
-```
-
-**Example output:**
-```
-PROJ-123: Add dark mode support
-  Type:        Story
-  Status:      In Progress
-  Assignee:    Jane Smith
-  Reporter:    John Doe
-  Created:     2025-08-18
-  Updated:     2026-04-02
-  Components:  Frontend
-  Fix Versions: v1.2
-
-  Description:
-    ...
 ```
 
 ### `jira search "<jql>"`
 
-Runs a JQL query and returns matching issues. Returns up to 50 results showing
-key, summary, status, assignee, and issue type.
+Runs a JQL query and returns matching issues (up to 50).
 
 ```bash
 jira search "project=PROJ ORDER BY updated DESC"
 jira search "project=PROJ AND status=Open"
 jira search "project=PROJ AND assignee=currentUser()"
-jira search "project=PROJ AND fixVersion='v1.2'"
-jira search "project=PROJ AND component='Frontend'"
 ```
-
-**Example output:**
-```
-3 issue(s) found (showing 3):
-
-  PROJ-124: Improve search performance [In Review]
-  PROJ-123: Add dark mode support [In Progress]
-  PROJ-100: Fix broken pagination [Resolved]
-```
-
-**Note:** Results are capped at 50. For larger result sets, add filters to narrow
-the query (e.g. `AND status=Open`, `AND updated >= -30d`).
 
 ### `jira comments <issue-key>`
 
@@ -125,27 +93,76 @@ Fetches all comments on an issue with author, date, and body text.
 jira comments PROJ-123
 ```
 
+### `jira create`
+
+Creates a new issue. **Required fields are discovered automatically** from the
+project's `createmeta` — every Jira project and issue type combination has its
+own set of required fields, so the command fetches those before attempting to
+create, and reports exactly what's missing if the call would fail.
+
+```bash
+# Minimal invocation — will report missing required fields if any exist
+jira create --project PROJ --type Story --summary "Add dark mode"
+
+# With optional fields
+jira create --project PROJ --type Bug \
+  --summary "Login fails on Safari" \
+  --description "Steps to reproduce..." \
+  --assignee jsmith \
+  --priority High \
+  --labels "frontend,regression" \
+  --components "Auth,Frontend"
+
+# Set a custom field by numeric ID
+jira create --project PROJ --type Story --summary "..." --cf-10014 "Sprint 3"
+
+# Set any field by its raw Jira field ID
+jira create --project PROJ --type Story --summary "..." --field-customfield_10200 "value"
+```
+
+**Flags:**
+
+| Flag | Description |
+|---|---|
+| `--project <key>` | Project key — required |
+| `--type <name>` | Issue type name (Story, Bug, Task, …) — required |
+| `--summary <text>` | Issue summary — required for most types |
+| `--description <text>` | Issue description (plain text; Jira wiki markup also accepted) |
+| `--assignee <username>` | Assignee's Jira username |
+| `--priority <name>` | Priority name (e.g. High, Medium, Low, Critical) |
+| `--labels <a,b,c>` | Comma-separated label names |
+| `--components <a,b>` | Comma-separated component names |
+| `--cf-NNNNN <value>` | Custom field by numeric ID (e.g. `--cf-10014 "Sprint 3"`) |
+| `--field-<id> <value>` | Any field by raw Jira field ID |
+| `--dry-run` | Validate fields and print the payload that would be posted, without creating anything |
+
+**How required-field discovery works:**
+
+Before posting, the command fetches the project's `createmeta` to find required
+fields for the given issue type. It tries two endpoint shapes in order:
+
+1. **Paginated** (Jira Server 9+ / Data Center): `GET /rest/api/2/issue/createmeta/{project}/issuetypes`
+2. **Classic** (older Jira Server): `GET /rest/api/2/issue/createmeta?projectKeys=…&expand=projects.issuetypes.fields`
+
+Whichever responds with 200 is used; the result is normalised so the rest of
+the command behaves identically regardless of which endpoint answered.
+
+If any required fields are not covered by the provided flags, it prints them
+with their type and the flag to use, then exits without creating anything.
+Re-run with the missing flags.
+
+If the issue type name is wrong for the project, the command lists valid types
+for that project.
+
 **Example output:**
 ```
-Comments on PROJ-123 (2):
-
-  [2025-08-18] John Doe:
-    Flagging this for design review before implementation.
-
-  [2025-09-23] Jane Smith:
-    Design approved — moving to development.
+✓ Created PROJ-456: https://jira.example.com/browse/PROJ-456
 ```
 
-## Using with other skills
+## Output format — Jira wiki markup
 
-When building pages from Jira content, use `jira get` to pull the full issue and
-`jira comments` for additional context. The `.jsh` script outputs plain text
-suitable for use in prompts or piped to other commands.
-
-### Output format — Jira wiki markup
-
-The `description` and comment `body` fields are returned in **Jira wiki markup**,
-not plain text or Markdown. Common patterns:
+The `description` and comment `body` fields from `get` and `comments` are
+returned in **Jira wiki markup**, not plain text or Markdown. Common patterns:
 
 | Jira markup | Meaning |
 |---|---|
@@ -154,13 +171,39 @@ not plain text or Markdown. Common patterns:
 | `{{text}}` | Inline code |
 | `[label\|url]` | Hyperlink |
 | `{color:#hex}text{color}` | Colored text (usually discard) |
-| `{*}text{*}` | Bold (alternate form) |
 | `# item` | Ordered list item |
 | `- item` | Unordered list item |
-| `\r\n` | Windows line endings |
 
-When consuming this output to generate DA pages or other content, strip the markup
-to plain text or convert to Markdown/HTML as appropriate for the target format.
+When consuming this output to generate content, strip or convert markup as
+appropriate for the target format.
+
+## Project metadata
+
+Several fields on issue creation require values from a fixed list defined per-project. Fetch these directly before prompting the user:
+
+```bash
+# All components defined in a project
+jira components ACE
+
+# All issue types available in a project
+jira types ACE
+```
+
+Or via the REST API directly:
+
+| Data | Endpoint |
+|---|---|
+| Components | `GET /rest/api/2/project/{key}/components` |
+| Labels in use in project | `GET /rest/api/2/search?jql=project={key}+AND+labels+is+not+EMPTY&fields=labels` |
+| All instance labels | `GET /rest/api/1.0/labels/suggest?query=&maxResults=100` |
+| Issue types (paginated, Server 9+) | `GET /rest/api/2/issue/createmeta/{key}/issuetypes` |
+| Issue types (classic) | `GET /rest/api/2/issue/createmeta?projectKeys={key}&expand=projects.issuetypes` |
+| Fields for a type (paginated) | `GET /rest/api/2/issue/createmeta/{key}/issuetypes/{typeId}` |
+| Priority values | `GET /rest/api/2/priority` |
+
+The `create` command fetches components automatically when `--components` is omitted and the field is required — it presents the full list from `/rest/api/2/project/{key}/components`, scored by relevance to the issue summary and description, and prompts the user to pick.
+
+For labels, `create` always prompts (even though labels are optional). It merges two sources: labels already used in the project (from the search API, boosted in ranking) and the full instance-wide label universe (from `/rest/api/1.0/labels/suggest`). Both are scored against the issue content; project-familiar labels are weighted higher and annotated with `(used in project)` in the prompt.
 
 ## Common errors
 
@@ -168,7 +211,9 @@ to plain text or convert to Markdown/HTML as appropriate for the target format.
 |---|---|---|
 | `No Jira tab found` | No browser tab with `jira` in the URL | Open Jira in your browser |
 | `API error 401` | SSO session expired | Refresh the Jira tab, log in again |
-| `eval failed` | Jira tab navigated away or closed | Check `playwright-cli tab-list` |
+| `Project not found` | Wrong project key or no permission | Check the key; verify you can see the project in the browser |
+| `Issue type not found` | Type name doesn't match this project | Run `jira create --project PROJ --type x` — it will list valid types |
+| `Missing required fields` | Project has additional required fields beyond summary | Re-run with the flags listed in the error output |
 
 ## SSO Jira instances
 
@@ -176,11 +221,5 @@ For corporate SSO-protected Jira instances (no personal API tokens available):
 - Uses Jira Server/Data Center REST API (`/rest/api/2/`) not Jira Cloud
 - Standard field names (`summary`, `description`, `status`, `assignee`) work
   reliably; custom fields (`customfield_XXXXX`) vary by instance
-- Session cookies are scoped to the corp domain; direct fetch from localhost is
-  rejected — page-context eval is required (already the default approach)
-
----
-
-> **TODO:** Revisit and tighten this documentation after real use. Add examples
-> of JQL queries that proved useful, output patterns that needed cleanup, and any
-> edge cases encountered.
+- Session cookies are scoped to the corp domain; page-context fetch (the
+  default) handles this automatically

--- a/skills/jira/jira.jsh
+++ b/skills/jira/jira.jsh
@@ -196,6 +196,7 @@ async function labels(project) {
 async function create(flags) {
   const project = flags.project;
   const issueType = flags.type;
+  const isDryRun = flags['dry-run'] || flags['dry_run'] || flags.dry;
 
   if (!project) cli.die('--project is required (e.g. jira create --project PROJ --type Story --summary "...")');
   if (!issueType) cli.die('--type is required (e.g. Story, Bug, Task)');
@@ -220,7 +221,7 @@ async function create(flags) {
   } else {
     // Shape 2 — classic expand
     const classicResp = await jiraGetRaw(
-      `/rest/api/2/issue/createmeta?projectKeys=${project}&issuetypeNames=${encodeURIComponent(issueType)}&expand=projects.issuetypes.fields`
+      `/rest/api/2/issue/createmeta?projectKeys=${project}&expand=projects.issuetypes.fields`
     );
     if (!classicResp.ok) {
       cli.die(`Could not fetch createmeta for project "${project}" (tried both endpoint variants). Status: ${classicResp.status}`);
@@ -278,6 +279,16 @@ async function create(flags) {
   if (flags.priority)    fields.priority = { name: flags.priority };
   if (flags.labels)      fields.labels = flags.labels.split(',').map(l => l.trim());
   if (flags.components)  fields.components = flags.components.split(',').map(n => ({ name: n.trim() }));
+
+  // Handle raw --field-<id>=<value> overrides for custom fields before
+  // required-field validation so these flags can satisfy required custom fields.
+  for (const [k, v] of Object.entries(flags)) {
+    if (k.startsWith('field-')) {
+      fields[k.slice(6)] = v;
+    } else if (k.startsWith('cf-')) {
+      fields[`customfield_${k.slice(3)}`] = v;
+    }
+  }
 
   // Check required fields from createmeta
   const requiredFields = Object.entries(typeMeta.fields ?? {})
@@ -376,6 +387,13 @@ async function create(flags) {
     }
   }
 
+  // Dry-run: show what would be posted without optional label prompting or sending.
+  if (isDryRun) {
+    console.log(c.yellow('Dry run — would POST to /rest/api/2/issue:'));
+    console.log(JSON.stringify({ fields }, null, 2));
+    process.exit(0);
+  }
+
   // Always surface label options if not supplied — optional but useful.
   // Pass --no-labels to explicitly skip.
   if (!flags.labels && !flags['no-labels']) {
@@ -429,22 +447,6 @@ async function create(flags) {
       console.log(c.dim('\nRe-run with --labels "<name>,<name>" to set labels, or --no-labels to skip.'));
       process.exit(1);
     }
-  }
-
-  // Handle raw --field-<id>=<value> overrides for custom fields
-  for (const [k, v] of Object.entries(flags)) {
-    if (k.startsWith('field-')) {
-      fields[k.slice(6)] = v;
-    } else if (k.startsWith('cf-')) {
-      fields[`customfield_${k.slice(3)}`] = v;
-    }
-  }
-
-  // Dry-run: show what would be posted without sending
-  if (flags['dry-run'] || flags['dry_run'] || flags.dry) {
-    console.log(c.yellow('Dry run — would POST to /rest/api/2/issue:'));
-    console.log(JSON.stringify({ fields }, null, 2));
-    process.exit(0);
   }
 
   // POST the new issue

--- a/skills/jira/jira.jsh
+++ b/skills/jira/jira.jsh
@@ -5,86 +5,48 @@
 //   jira get <issue-key>
 //   jira search "<jql>"
 //   jira comments <issue-key>
+//   jira create --project <key> --type <type> --summary <text> [--description <text>] [--assignee <name>]
 
 // --- Tab management ---
 
-let _tabId = null;
+let _tab = null;
 let _jiraBase = null;
 
 async function findJiraTab() {
-  if (_tabId) return _tabId;
-  const list = await exec('playwright-cli tab-list');
-  if (list.exitCode !== 0) {
-    console.error('Error: Failed to list browser tabs.');
-    if (list.stderr) console.error(list.stderr.trim());
-    process.exit(1);
+  if (_tab) return _tab;
+  _tab = await browser.findTab({ urlMatch: /jira/ });
+  if (!_tab) {
+    cli.die('No Jira tab found. Open Jira in your browser and try again.');
   }
-  const lines = list.stdout.split('\n');
-  for (const line of lines) {
-    if (line.toLowerCase().includes('jira')) {
-      const m = line.match(/^\[([^\]]+)\]/);
-      const urlMatch = line.match(/https?:\/\/\S+/);
-      if (m && urlMatch) {
-        _tabId = m[1];
-        _jiraBase = urlMatch[0].match(/^https?:\/\/[^\/]+/)[0];
-        return _tabId;
-      }
-    }
-  }
-  console.error('Error: No Jira tab found. Open Jira in your browser and try again.');
-  process.exit(1);
+  _jiraBase = new URL(_tab.url).origin;
+  return _tab;
 }
 
-// --- Eval helper ---
-// Writes JS to a temp file, evals in the Jira tab, returns parsed JSON.
+// --- API helpers ---
 
-async function evalInJiraTab(expr, { fatal = true } = {}) {
-  const tabId = await findJiraTab();
-  const tmpFile = '/shared/.jira_eval_' + Date.now() + '.js';
-  await fs.writeFile(tmpFile, expr.trim());
-  const result = await exec(`playwright-cli eval-file ${tmpFile} --tab=${tabId}`);
-  await fs.rm(tmpFile).catch(async () => {
-    await fs.writeFile(tmpFile, '').catch(() => {});
+// Raw fetch — returns the full response; caller checks resp.ok
+async function jiraGetRaw(path) {
+  const tab = await findJiraTab();
+  return browser.fetch(tab, _jiraBase + path);
+}
+
+// Fetch and throw on non-2xx
+async function jiraGet(path) {
+  const resp = await jiraGetRaw(path);
+  if (!resp.ok) {
+    cli.die(`API error ${resp.status}. Is your Jira session active? (Refresh the Jira tab if needed.)`);
+  }
+  return resp.body;
+}
+
+async function jiraPost(path, body) {
+  const tab = await findJiraTab();
+  const resp = await browser.fetch(tab, _jiraBase + path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
   });
-
-  if (result.exitCode !== 0) {
-    if (!fatal) return null;
-    console.error('Eval failed:', result.stderr);
-    process.exit(1);
-  }
-
-  let data;
-  try {
-    const stdout = result.stdout.trim();
-    data = JSON.parse(stdout);
-    if (typeof data === 'string') data = JSON.parse(data);
-  } catch (e) {
-    if (!fatal) return null;
-    console.error('Failed to parse API response:', result.stdout.substring(0, 200));
-    process.exit(1);
-  }
-
-  return data;
-}
-
-// --- API helper ---
-
-async function jiraFetch(path) {
-  await findJiraTab();
-  const url = _jiraBase + path;
-  const expr = `
-(async () => {
-  const r = await fetch(${JSON.stringify(url)}, { credentials: 'include' });
-  if (!r.ok) return JSON.stringify({ __error: r.status });
-  return r.text();
-})()
-  `.trim();
-  const data = await evalInJiraTab(expr);
-  if (data && data.__error) {
-    console.error(`API error ${data.__error}. Is your Jira session active?`);
-    process.exit(1);
-  }
-  return data;
+  return resp;
 }
 
 // --- Formatters ---
@@ -111,24 +73,24 @@ function stripWiki(text) {
 
 async function detect() {
   await findJiraTab();
-  console.log(`Found Jira tab: ${_jiraBase}`);
+  console.log(`Found Jira tab: ${c.cyan(_jiraBase)}`);
   console.log('Please confirm this is the correct Jira instance before proceeding.');
 }
 
 async function whoami() {
-  const data = await jiraFetch('/rest/api/2/myself');
-  console.log(`Authenticated as: ${data.displayName} (${data.emailAddress})`);
+  const data = await jiraGet('/rest/api/2/myself');
+  console.log(`Authenticated as: ${c.bold(data.displayName)} (${data.emailAddress})`);
 }
 
 async function get(key) {
-  if (!key) { console.error('Usage: jira get <issue-key>'); process.exit(1); }
-  const data = await jiraFetch(`/rest/api/2/issue/${key}`);
+  if (!key) cli.die('Usage: jira get <issue-key>');
+  const data = await jiraGet(`/rest/api/2/issue/${key}`);
   const f = data.fields;
   const out = [
-    `${data.key}: ${f.summary}`,
+    `${c.bold(data.key)}: ${f.summary}`,
     `  Type:        ${f.issuetype?.name || ''}`,
     `  Status:      ${f.status?.name || ''}`,
-    `  Assignee:    ${f.assignee?.displayName || 'Unassigned'}`,
+    `  Assignee:    ${f.assignee?.displayName || c.dim('Unassigned')}`,
     `  Reporter:    ${f.reporter?.displayName || ''}`,
     `  Created:     ${fmtDate(f.created)}`,
     `  Updated:     ${fmtDate(f.updated)}`,
@@ -140,60 +102,423 @@ async function get(key) {
   if (f.description) {
     stripWiki(f.description).split('\n').forEach(l => out.push(`    ${l}`));
   } else {
-    out.push('    (none)');
+    out.push(`    ${c.dim('(none)')}`);
   }
   console.log(out.join('\n'));
 }
 
 async function search(jql) {
-  if (!jql) { console.error('Usage: jira search "<jql>"'); process.exit(1); }
+  if (!jql) cli.die('Usage: jira search "<jql>"');
   const encoded = encodeURIComponent(jql);
-  const data = await jiraFetch(`/rest/api/2/search?jql=${encoded}&maxResults=50&fields=summary,status,assignee,issuetype`);
+  const data = await jiraGet(`/rest/api/2/search?jql=${encoded}&maxResults=50&fields=summary,status,assignee,issuetype`);
   const issues = data.issues || [];
-  console.log(`${data.total} issue(s) found (showing ${issues.length}):\n`);
+  console.log(`${c.bold(String(data.total))} issue(s) found (showing ${issues.length}):\n`);
   issues.forEach(i => {
     const status = i.fields.status?.name || '';
-    console.log(`  ${i.key}: ${i.fields.summary} [${status}]`);
+    console.log(`  ${c.cyan(i.key)}: ${i.fields.summary} ${c.dim('[' + status + ']')}`);
   });
 }
 
 async function comments(key) {
-  if (!key) { console.error('Usage: jira comments <issue-key>'); process.exit(1); }
-  const data = await jiraFetch(`/rest/api/2/issue/${key}/comment`);
+  if (!key) cli.die('Usage: jira comments <issue-key>');
+  const data = await jiraGet(`/rest/api/2/issue/${key}/comment`);
   const items = data.comments || [];
-  console.log(`Comments on ${key} (${items.length}):\n`);
-  items.forEach(c => {
-    console.log(`  [${fmtDate(c.created)}] ${c.author?.displayName || 'Unknown'}:`);
-    stripWiki(c.body).split('\n').slice(0, 20).forEach(l => console.log(`    ${l}`));
+  console.log(`Comments on ${c.bold(key)} (${items.length}):\n`);
+  items.forEach(comment => {
+    console.log(`  ${c.dim('[' + fmtDate(comment.created) + ']')} ${c.bold(comment.author?.displayName || 'Unknown')}:`);
+    stripWiki(comment.body).split('\n').slice(0, 20).forEach(l => console.log(`    ${l}`));
     console.log('');
   });
 }
 
+async function components(project) {
+  if (!project) cli.die('Usage: jira components <project-key>');
+  const resp = await jiraGetRaw(`/rest/api/2/project/${project}/components`);
+  if (!resp.ok) cli.die(`Could not fetch components for project "${project}" (${resp.status})`);
+  const items = resp.body ?? [];
+  if (!items.length) { console.log(`No components defined for ${project}.`); return; }
+  console.log(`Components for ${c.bold(project)} (${items.length}):\n`);
+  items.sort((a, b) => a.name.localeCompare(b.name))
+       .forEach(item => console.log(`  ${item.name}${item.description ? c.dim(' — ' + item.description) : ''}`));
+}
+
+async function types(project) {
+  if (!project) cli.die('Usage: jira types <project-key>');
+  // Try paginated endpoint first, fall back to classic
+  const paged = await jiraGetRaw(`/rest/api/2/issue/createmeta/${project}/issuetypes`);
+  let items;
+  if (paged.ok) {
+    items = paged.body.values ?? [];
+  } else {
+    const classic = await jiraGetRaw(`/rest/api/2/issue/createmeta?projectKeys=${project}&expand=projects.issuetypes`);
+    if (!classic.ok) cli.die(`Could not fetch issue types for project "${project}" (${classic.status})`);
+    items = classic.body.projects?.[0]?.issuetypes ?? [];
+  }
+  if (!items.length) { console.log(`No issue types found for ${project}.`); return; }
+  console.log(`Issue types for ${c.bold(project)} (${items.length}):\n`);
+  items.sort((a, b) => a.name.localeCompare(b.name))
+       .forEach(item => console.log(`  ${item.name}${item.description ? c.dim(' — ' + item.description) : ''}`));
+}
+
+async function labels(project) {
+  if (!project) cli.die('Usage: jira labels <project-key>');
+  const [projectResp, instanceResp] = await Promise.all([
+    jiraGetRaw(`/rest/api/2/search?jql=${encodeURIComponent(`project=${project} AND labels is not EMPTY`)}&maxResults=100&fields=labels`),
+    jiraGetRaw(`/rest/api/1.0/labels/suggest?query=&maxResults=100`),
+  ]);
+  if (!projectResp.ok) cli.die(`Could not fetch labels for project "${project}" (${projectResp.status})`);
+
+  const projectLabels = new Set();
+  for (const issue of projectResp.body.issues ?? []) {
+    for (const label of issue.fields.labels ?? []) projectLabels.add(label);
+  }
+
+  const instanceLabels = new Set();
+  if (instanceResp.ok) {
+    for (const s of instanceResp.body.suggestions ?? []) instanceLabels.add(s.label);
+  }
+
+  const allLabels = [...new Set([...projectLabels, ...instanceLabels])].sort();
+  if (!allLabels.length) { console.log(`No labels found.`); return; }
+
+  console.log(`Labels for ${c.bold(project)}:\n`);
+  if (projectLabels.size) {
+    console.log(c.bold(`  Used in this project (${projectLabels.size}):`));
+    [...projectLabels].sort().forEach(l => console.log(`    ${l}`));
+  }
+  const instanceOnly = allLabels.filter(l => !projectLabels.has(l));
+  if (instanceOnly.length) {
+    console.log(c.dim(`\n  Instance-wide (${instanceOnly.length}):`));
+    instanceOnly.forEach(l => console.log(c.dim(`    ${l}`)));
+  }
+}
+
+async function create(flags) {
+  const project = flags.project;
+  const issueType = flags.type;
+
+  if (!project) cli.die('--project is required (e.g. jira create --project PROJ --type Story --summary "...")');
+  if (!issueType) cli.die('--type is required (e.g. Story, Bug, Task)');
+
+  // Fetch createmeta — try multiple endpoint shapes in order:
+  //   1. Paginated (Jira Server 9+ / Data Center): GET /createmeta/{project}/issuetypes
+  //   2. Classic (Jira Server <9 / older DC):       GET /createmeta?projectKeys=…&expand=…
+  // Both return the same logical data; we normalise to { allTypes, getFields(typeId) }.
+
+  let allTypes = [];
+  let getFields; // async (typeId) => Record<fieldId, fieldMeta>
+
+  const paginatedTypesResp = await jiraGetRaw(`/rest/api/2/issue/createmeta/${project}/issuetypes`);
+
+  if (paginatedTypesResp.ok) {
+    // Shape 1 — paginated
+    allTypes = paginatedTypesResp.body.values ?? [];
+    getFields = async (typeId) => {
+      const fd = await jiraGet(`/rest/api/2/issue/createmeta/${project}/issuetypes/${typeId}`);
+      return Object.fromEntries((fd.values ?? []).map(f => [f.fieldId, f]));
+    };
+  } else {
+    // Shape 2 — classic expand
+    const classicResp = await jiraGetRaw(
+      `/rest/api/2/issue/createmeta?projectKeys=${project}&issuetypeNames=${encodeURIComponent(issueType)}&expand=projects.issuetypes.fields`
+    );
+    if (!classicResp.ok) {
+      cli.die(`Could not fetch createmeta for project "${project}" (tried both endpoint variants). Status: ${classicResp.status}`);
+    }
+    const projectMeta = classicResp.body.projects?.[0];
+    if (!projectMeta) {
+      cli.die(`Project "${project}" not found or you don't have permission to create issues there.`);
+    }
+    // Normalise classic issuetypes into the same shape
+    allTypes = projectMeta.issuetypes ?? [];
+    getFields = async (typeId) => {
+      const typeMeta = allTypes.find(t => t.id === typeId);
+      return typeMeta?.fields ?? {};
+    };
+  }
+
+  if (!allTypes.length) {
+    cli.die(`Project "${project}" not found or you don't have permission to create issues there.`);
+  }
+
+  const matchedType = allTypes.find(t => t.name.toLowerCase() === issueType.toLowerCase());
+  if (!matchedType) {
+    console.error(`Issue type "${issueType}" not found in project ${project}.`);
+    console.error(`Available types: ${allTypes.map(t => t.name).join(', ')}`);
+    process.exit(1);
+  }
+
+  const rawFields = await getFields(matchedType.id);
+  const typeMeta = { fields: rawFields };
+
+  // Build the fields object — start with what was passed
+  const fields = {
+    project: { key: project },
+    issuetype: { name: issueType },
+  };
+
+  // Map flag names to Jira field names
+  const fieldMap = {
+    summary: 'summary',
+    description: 'description',
+    assignee: 'assignee',
+    priority: 'priority',
+    labels: 'labels',
+    components: 'components',
+  };
+
+  // Attribution footer (appended to description)
+  const attribution = '\n\n----\n_Created with sliccy (ai-ecoverse/skills@0.2.5)_';
+
+  // Apply provided flags
+  if (flags.summary)     fields.summary = flags.summary;
+  if (flags.description) fields.description = flags.description + attribution;
+  else                   fields.description = attribution.trim();
+  if (flags.assignee)    fields.assignee = { name: flags.assignee };
+  if (flags.priority)    fields.priority = { name: flags.priority };
+  if (flags.labels)      fields.labels = flags.labels.split(',').map(l => l.trim());
+  if (flags.components)  fields.components = flags.components.split(',').map(n => ({ name: n.trim() }));
+
+  // Check required fields from createmeta
+  const requiredFields = Object.entries(typeMeta.fields ?? {})
+    .filter(([, v]) => v.required)
+    .map(([k, v]) => ({ id: k, name: v.name, schema: v.schema }));
+
+  const missing = [];
+  for (const req of requiredFields) {
+    const id = req.id;
+    // 'summary' maps directly; others need checking
+    if (id === 'summary' && !fields.summary) {
+      missing.push(req);
+    } else if (id === 'issuetype' || id === 'project') {
+      // already set
+    } else if (!(id in fields)) {
+      // Check if a flag alias covered it
+      const aliasKey = Object.entries(fieldMap).find(([, v]) => v === id)?.[0];
+      if (aliasKey && flags[aliasKey]) {
+        // covered
+      } else {
+        missing.push(req);
+      }
+    }
+  }
+
+  if (missing.length > 0) {
+    // For fields with a known allowed-values list (components, priority, etc.),
+    // try to help the user pick rather than just failing.
+    const unresolved = [];
+
+    for (const req of missing) {
+      const fieldMeta = typeMeta.fields[req.id];
+
+      if (req.id === 'components') {
+        // Fetch project components and suggest likely matches
+        const compResp = await jiraGetRaw(`/rest/api/2/project/${project}/components`);
+        const allComponents = compResp.ok ? (compResp.body ?? []) : [];
+        const names = allComponents.map(c => c.name);
+
+        if (names.length === 0) {
+          unresolved.push(req);
+          continue;
+        }
+
+        // Score components against summary + description for likely candidates
+        const text = ((fields.summary || '') + ' ' + (fields.description || '')).toLowerCase();
+        const scored = names.map(name => {
+          const words = name.toLowerCase().split(/\W+/);
+          const score = words.reduce((n, w) => n + (w.length > 2 && text.includes(w) ? 1 : 0), 0);
+          return { name, score };
+        }).sort((a, b) => b.score - a.score);
+
+        const suggestions = scored.filter(s => s.score > 0);
+        const others = scored.filter(s => s.score === 0);
+
+        console.log(c.yellow(`\nRequired: Component/s`));
+        console.log('Available components for this project:\n');
+        if (suggestions.length) {
+          console.log(c.bold('  Likely matches (based on issue content):'));
+          suggestions.forEach((s, i) => console.log(`    ${c.cyan(String(i + 1))}. ${s.name}`));
+          if (others.length) {
+            console.log(c.dim('\n  Other components:'));
+            others.forEach((s, i) => console.log(c.dim(`    ${i + suggestions.length + 1}. ${s.name}`)));
+          }
+        } else {
+          names.forEach((name, i) => console.log(`    ${c.cyan(String(i + 1))}. ${name}`));
+        }
+
+        const allOrdered = [...suggestions.map(s => s.name), ...others.map(s => s.name)];
+        console.log('');
+        console.error('\nRe-run with: --components "<name>"');
+        process.exit(1);
+
+      } else if (fieldMeta?.allowedValues?.length) {
+        // Generic allowed-values prompt for other required fields
+        const values = fieldMeta.allowedValues.map(v => v.name ?? v.value ?? v.id);
+        console.error(c.yellow(`\nRequired: ${req.name}`));
+        values.forEach((v, i) => console.error(`  ${c.cyan(String(i + 1))}. ${v}`));
+        console.error(`\nRe-run with: --field-${req.id} "<value>"`);
+        process.exit(1);
+
+      } else {
+        unresolved.push(req);
+      }
+    }
+
+    if (unresolved.length > 0) {
+      console.error(c.red('\nStill missing required fields:\n'));
+      unresolved.forEach(f => {
+        const hint = f.schema?.type ? ` (${f.schema.type})` : '';
+        console.error(`  ${c.bold(f.name)}${c.dim(hint)}  →  pass as --${f.id.replace(/customfield_/, 'cf-')}`);
+      });
+      console.error('');
+      console.error('Re-run with the missing fields. For custom fields, use --cf-NNNNN or pass the raw field ID via --field-<id>=<value>.');
+      process.exit(1);
+    }
+  }
+
+  // Always surface label options if not supplied — optional but useful.
+  // Pass --no-labels to explicitly skip.
+  if (!flags.labels && !flags['no-labels']) {
+    // Fetch two sources and merge:
+    //   1. Instance-wide label suggest (broad universe, up to 100)
+    //   2. Labels already used in this project (used to boost weight)
+    const [instanceResp, projectResp] = await Promise.all([
+      jiraGetRaw(`/rest/api/1.0/labels/suggest?query=&maxResults=100`),
+      jiraGetRaw(`/rest/api/2/search?jql=${encodeURIComponent(`project=${project} AND labels is not EMPTY`)}&maxResults=100&fields=labels`),
+    ]);
+
+    const projectLabels = new Set();
+    if (projectResp.ok) {
+      for (const issue of projectResp.body.issues ?? []) {
+        for (const label of issue.fields.labels ?? []) projectLabels.add(label);
+      }
+    }
+
+    const allLabels = new Set(projectLabels);
+    if (instanceResp.ok) {
+      for (const s of instanceResp.body.suggestions ?? []) allLabels.add(s.label);
+    }
+
+    const knownLabels = [...allLabels].sort();
+
+    if (knownLabels.length) {
+      const text = ((fields.summary || '') + ' ' + (fields.description || '')).toLowerCase();
+      const scored = knownLabels.map(name => {
+        const words = name.toLowerCase().split(/\W+/);
+        const contentScore = words.reduce((n, w) => n + (w.length > 2 && text.includes(w) ? 1 : 0), 0);
+        const projectBoost = projectLabels.has(name) ? 2 : 0; // labels used in this project rank higher
+        return { name, score: contentScore + projectBoost, inProject: projectLabels.has(name) };
+      }).sort((a, b) => b.score - a.score);
+
+      const suggestions = scored.filter(s => s.score > 0);
+      const others = scored.filter(s => s.score === 0);
+
+      console.log(c.yellow('\nOptional: Labels'));
+      console.log('Labels in use in this project:\n');
+      if (suggestions.length) {
+        console.log(c.bold('  Likely matches:'));
+        suggestions.forEach((s, i) => console.log(`    ${c.cyan(String(i + 1))}. ${s.name}${s.inProject ? c.dim(' (used in project)') : ''}`));
+        if (others.length) {
+          console.log(c.dim('\n  Other labels:'));
+          others.forEach((s, i) => console.log(c.dim(`    ${i + suggestions.length + 1}. ${s.name}${s.inProject ? ' (used in project)' : ''}`)));
+        }
+      } else {
+        scored.forEach((s, i) => console.log(`    ${c.cyan(String(i + 1))}. ${s.name}${s.inProject ? c.dim(' (used in project)') : ''}`));
+      }
+
+      console.log(c.dim('\nRe-run with --labels "<name>,<name>" to set labels, or --no-labels to skip.'));
+      process.exit(1);
+    }
+  }
+
+  // Handle raw --field-<id>=<value> overrides for custom fields
+  for (const [k, v] of Object.entries(flags)) {
+    if (k.startsWith('field-')) {
+      fields[k.slice(6)] = v;
+    } else if (k.startsWith('cf-')) {
+      fields[`customfield_${k.slice(3)}`] = v;
+    }
+  }
+
+  // Dry-run: show what would be posted without sending
+  if (flags['dry-run'] || flags['dry_run'] || flags.dry) {
+    console.log(c.yellow('Dry run — would POST to /rest/api/2/issue:'));
+    console.log(JSON.stringify({ fields }, null, 2));
+    process.exit(0);
+  }
+
+  // POST the new issue
+  const resp = await jiraPost('/rest/api/2/issue', { fields });
+
+  if (!resp.ok) {
+    const body = resp.body;
+    const errors = body?.errors ? Object.entries(body.errors).map(([k, v]) => `  ${k}: ${v}`).join('\n') : '';
+    const messages = body?.errorMessages?.join('\n  ') ?? '';
+    console.error(c.red(`Failed to create issue (${resp.status}):`));
+    if (errors)   console.error(errors);
+    if (messages) console.error('  ' + messages);
+    process.exit(1);
+  }
+
+  const created = resp.body;
+  console.log(`${c.green('✓')} Created ${c.bold(created.key)}: ${_jiraBase}/browse/${created.key}`);
+}
+
 // --- Main ---
 
-const rawArgs = process.argv.slice(2);
-const [cmd, ...cmdArgs] = rawArgs;
+const { positional, flags } = process.argv.parseFlags();
+const [cmd] = positional;
+
+const HELP = `
+Jira CLI — interact with Jira via the browser SSO session.
+
+Usage: jira <command> [args]
+
+Commands:
+  detect                         Find the Jira tab and confirm the instance URL
+  whoami                         Verify auth — prints logged-in user
+  get <issue-key>                Fetch a single issue with full detail
+  search "<jql>"                 Run a JQL query (up to 50 results)
+  comments <issue-key>           Fetch all comments on an issue
+  components <project-key>       List all components defined in a project
+  types <project-key>            List all issue types available in a project
+  labels <project-key>           List all labels in use in a project
+  create                         Create a new issue (discovers required fields automatically)
+
+create flags:
+  --project  <key>               Project key (required)
+  --type     <name>              Issue type name (required, e.g. Story, Bug, Task)
+  --summary  <text>              Issue summary (required for most types)
+  --description <text>           Issue description
+  --assignee <username>          Assignee username
+  --priority <name>              Priority name (e.g. High, Medium, Low)
+  --labels   <a,b,c>             Comma-separated labels
+  --components <a,b>             Comma-separated component names
+  --cf-NNNNN <value>             Set a custom field by numeric ID (e.g. --cf-10014 sprint-1)
+  --field-<id> <value>           Set any field by its raw Jira field ID
+
+Notes:
+  - Run 'jira create --project PROJ --type Story' with no --summary to see
+    all required fields for that project + type before committing.
+  - Required fields vary per project and issue type; the command fetches
+    createmeta automatically and reports what's missing.
+`.trim();
 
 if (!cmd || cmd === 'help' || cmd === '--help') {
-  console.log('Jira CLI — interact with Jira via the browser SSO session.\n');
-  console.log('Usage: jira <command> [args]\n');
-  console.log('Commands:');
-  console.log('  detect                        Find the Jira tab and confirm the instance URL');
-  console.log('  whoami                        Verify auth — prints logged-in user');
-  console.log('  get <issue-key>               Fetch a single issue with full detail');
-  console.log('  search "<jql>"                Run a JQL query (up to 50 results)');
-  console.log('  comments <issue-key>          Fetch all comments on an issue');
+  console.log(HELP);
   process.exit(0);
 }
 
 switch (cmd) {
-  case 'detect':   await detect(); break;
-  case 'whoami':   await whoami(); break;
-  case 'get':      await get(cmdArgs[0]); break;
-  case 'search':   await search(cmdArgs.join(' ')); break;
-  case 'comments': await comments(cmdArgs[0]); break;
+  case 'detect':     await detect(); break;
+  case 'whoami':     await whoami(); break;
+  case 'get':        await get(positional[1]); break;
+  case 'search':     await search(positional.slice(1).join(' ') || flags._); break;
+  case 'comments':   await comments(positional[1]); break;
+  case 'components': await components(positional[1]); break;
+  case 'types':      await types(positional[1]); break;
+  case 'labels':     await labels(positional[1]); break;
+  case 'create':     await create(flags); break;
   default:
-    console.error(`Unknown command: ${cmd}`);
-    console.error('Run "jira help" for usage.');
-    process.exit(1);
+    cli.die(`Unknown command: ${cmd}\nRun "jira help" for usage.`);
 }


### PR DESCRIPTION
## Summary

Adds `jira create` to the Jira skill, plus three supporting commands (`components`, `types`, `labels`) and a general modernization of the script to use current runtime extensions.

## New commands

- **`jira create`** — creates a new issue with automatic required-field discovery via `createmeta`. Handles both the paginated endpoint (Jira Server 9+ / Data Center) and the classic expand endpoint, normalizing both into the same flow.
- **`jira components <project>`** — lists all components defined in a project, with descriptions
- **`jira types <project>`** — lists all issue types available in a project
- **`jira labels <project>`** — lists labels in two tiers: used in the project (boosted) and instance-wide

## How `jira create` works

1. Fetches `createmeta` for the given project + issue type to discover required fields
2. If required fields are missing from the provided flags, prints the full list of available values (fetched live from the API) and exits with the exact flag to add — no guessing
3. If `--components` or `--labels` are omitted, fetches the available options and surfaces them with relevance scoring against the issue summary and description, weighted by prior use in the project
4. Appends a `Created with sliccy` attribution footer to the description
5. `--dry-run` flag prints the full JSON payload without posting

## Modernization

Ported the existing read commands (`get`, `search`, `comments`, `detect`, `whoami`) from the legacy `playwright-cli eval-file` temp-file pattern to `browser.findTab` + `browser.fetch`. Replaced the hand-rolled arg parser with `process.argv.parseFlags()` and `cli`/`c` globals throughout.

## Flags

| Flag | Description |
|---|---|
| `--project <key>` | Project key (required) |
| `--type <name>` | Issue type name (required) |
| `--summary <text>` | Issue summary |
| `--description <text>` | Issue description (Jira wiki markup accepted) |
| `--assignee <username>` | Assignee username |
| `--priority <name>` | Priority name |
| `--labels <a,b,c>` | Comma-separated labels |
| `--components <a,b>` | Comma-separated component names |
| `--cf-NNNNN <value>` | Custom field by numeric ID |
| `--field-<id> <value>` | Any field by raw Jira field ID |
| `--dry-run` | Print payload without posting |
| `--no-labels` | Skip the label suggestion step |