### PR TITLE
fix(linkedin): handle unquoted JSESSIONID cookie format

### DIFF
--- a/skills/linkedin/scripts/linkedin.jsh
+++ b/skills/linkedin/scripts/linkedin.jsh
@@ -129,8 +129,20 @@ async function getCsrfToken(tabId) {
     process.exit(1);
   }
   var raw = r.stdout.trim();
-  var match = raw.match(/JSESSIONID="([^"]+)"/);
-  var token = match ? match[1] : raw.replace(/^"|"$/g, '');
+  // Cookie may come back as JSESSIONID="ajax:..." (quoted, legacy format) or
+  // JSESSIONID=ajax:...\tDomain=...\tPath=... (unquoted, tab-separated metadata)
+  var token = '';
+  var quoted = raw.match(/JSESSIONID="([^"]+)"/);
+  if (quoted) {
+    token = quoted[1];
+  } else {
+    var unquoted = raw.match(/JSESSIONID=([^\t\r\n;]+)/);
+    if (unquoted) {
+      token = unquoted[1].replace(/^"|"$/g, '');
+    } else {
+      token = raw.replace(/^"|"$/g, '');
+    }
+  }
   if (!token || token === 'undefined') {
     console.error('No JSESSIONID cookie found. Please log into LinkedIn in your browser.');
     process.exit(1);


### PR DESCRIPTION
The `linkedin` skill started returning `Auth failed (403)` for every Voyager API call today on at least one SLICC instance. Root cause: LinkedIn's `JSESSIONID` cookie is now returned by `playwright-cli cookie-get` without surrounding double quotes, in tab-separated metadata form:

```
JSESSIONID=ajax:2755595661793862308	Domain=.www.linkedin.com	Path=/	Secure=true	HttpOnly=false	Expires=-1
```

The previous `getCsrfToken()` regex matched only the legacy quoted form (`JSESSIONID="ajax:..."`), so on the unquoted form the match fell through to `raw.replace(/^"|"$/g, '')`, which used the entire multi-line stdout as the CSRF token â instantly tripping LinkedIn's anti-CSRF check.

This patch keeps the legacy quoted regex as the first branch, then adds an unquoted fallback that takes the value up to the first tab/newline/semicolon, and only falls back to the strip-edges behavior if neither pattern matches. No call sites change; behavior on browsers still emitting the quoted form is unchanged.

### Verification

After applying the patch locally, `linkedin list --limit 5` returned the expected JSON (5 posts with engagement data) on a tab where `cookie-get JSESSIONID --tab=...` emits the unquoted form. Auth-failure path unchanged when no cookie is present (`token === ''` still triggers the "Please log into LinkedIn" exit).

### Files changed

- `skills/linkedin/scripts/linkedin.jsh` â `getCsrfToken()` parser only.