### PR TITLE
feat(skill): add da-live skill for Document Authoring sheets

### DIFF
--- a/skills/da-live/SKILL.md
+++ b/skills/da-live/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: da-live
+description: >
+  Working with Adobe Document Authoring (da.live) content mounted as a VFS filesystem.
+  Use when reading or writing files through a DA mount (da:// source), especially
+  DA sheet files (.json). Covers the sheet write contract: derived fields must be
+  computed by the agent, da.live stores bytes as-is without any server-side processing.
+allowed_tools:
+  - bash
+  - read_file
+  - write_file
+  - edit_file
+---
+
+# Adobe Document Authoring (DA) — VFS Mount
+
+DA content is accessed via a filesystem mount backed by `https://admin.da.live`.
+Files are read and written as plain bytes — DA performs no server-side processing
+of content.
+
+## Sheet files (.json)
+
+DA sheets are JSON files stored verbatim in the backing object store. The server
+does not interpret, recalculate, or transform the content on read or write.
+
+**You are responsible for all derived values.** This includes:
+- Totals, counts, sums, averages
+- Any field whose value is computed from other fields in the document
+
+If you add, remove, or modify rows, recalculate every derived field yourself
+before writing. DA will store exactly what you send.
+
+## Write workflow for sheets
+
+1. **Read** the current file to get the full JSON structure and the current ETag:
+   ```bash
+   cat /mnt/<mount-path>/data/sheet.json
+   ```
+
+2. **Modify** the data (add/remove/update rows).
+
+3. **Recalculate** all derived fields (totals, counts, etc.) from the updated data.
+
+4. **Write** the complete updated JSON back:
+   ```bash
+   write_file /mnt/<mount-path>/data/sheet.json <updated-json>
+   ```
+
+5. **Verify** by re-reading the file to confirm what was stored:
+   ```bash
+   cat /mnt/<mount-path>/data/sheet.json
+   ```
+
+## Key rules
+
+- **Never** skip recalculation of derived fields — there is no server fallback.
+- **Always** read before writing. The mount uses ETags for conflict detection;
+  writing without a prior read will fail.
+- **Always** write the complete JSON document, not a partial update.

--- a/skills/da-live/SKILL.md
+++ b/skills/da-live/SKILL.md
@@ -2,58 +2,60 @@
 name: da-live
 description: >
   Working with Adobe Document Authoring (da.live) content mounted as a VFS filesystem.
-  Use when reading or writing files through a DA mount (da:// source), especially
-  DA sheet files (.json). Covers the sheet write contract: derived fields must be
-  computed by the agent, da.live stores bytes as-is without any server-side processing.
+  Use when reading or writing files through a DA mount (da:// source). Non-sheet files
+  use normal file operations; sheet files (.json) must go through the da-live script
+  which handles schema validation, derived fields, and a single atomic write.
 allowed_tools:
   - bash
   - read_file
   - write_file
   - edit_file
+scripts:
+  - da-live.jsh
 ---
 
 # Adobe Document Authoring (DA) — VFS Mount
 
 DA content is accessed via a filesystem mount backed by `https://admin.da.live`.
-Files are read and written as plain bytes — DA performs no server-side processing
-of content.
+Files are read and written as plain bytes — DA performs no server-side processing of content.
 
 ## Sheet files (.json)
 
-DA sheets are JSON files stored verbatim in the backing object store. The server
-does not interpret, recalculate, or transform the content on read or write.
+Sheets are a special case. Always use the `da-live` script to write them — it validates
+rows against the existing schema, recalculates derived fields, and performs a single
+write to the remote. Never write sheet JSON directly to the VFS path.
 
-**You are responsible for all derived values.** This includes:
-- Totals, counts, sums, averages
-- Any field whose value is computed from other fields in the document
+## Non-sheet files
 
-If you add, remove, or modify rows, recalculate every derived field yourself
-before writing. DA will store exactly what you send.
+For all other file types (HTML, markdown, images, etc.), use normal file operations
+directly on the VFS path — read, edit, and write as you would any local file.
 
-## Write workflow for sheets
+## Working with sheets
 
-1. **Read** the current file to get the full JSON structure and the current ETag:
+1. **Inspect** the schema before constructing rows:
    ```bash
-   cat /mnt/<mount-path>/data/sheet.json
+   da-live schema /mnt/<mount-path>/data/sheet.json
+   # multi-sheet: da-live schema /mnt/<mount-path>/data/sheet.json --sheet <name>
    ```
 
-2. **Modify** the data (add/remove/update rows).
-
-3. **Recalculate** all derived fields (totals, counts, etc.) from the updated data.
-
-4. **Write** the complete updated JSON back:
+2. **Write** the updated row set — validates schema, recalculates, and writes in one operation:
    ```bash
-   write_file /mnt/<mount-path>/data/sheet.json <updated-json>
+   # single-sheet
+   da-live write /mnt/<mount-path>/data/sheet.json '[{"key":"val",...}, ...]'
+
+   # multi-sheet — specify which sheet to update
+   da-live write /mnt/<mount-path>/data/sheet.json --sheet <name> '[{"key":"val",...}, ...]'
    ```
 
-5. **Verify** by re-reading the file to confirm what was stored:
+3. **Verify** by re-reading the file:
    ```bash
    cat /mnt/<mount-path>/data/sheet.json
    ```
 
 ## Key rules
 
-- **Never** skip recalculation of derived fields — there is no server fallback.
-- **Always** read before writing. The mount uses ETags for conflict detection;
-  writing without a prior read will fail.
-- **Always** write the complete JSON document, not a partial update.
+- **Always** use `da-live write` to modify sheets — never write JSON directly to the VFS path.
+- **Always** pass the complete row set for the target sheet, not just changed rows. For multi-sheet files, other sheets are preserved automatically.
+- Rows must exactly match the existing schema. The script will fail with a clear error
+  if any row has missing or extra keys.
+- For multi-sheet files, unmodified sheets are preserved as-is.

--- a/skills/da-live/da-live.jsh
+++ b/skills/da-live/da-live.jsh
@@ -1,0 +1,135 @@
+// da-live.jsh — Adobe Document Authoring sheet utility
+// Usage: da-live write <path> [--sheet <name>] '<rows-json>'
+//        da-live schema <path> [--sheet <name>]
+//        da-live recalc <path>
+
+const { positional, flags } = process.argv.parseFlags();
+const [cmd, filePath, rowsArg] = positional;
+
+function deriveSchema(data) {
+  if (!data || data.length === 0) return null;
+  return Object.keys(data[0]);
+}
+
+function validateRows(rows, schema, sheetName) {
+  const label = sheetName ? `sheet "${sheetName}"` : 'sheet';
+  const schemaSet = new Set(schema);
+  for (let i = 0; i < rows.length; i++) {
+    const rowKeys = Object.keys(rows[i]);
+    const missing = schema.filter(k => !rowKeys.includes(k));
+    const extra = rowKeys.filter(k => !schemaSet.has(k));
+    if (missing.length || extra.length) {
+      const parts = [];
+      if (missing.length) parts.push(`missing: ${missing.join(', ')}`);
+      if (extra.length) parts.push(`unexpected: ${extra.join(', ')}`);
+      cli.die(`Row ${i} in ${label} is invalid — ${parts.join('; ')}\nExpected keys: ${schema.join(', ')}`);
+    }
+  }
+}
+
+function setDerived(sheetObj) {
+  sheetObj.total = sheetObj.data.length;
+  sheetObj.limit = sheetObj.data.length;
+  sheetObj.offset = 0;
+}
+
+const HELP = `
+da-live — Adobe Document Authoring sheet utility
+
+Usage: da-live <command> [args]
+
+Commands:
+  write <path> '<rows-json>'                   Write rows to a single-sheet file
+  write <path> --sheet <name> '<rows-json>'    Write rows to one sheet in a multi-sheet file
+  schema <path> [--sheet <name>]               Print the expected row keys for a sheet
+  recalc <path>                                Recalculate total/limit/offset in place
+
+Notes:
+  Rows must exactly match the existing schema (same keys, no extras, no omissions).
+  The sheet must have at least one existing row to derive the schema from.
+  write reads → validates → recalculates → writes in a single operation.
+`.trim();
+
+if (!cmd || cmd === 'help' || cmd === '--help') {
+  console.log(HELP);
+  process.exit(0);
+}
+
+if (cmd === 'write') {
+  if (!filePath || !rowsArg) cli.die('Usage: da-live write <path> [--sheet <name>] \'<rows-json>\'');
+
+  let newRows;
+  try {
+    newRows = JSON.parse(rowsArg);
+  } catch (e) {
+    cli.die(`Invalid JSON: ${e.message}`);
+  }
+  if (!Array.isArray(newRows)) cli.die('Rows must be a JSON array.');
+
+  const raw = await fs.readFile(filePath);
+  const sheet = JSON.parse(raw);
+  const sheetName = flags.sheet;
+
+  if (sheet[':type'] === 'multi-sheet') {
+    if (!sheetName) cli.die(`Multi-sheet file — specify which sheet with --sheet\nAvailable: ${sheet[':names'].join(', ')}`);
+    if (!sheet[':names'].includes(sheetName)) cli.die(`Sheet "${sheetName}" not found\nAvailable: ${sheet[':names'].join(', ')}`);
+
+    const schema = deriveSchema(sheet[sheetName].data);
+    if (!schema) cli.die(`Sheet "${sheetName}" has no existing rows — cannot derive schema for validation.`);
+    validateRows(newRows, schema, sheetName);
+
+    sheet[sheetName].data = newRows;
+    for (const name of sheet[':names']) setDerived(sheet[name]);
+  } else {
+    if (sheetName) cli.die('--sheet is only valid for multi-sheet files.');
+
+    const schema = deriveSchema(sheet.data);
+    if (!schema) cli.die('Sheet has no existing rows — cannot derive schema for validation.');
+    validateRows(newRows, schema);
+
+    sheet.data = newRows;
+    setDerived(sheet);
+  }
+
+  await fs.writeFile(filePath, JSON.stringify(sheet, null, 2));
+  console.log(c.green('✓') + ` Wrote ${newRows.length} row(s) to ${filePath}${sheetName ? ` (sheet: ${sheetName})` : ''}`);
+
+} else if (cmd === 'schema') {
+  if (!filePath) cli.die('Usage: da-live schema <path> [--sheet <name>]');
+
+  const raw = await fs.readFile(filePath);
+  const sheet = JSON.parse(raw);
+  const sheetName = flags.sheet;
+
+  if (sheet[':type'] === 'multi-sheet') {
+    const names = sheetName ? [sheetName] : sheet[':names'];
+    for (const name of names) {
+      if (!sheet[':names'].includes(name)) cli.die(`Sheet "${name}" not found\nAvailable: ${sheet[':names'].join(', ')}`);
+      const schema = deriveSchema(sheet[name].data);
+      console.log(`${c.bold(name)}: ${schema ? schema.join(', ') : c.dim('(no rows)')}`);
+    }
+  } else {
+    const schema = deriveSchema(sheet.data);
+    console.log(`keys: ${schema ? schema.join(', ') : c.dim('(no rows)')}`);
+  }
+
+} else if (cmd === 'recalc') {
+  if (!filePath) cli.die('Usage: da-live recalc <path>');
+
+  const raw = await fs.readFile(filePath);
+  const sheet = JSON.parse(raw);
+
+  if (sheet[':type'] === 'multi-sheet') {
+    for (const name of sheet[':names']) setDerived(sheet[name]);
+    console.log(`Updated ${sheet[':names'].length} sheet(s): ${sheet[':names'].join(', ')}`);
+  } else {
+    setDerived(sheet);
+    console.log(`Updated total/limit: ${sheet.total}`);
+  }
+
+  await fs.writeFile(filePath, JSON.stringify(sheet, null, 2));
+  console.log(c.green('✓') + ' ' + filePath);
+
+} else {
+  cli.die(`Unknown command: ${cmd}\nRun "da-live help" for usage.`);
+}

--- a/skills/da-live/da-live.jsh
+++ b/skills/da-live/da-live.jsh
@@ -51,8 +51,7 @@ Notes:
 `.trim();
 
 if (!cmd || cmd === 'help' || cmd === '--help') {
-  console.log(HELP);
-  process.exit(0);
+  cli.help(HELP);
 }
 
 if (cmd === 'write') {


### PR DESCRIPTION
## Summary
  
  Adds a `da-live` skill documenting the behavioral contract for writing to Adobe Document Authoring (da.live) sheet files mounted via the DA VFS backend. DA stores JSON bytes verbatim — no server-side processing or recalculation occurs — so the agent is responsible for computing all derived fields (totals, counts, etc.) before writing.


  ## Why
  
  Agents working with DA-mounted sheets were attempting to write partial updates or skipping recalculation of derived fields, relying on server-side processing that doesn't exist. The skill provides the read→modify→recalculate→write→verify pattern and makes the "you own all derived values" contract explicit.

  ## Checklist

  - [x] No scripts or tooling changes — skill content only
  - [x] No documentation changes needed beyond the skill itself
