### PR TITLE
fix(gmail): make --search span all mail (not just inbox)

### DIFF
--- a/skills/gmail/scripts/gmail.jsh
+++ b/skills/gmail/scripts/gmail.jsh
@@ -293,9 +293,13 @@ async function cmdMail() {
   const search = flags.search || null;
   const date = flags.date || null;
 
-  // Build Gmail search query
+  // Build Gmail search query.
+  // Only scope to the inbox when the caller hasn't supplied an explicit search
+  // query — otherwise archived/labelled mail (e.g. auto-filed receipts) would be
+  // invisible. A caller who wants to restrict to the inbox can pass `in:inbox`
+  // (or `is:unread`) as part of --search.
   const queryParts = [];
-  queryParts.push('in:inbox');
+  if (!search) queryParts.push('in:inbox');
   if (unread) queryParts.push('is:unread');
   if (date) {
     const afterDate = durationToDate(date);


### PR DESCRIPTION
## Problem

`gmail mail --search "<query>"` always prepended `in:inbox` to the Gmail query, so any message that had been archived or auto-filed under a label (a very common case for receipts, notifications, etc.) was invisible to search. For example, FREENOW / Uber ride receipts that Gmail filters move out of the inbox returned zero results even though they exist.

## Fix

Only scope to `in:inbox` when the caller has **not** supplied an explicit `--search` query. When `--search` is present, the raw query is sent as-is so it spans all mail. Callers who want to restrict to the inbox can still pass `in:inbox` (or `is:unread`) inside `--search`.

The `--unread` and `--date` modifiers are unchanged.

## Testing

Verified live: `gmail mail --search "from:my.free-now.com"` returned 0 before the change and 15 matching ride receipts after, including archived ones.