### PR TITLE
feat(concur): create cash expenses + change payment type

### DIFF
--- a/skills/concur/SKILL.md
+++ b/skills/concur/SKILL.md
@@ -84,7 +84,10 @@ These hit the public-API surface at `www-us2.api.concursolutions.com/api/v3.0/*`
 
 | Command | Description |
 |---|---|
-| `concur attach-receipt <reportId> <expenseId> <localPath>` | Upload a receipt image and attach it to a specific expense entry. Auto-converts HEIC/PNG → JPEG via ImageMagick (downscaled to 2048px max, quality 85). Pass `--no-convert` to skip conversion. |
+| `concur new-expense <reportId> --type=<expenseTypeId> --date=YYYY-MM-DD --amount=NN.NN --currency=<ISO> --location=<locationId> [--vendor="..."] [--payment=CASH] [--exchange=<rate>] [--comment="..."] [--personal] [--receipt=<imageId>] [--fields='<json>']` | Create a brand-new (out-of-pocket / cash) expense line via `SaveNewExpenseEntry`/`createExpense`. `policyId` auto-resolves from the report. `--payment=CASH` = Out of Pocket, `PCCD` = Pending Card Transaction. An `exchangeRate` is always sent (defaults to 1.0 for same-currency; pass `--exchange` for a foreign currency, e.g. GBP→EUR `1.1555`). Many policies require extra required fields — pass them via `--fields '<json>'` (e.g. `custom8`/`custom24` list items, `taxRateLocation`, `receiptTypeId`). Note: for non-meal types (e.g. transport `TAXIX`) set `isExpensePartOfTravelAllowance:false` in `--fields`; meals/lodging policies may want it true. Returns the new `expenseId`. |
+| `concur set-payment <reportId> <expenseId> <CASH\|PCCD> [--comment="..."]` | Change an existing entry's payment type via `UpdateExistingExpenseEntry` (e.g. flip Corporate Card → Out of Pocket). `policyId` auto-resolves. |
+| `concur payment-types` | List the payment types available to the report owner (`GetPaymentTypes`). `CASH`="Out of Pocket", `PCCD`="Pending Card Transaction". |
+| `concur attach-receipt <reportId> <expenseId> <localPath>` | Upload a receipt image and attach it to a specific expense entry. Auto-converts HEIC/PNG → JPEG via ImageMagick (downscaled to 2048px max, quality 85). Pass `--no-convert` to skip conversion. (PDF attach needs ghostscript; attach a rendered image if unavailable.) |
 | `concur submit <reportId> [--source=WEB] [--approver-validated]` | Two-step submit: runs server validation, then commits. Returns `{validation, commit}` statuses (both should be `COMPLETED`). |
 
 ### Escape hatches

--- a/skills/concur/SKILL.md
+++ b/skills/concur/SKILL.md
@@ -23,6 +23,42 @@ concur reports-v3                          # full historical report list (REST v
 concur ops                                 # list every callable GraphQL operation
 ```
 
+## Workflow: build and submit an out-of-pocket expense report
+
+End-to-end sequence for filing a cash/personal expense report from scratch. Validate at each checkpoint before proceeding.
+
+```bash
+# 1. Create the report header (or reuse an existing reportId)
+concur graphql CreateReportHeader '{"userId":"<uid>","contextRole":"TRAVELER","fields":{...}}'
+#    Checkpoint: capture the returned reportId.
+
+# 2. Add each out-of-pocket line. Meals/lodging: isExpensePartOfTravelAllowance true;
+#    transport (TAXIX): false. Foreign currency needs --exchange; same-currency uses 1.0.
+concur new-expense <reportId> --type=BRKFT --date=2026-06-01 --vendor="..." \
+  --amount=39.38 --currency=GBP --location=<locationId> --payment=CASH --exchange=1.1555 \
+  --fields='{"custom8":{...},"custom24":{...},"taxRateLocation":"HOME","receiptTypeId":"R","isExpensePartOfTravelAllowance":true}'
+#    Checkpoint: each call returns the new expenseId — record it for the receipt step.
+
+# 3. Itemize entries that require it (e.g. hotel folio -> room + tax per night)
+concur itemize hotel <reportId> <hotelExpenseId> bill.json
+#    Checkpoint: sum of itemizations must equal the parent entry total.
+
+# 4. Attach a receipt image to each entry
+concur attach-receipt <reportId> <expenseId> /path/to/receipt.jpg
+
+# 5. Check exceptions — this is the submit gate
+concur exceptions <reportId>
+#    Checkpoint: hasBlockingExceptions MUST be false before submitting.
+#    Fix blocking issues (ITEMREQ -> itemize; some RECEIPT_REQUIRED -> attach-receipt) and re-check.
+
+# 6. Submit (2-step validate + commit, both must be COMPLETED)
+concur submit <reportId>
+#    Checkpoint: verify with `concur report-v3 <reportId>` (ApprovalStatusName changes from
+#    "Not Submitted" to "Pending Audit Review"/"Submitted & Pending Approval").
+```
+
+To flip an existing card transaction to personal/out-of-pocket: `concur set-payment <reportId> <expenseId> CASH`.
+
 ## Authentication
 
 Concur authenticates with cookies on `*.concursolutions.com`. SLICC's localhost-origin `fetch` cannot send those cookies, so this skill **always issues requests from the page context** of an existing Concur tab via `playwright-cli eval-file`.

--- a/skills/concur/SKILL.md
+++ b/skills/concur/SKILL.md
@@ -94,7 +94,8 @@ These hit the public-API surface at `www-us2.api.concursolutions.com/api/v3.0/*`
 
 | Command | Description |
 |---|---|
-| `concur ops` | List all 56 bundled GraphQL operations. |
+| `concur ops` | List all bundled GraphQL operations. |
+| `concur exceptions <reportId>` | Report status check: lists all validation exceptions (errors/warnings) grouped per entry, with `code`, `isBlocking`, and `message` (e.g. `ITEMREQ` "Itemizations are required", `RECEIPT_REQUIRED` "You must attach a receipt image"). Returns `hasBlockingExceptions` so you can tell if a report can be submitted. |
 | `concur graphql <opName> [<variables-json>] [spend\|cds]` | Run any captured operation verbatim. |
 | `concur tab` | Print the targetId of the Concur tab the skill is using. |
 | `concur help` | Usage + examples. |

--- a/skills/concur/references/operations/GetNewExpenseEntry.graphql
+++ b/skills/concur/references/operations/GetNewExpenseEntry.graphql
@@ -1,0 +1,287 @@
+fragment ExpenseTypeFragment on ExpenseType {
+  id
+  name
+  itemizationType
+  text
+  header
+  parentName
+  code
+  visibilityCode
+  itemizeStyle
+  shouldAddUserAsDefaultAttendee
+  allowEditAttendeeAmount
+  allowEditAttendeeCount
+  shouldDisplayAttendeeAmounts
+  itemizationWizardId
+  meta {
+    isTravelAllowanceExpense
+    canCombineExpense
+    isItemizationAllowed
+    isItemizationRequired
+    hasItemizationWizard
+    isJapanPublicTransportation
+    __typename
+  }
+  __typename
+}
+
+fragment AmountValueFragment on AmountValue {
+  amountValue: value {
+    value
+    currencyCode
+    __typename
+  }
+  __typename
+}
+
+fragment BooleanValueFragment on BooleanValue {
+  booleanValue: value
+  isValid
+  __typename
+}
+
+fragment DateValueFragment on DateValue {
+  dateValue: value
+  isValid
+  __typename
+}
+
+fragment ExchangeRateValueFragment on ExchangeRateValue {
+  value
+  operation
+  __typename
+}
+
+fragment ExpenseAmountFragment on ExpenseAmount {
+  expenseAmountValue: value
+  __typename
+}
+
+fragment FloatValueFragment on FloatValue {
+  floatValue: value
+  __typename
+}
+
+fragment IntegerValueFragment on IntegerValue {
+  integerValue: value
+  __typename
+}
+
+fragment ListItemValueFragment on ListItemValue {
+  code
+  id
+  listItemValue: value
+  __typename
+}
+
+fragment ListValueFragment on ListValue {
+  isValid
+  listValue: value {
+    code
+    id
+    value
+    __typename
+  }
+  __typename
+}
+
+fragment LocationValueFragment on LocationListValue {
+  isValid
+  locationValue: value {
+    id
+    name
+    city
+    value
+    countryCode
+    countrySubDivisionCode
+    __typename
+  }
+  __typename
+}
+
+fragment StringValueFragment on StringValue {
+  stringValue: value
+  __typename
+}
+
+fragment FormFieldFragment on FormField {
+  id
+  label
+  formFieldId
+  value {
+    ...AmountValueFragment
+    ...BooleanValueFragment
+    ...DateValueFragment
+    ...ExchangeRateValueFragment
+    ...ExpenseAmountFragment
+    ...FloatValueFragment
+    ...IntegerValueFragment
+    ...ListItemValueFragment
+    ...ListValueFragment
+    ...LocationValueFragment
+    ...StringValueFragment
+    __typename
+  }
+  accessMode
+  control
+  dataType
+  defaultValue {
+    value
+    code
+    listItemId
+    isValid
+    __typename
+  }
+  sequence
+  maximumLength
+  tooltip
+  hasLineSeparator
+  isCopyDownSource
+  itemizationCopyDownAction
+  isExternalList
+  targetFieldSettings {
+    action
+    formFieldId
+    lhsOperandSource
+    operator
+    rhsOperand
+    __typename
+  }
+  comments {
+    comment
+    creationDate
+    isLatest
+    createdForUserId
+    author {
+      first
+      last
+      preferred
+      __typename
+    }
+    __typename
+  }
+  options {
+    id
+    code
+    value
+    __typename
+  }
+  isRequired
+  list {
+    id
+    level
+    parentId
+    displayFormat
+    defaultSearchBy: searchCriteria
+    __typename
+  }
+  dataValidator {
+    validationExpression
+    failureMessage
+    __typename
+  }
+  requiredForSave
+  taxAuthorityId
+  taxFormId
+  showFieldForCountryCode
+  __typename
+}
+
+query GetNewExpenseEntry($reportId: String!, $userId: String!, $reportIdAsID: ID!, $userIdAsID: ID!, $expenseTypeId: ID!, $contextRole: ContextRoleType!, $shouldFetchExpenseForm: Boolean! = true, $expenseTypeChangeContext: ExpenseTypeChangeNewExpenseContext) {
+  expenseTypeFilters(
+    userId: $userId
+    contextRole: $contextRole
+    reportId: $reportId
+  ) {
+    shouldFilterCashAdvanceExpenseTypes
+    shouldFilterCompanyCarExpenseType
+    shouldFilterPersonalCarExpenseType
+    __typename
+  }
+  vehicleRegistrationInfo {
+    hasPersonalCar
+    hasCompanyCar
+    __typename
+  }
+  employee(userId: $userId, contextRole: $contextRole) {
+    userId
+    contextRole
+    expenseReport(reportId: $reportId) {
+      reportId
+      rptKey
+      reportDetails {
+        id
+        allocationFormId
+        userId
+        policy {
+          id
+          expenseListDetailFormId
+          meta {
+            canUploadImagesToExpenses
+            canShowReceipts
+            __typename
+          }
+          __typename
+        }
+        expenseTypes {
+          ...ExpenseTypeFragment
+          __typename
+        }
+        meta {
+          isApproved
+          canReopen
+          isReopened
+          isSubmitted
+          canAddExpense
+          canAllocateExpenses
+          isReceiptImageAvailable
+          __typename
+        }
+        name
+        approvedAmount {
+          value
+          currencyCode
+          __typename
+        }
+        currencyCode
+        countryCode
+        taxConfigId
+        __typename
+      }
+      __typename
+    }
+    __typename
+  }
+  newExpenseForm(
+    dataContext: {reportId: $reportIdAsID, expenseTypeId: $expenseTypeId, expenseTypeChangeContext: $expenseTypeChangeContext}
+    userContext: {userId: $userIdAsID, contextType: $contextRole}
+  ) @include(if: $shouldFetchExpenseForm) {
+    travelRequestEntries {
+      entries {
+        id
+        value
+        __typename
+      }
+      __typename
+    }
+    mainForm {
+      attendeesLinkAccessMode
+      calculateTaxLinkAccessMode
+      fields {
+        ...FormFieldFragment
+        __typename
+      }
+      __typename
+    }
+    meta {
+      canAllocate
+      __typename
+    }
+    expenseTypeDetails {
+      quickTips
+      __typename
+    }
+    backendMileageConfigs
+    __typename
+  }
+}

--- a/skills/concur/references/operations/SaveNewExpenseEntry.graphql
+++ b/skills/concur/references/operations/SaveNewExpenseEntry.graphql
@@ -1,0 +1,607 @@
+mutation SaveNewExpenseEntry($reportId: ID!, $contextRole: ContextRoleType!, $userId: ID!, $fields: CreateExpenseFieldsInput!, $taxFields: [TaxField!] = null, $expenseTypeId: String!, $policyId: String!, $shouldIncludeRpeKey: Boolean = false, $expenseListDetailFormId: String, $isTrexEnabled: Boolean!) {
+  createExpense(
+    dataContext: {reportId: $reportId, fields: $fields, taxFields: $taxFields, expenseListDetailFormId: $expenseListDetailFormId}
+    userContext: {userId: $userId, contextType: $contextRole}
+  ) {
+    id
+    rpeKey @include(if: $shouldIncludeRpeKey)
+    reportDetails @include(if: $isTrexEnabled) {
+      ...ExpenseReportDetailsFragment
+      __typename
+    }
+    entry @include(if: $isTrexEnabled) {
+      ...EreExpenseEntrySummaryFragment
+      __typename
+    }
+    existingExpenseForm @include(if: $isTrexEnabled) {
+      ...ExistingExpenseFormFragment
+      __typename
+    }
+    entryExceptions @include(if: $isTrexEnabled) {
+      ...EreEntryExceptionsFragment
+      __typename
+    }
+    expenseTypeFilters @include(if: $isTrexEnabled) {
+      shouldFilterCashAdvanceExpenseTypes
+      shouldFilterCompanyCarExpenseType
+      shouldFilterPersonalCarExpenseType
+      __typename
+    }
+    vehicleRegistrationInfo @include(if: $isTrexEnabled) {
+      hasPersonalCar
+      hasCompanyCar
+      __typename
+    }
+    __typename
+  }
+  CDS_addRecentExpenseTypes(policyId: $policyId, expenseTypeId: $expenseTypeId)
+}
+
+fragment EreEntryExceptionsFragment on EntryExceptions {
+  reportId
+  expenseId
+  attendeesExceptionLevel
+  transactionAmount {
+    value
+    currencyCode
+    __typename
+  }
+  transactionDate
+  expenseType {
+    id
+    code
+    name
+    meta {
+      isJapanPublicTransportation
+      __typename
+    }
+    __typename
+  }
+  countOfExceptions
+  hasBlockingExceptions
+  entryExceptions {
+    allocationId
+    exceptionCode
+    expenseId
+    isBlocking
+    message
+    parameters {
+      entryExceptionAttendees {
+        lastName
+        firstName
+        entryAmount
+        crnCode
+        totalExpensed
+        totalAuthorized
+        __typename
+      }
+      missingFields {
+        missingSpecialParentField
+        fields
+        fieldIds
+        __typename
+      }
+      __typename
+    }
+    parentExpenseId
+    __typename
+  }
+  itemizationsExceptions {
+    reportId
+    expenseId
+    attendeesExceptionLevel
+    itemizationId
+    transactionAmount {
+      value
+      currencyCode
+      __typename
+    }
+    transactionDate
+    expenseType {
+      id
+      code
+      name
+      meta {
+        isJapanPublicTransportation
+        __typename
+      }
+      __typename
+    }
+    countOfExceptions
+    hasBlockingExceptions
+    exceptions {
+      allocationId
+      exceptionCode
+      expenseId
+      isBlocking
+      message
+      parameters {
+        entryExceptionAttendees {
+          lastName
+          firstName
+          entryAmount
+          crnCode
+          totalExpensed
+          totalAuthorized
+          __typename
+        }
+        missingFields {
+          missingSpecialParentField
+          fields
+          fieldIds
+          __typename
+        }
+        __typename
+      }
+      parentExpenseId
+      __typename
+    }
+    __typename
+  }
+  __typename
+}
+
+fragment ExpenseEntrySummaryFragment on ExpenseEntrySummary {
+  allocationState
+  approvedAmount {
+    value
+    currencyCode
+    __typename
+  }
+  attendeeCount
+  claimedAmount {
+    value
+    currencyCode
+    __typename
+  }
+  eReceiptImageId
+  expenseSourceIdentifiers {
+    eReceiptId
+    expenseCaptureImageId
+    jptRouteId
+    personalCardTransactionId
+    quickExpenseId
+    segmentId
+    segmentTypeId
+    tripId
+    creditCardTransaction {
+      id
+      type
+      __typename
+    }
+    __typename
+  }
+  expenseType {
+    id
+    code
+    name
+    meta {
+      isJapanPublicTransportation
+      __typename
+    }
+    __typename
+  }
+  id
+  isImageRequired
+  isPaperReceiptRequired
+  isPersonalExpense
+  jptRouteId
+  location {
+    city
+    countryCode
+    countrySubDivisionCode
+    id
+    name
+    __typename
+  }
+  meta {
+    canDelete
+    hasAffidavit
+    hasAllocation
+    hasAttendees
+    hasBlockingExceptions
+    hasComments
+    hasExceptions
+    hasItemizations
+    hasReceiptImage
+    hasSource
+    hasXmlReceipt
+    hasSourceCreditCard
+    hasSourceEReceipt
+    hasSourceItinerary
+    hasSourceExpenseIt
+    hasSourceMobile
+    hasSourcePersonalCard
+    __typename
+  }
+  parentExpenseId
+  paymentType {
+    id
+    code
+    name
+    __typename
+  }
+  receiptImageId
+  rpeKey
+  transactionAmount {
+    value
+    currencyCode
+    __typename
+  }
+  postedAmount {
+    value
+    currencyCode
+    __typename
+  }
+  transactionDate
+  vendor {
+    id
+    description
+    name
+    __typename
+  }
+  __typename
+}
+
+fragment EreExpenseEntrySummaryFragment on ExpenseEntrySummary {
+  ...ExpenseEntrySummaryFragment
+  cctReceiptImageId
+  travel {
+    hotelCheckinDate
+    hotelCheckoutDate
+    __typename
+  }
+  itemizations {
+    id
+    attendeeCount
+    allocationState
+    isPersonalExpense
+    approvedAmount {
+      value
+      currencyCode
+      __typename
+    }
+    meta {
+      canDelete
+      hasAllocation
+      hasAttendees
+      hasComments
+      hasExceptions
+      hasBlockingExceptions
+      __typename
+    }
+    expenseType {
+      id
+      code
+      name
+      __typename
+    }
+    rpeKey
+    transactionAmount {
+      value
+      currencyCode
+      __typename
+    }
+    transactionDate
+    __typename
+  }
+  __typename
+}
+
+fragment AmountValueFragment on AmountValue {
+  amountValue: value {
+    value
+    currencyCode
+    __typename
+  }
+  __typename
+}
+
+fragment BooleanValueFragment on BooleanValue {
+  booleanValue: value
+  isValid
+  __typename
+}
+
+fragment DateValueFragment on DateValue {
+  dateValue: value
+  isValid
+  __typename
+}
+
+fragment ExchangeRateValueFragment on ExchangeRateValue {
+  value
+  operation
+  __typename
+}
+
+fragment ExpenseAmountFragment on ExpenseAmount {
+  expenseAmountValue: value
+  __typename
+}
+
+fragment FloatValueFragment on FloatValue {
+  floatValue: value
+  __typename
+}
+
+fragment IntegerValueFragment on IntegerValue {
+  integerValue: value
+  __typename
+}
+
+fragment ListItemValueFragment on ListItemValue {
+  code
+  id
+  listItemValue: value
+  __typename
+}
+
+fragment ListValueFragment on ListValue {
+  isValid
+  listValue: value {
+    code
+    id
+    value
+    __typename
+  }
+  __typename
+}
+
+fragment LocationValueFragment on LocationListValue {
+  isValid
+  locationValue: value {
+    id
+    name
+    city
+    value
+    countryCode
+    countrySubDivisionCode
+    __typename
+  }
+  __typename
+}
+
+fragment StringValueFragment on StringValue {
+  stringValue: value
+  __typename
+}
+
+fragment FormFieldFragment on FormField {
+  id
+  label
+  formFieldId
+  value {
+    ...AmountValueFragment
+    ...BooleanValueFragment
+    ...DateValueFragment
+    ...ExchangeRateValueFragment
+    ...ExpenseAmountFragment
+    ...FloatValueFragment
+    ...IntegerValueFragment
+    ...ListItemValueFragment
+    ...ListValueFragment
+    ...LocationValueFragment
+    ...StringValueFragment
+    __typename
+  }
+  accessMode
+  control
+  dataType
+  defaultValue {
+    value
+    code
+    listItemId
+    isValid
+    __typename
+  }
+  sequence
+  maximumLength
+  tooltip
+  hasLineSeparator
+  isCopyDownSource
+  itemizationCopyDownAction
+  isExternalList
+  targetFieldSettings {
+    action
+    formFieldId
+    lhsOperandSource
+    operator
+    rhsOperand
+    __typename
+  }
+  comments {
+    comment
+    creationDate
+    isLatest
+    createdForUserId
+    author {
+      first
+      last
+      preferred
+      __typename
+    }
+    __typename
+  }
+  options {
+    id
+    code
+    value
+    __typename
+  }
+  isRequired
+  list {
+    id
+    level
+    parentId
+    displayFormat
+    defaultSearchBy: searchCriteria
+    __typename
+  }
+  dataValidator {
+    validationExpression
+    failureMessage
+    __typename
+  }
+  requiredForSave
+  taxAuthorityId
+  taxFormId
+  showFieldForCountryCode
+  __typename
+}
+
+fragment JptRouteSummaryFragment on JptRouteSummary {
+  assignment
+  companyId
+  creationDateTime
+  currencyCode
+  distanceUnit
+  documentId
+  entryId
+  eReceiptId
+  fromLocation
+  hasCommuterPassDeduction
+  hasIcCard
+  id
+  isCheap
+  isEasy
+  isFast
+  isExpress
+  isIcTicket
+  isLegacyData
+  isRoundTrip
+  lastModifiedDateTime
+  originType
+  routeUUID
+  seatType
+  toLocation
+  totalAdditionalAmount
+  totalAmount
+  totalDistance
+  transactionDate
+  transactionId
+  userId
+  __typename
+}
+
+fragment ExistingExpenseFormFragment on ExistingExpenseForm {
+  expenseId
+  expenseTypeId
+  travelRequestEntries {
+    entries {
+      id
+      value
+      __typename
+    }
+    __typename
+  }
+  mainForm {
+    attendeesLinkAccessMode
+    calculateTaxLinkAccessMode
+    fields {
+      ...FormFieldFragment
+      __typename
+    }
+    isFormEditable
+    __typename
+  }
+  meta {
+    canAllocate
+    canDelete
+    hasMixedAllocations
+    hasXmlReceipt
+    __typename
+  }
+  backendMileageConfigs
+  expenseTypeDetails {
+    expenseTypeId
+    quickTips
+    __typename
+  }
+  jptRouteSummary {
+    ...JptRouteSummaryFragment
+    __typename
+  }
+  __typename
+}
+
+fragment ExpenseTypeFragment on ExpenseType {
+  id
+  name
+  itemizationType
+  text
+  header
+  parentName
+  code
+  visibilityCode
+  itemizeStyle
+  shouldAddUserAsDefaultAttendee
+  allowEditAttendeeAmount
+  allowEditAttendeeCount
+  shouldDisplayAttendeeAmounts
+  itemizationWizardId
+  meta {
+    isTravelAllowanceExpense
+    canCombineExpense
+    isItemizationAllowed
+    isItemizationRequired
+    hasItemizationWizard
+    isJapanPublicTransportation
+    __typename
+  }
+  __typename
+}
+
+fragment ExpenseReportDetailsFragment on ExpenseReportDetails {
+  id
+  allocationFormId
+  reportType
+  userId
+  policy {
+    id
+    allowReceiptAffidavits
+    receiptAffidavitExplanation
+    receiptAffidavitAcceptance
+    expenseListDetailFormId
+    meta {
+      canShowReceipts
+      canUploadImagesToExpenses
+      __typename
+    }
+    __typename
+  }
+  expenseTypes {
+    ...ExpenseTypeFragment
+    __typename
+  }
+  meta {
+    isApproved
+    canReopen
+    isReopened
+    isSubmitted
+    canAddExpense
+    canAllocateExpenses
+    isReceiptImageAvailable
+    __typename
+  }
+  name
+  claimedAmount {
+    value
+    currencyCode
+    __typename
+  }
+  approvedAmount {
+    value
+    currencyCode
+    __typename
+  }
+  reportTotal {
+    value
+    currencyCode
+    __typename
+  }
+  currencyCode
+  countryCode
+  taxConfigId
+  __typename
+}

--- a/skills/concur/scripts/concur.jsh
+++ b/skills/concur/scripts/concur.jsh
@@ -1049,6 +1049,56 @@ const commands = {
     return { count: list.length, operations: list };
   },
 
+  // Report status + all validation exceptions (error/warning messages) for a
+  // report. Surfaces blocking issues like ITEMREQ ("Itemizations are required")
+  // and RECEIPT_REQUIRED ("You must attach a receipt image"), grouped per entry.
+  // Usage: concur exceptions <reportId>
+  async exceptions(reportId) {
+    if (!reportId) { console.error('Usage: concur exceptions <reportId>'); process.exit(1); }
+    const userId = await getUserId();
+    const data = await callOp('GetReportExceptionsAndEntries', {
+      userId, contextRole: 'TRAVELER', reportId,
+      expenseListDetailFormId: null, includeDetailItemizations: false,
+    });
+    const meta = {};
+    for (const e of (data?.reportEntriesDetails?.entries || [])) {
+      const s = e.summary || {};
+      meta[e.expenseId] = {
+        expenseType: s.expenseType?.name,
+        vendor: s.vendor?.description || s.vendor?.name,
+      };
+    }
+    const seen = new Set();
+    const exById = {};
+    const headerEx = [];
+    (function walk(o) {
+      if (Array.isArray(o)) { o.forEach(walk); return; }
+      if (o && typeof o === 'object') {
+        if (o.exceptionCode && o.message) {
+          const key = (o.expenseId || 'HEADER') + '|' + o.exceptionCode + '|' + o.message;
+          if (!seen.has(key)) {
+            seen.add(key);
+            const rec = { code: o.exceptionCode, isBlocking: !!o.isBlocking, message: o.message };
+            if (o.expenseId) (exById[o.expenseId] = exById[o.expenseId] || []).push(rec);
+            else headerEx.push(rec);
+          }
+        }
+        for (const k in o) walk(o[k]);
+      }
+    })(data);
+    const entries = Object.keys(exById).map(id => ({
+      expenseId: id, ...(meta[id] || {}), exceptions: exById[id],
+    }));
+    const allBlocking = [...headerEx, ...entries.flatMap(e => e.exceptions)].some(x => x.isBlocking);
+    return {
+      reportId,
+      hasBlockingExceptions: allBlocking,
+      totalExceptions: headerEx.length + entries.reduce((n, e) => n + e.exceptions.length, 0),
+      headerExceptions: headerEx,
+      entryExceptions: entries,
+    };
+  },
+
   // List the payment types available to the report owner.
   // CASH = "Out of Pocket", PCCD = "Pending Card Transaction".
   async 'payment-types'() {

--- a/skills/concur/scripts/concur.jsh
+++ b/skills/concur/scripts/concur.jsh
@@ -209,6 +209,20 @@ async function callOp(opName, variables = {}, surface = 'spend') {
   return graphql(surface, { operationName: opName, query, variables });
 }
 
+// Resolve a report's policyId (needed by create/update expense mutations).
+async function getReportPolicyId(reportId) {
+  const userId = await getUserId();
+  const data = await callOp('GetReportPageData', {
+    reportId, includeSummary: true, includePolicy: true, includeEntries: false,
+    includeExceptions: false, includeGroupSettings: false, includeSiteSettings: false,
+    includeWorkflows: false, includeCostObjects: false, userId, contextRole: 'TRAVELER',
+    includeDetailItemizations: false, shouldChangeWarningAlertsToInformation: false,
+  });
+  const m = JSON.stringify(data || {}).match(/"policyId":"([^"]+)"/);
+  if (!m) throw new Error(`Could not resolve policyId for report ${reportId}`);
+  return m[1];
+}
+
 // Lookup a single report's status in the user's report list.
 // Returns { reportId, name, approvalStatus, approvalStatusId, isLocked, ... }
 // where isLocked === true means the report rejects mutations (Approved,
@@ -1033,6 +1047,79 @@ const commands = {
     const r = await exec(`ls ${OPS_DIR}`);
     const list = r.stdout.split('\n').filter(Boolean).map(s => s.replace(/\.graphql$/, ''));
     return { count: list.length, operations: list };
+  },
+
+  // List the payment types available to the report owner.
+  // CASH = "Out of Pocket", PCCD = "Pending Card Transaction".
+  async 'payment-types'() {
+    const userId = await getUserId();
+    return await callOp('GetPaymentTypes', { reportOwnerUserId: userId });
+  },
+
+  // Change an existing entry's payment type (e.g. Corporate Card -> Out of Pocket).
+  // Usage: concur set-payment <reportId> <expenseId> <CASH|PCCD> [--comment="..."] [--policy=<id>]
+  async 'set-payment'(reportId, expenseId, paymentTypeId, ...rest) {
+    if (!reportId || !expenseId || !paymentTypeId) {
+      console.error('Usage: concur set-payment <reportId> <expenseId> <CASH|PCCD> [--comment="..."]');
+      console.error('  CASH = Out of Pocket, PCCD = Pending Card Transaction');
+      process.exit(1);
+    }
+    const flags = parseFlags(rest, {});
+    const userId = await getUserId();
+    const policyId = flags.policy || await getReportPolicyId(reportId);
+    const fields = { paymentTypeId };
+    if (flags.comment) fields.comment = flags.comment;
+    return await callOp('UpdateExistingExpenseEntry', {
+      taxFields: null, userId, contextRole: 'TRAVELER', isTrexEnabled: true,
+      reportId, expenseId, shouldCopyDownFields: false, fields,
+      expenseTypeId: '', policyId, updateRecentExpenseType: false, expenseListDetailFormId: null,
+    });
+  },
+
+  // Create a brand-new (out-of-pocket / cash) expense line on a report.
+  // Usage: concur new-expense <reportId> --type=<expenseTypeId> --date=YYYY-MM-DD \
+  //          --amount=NN.NN --currency=GBP --location=<locationId> [--vendor="..."] \
+  //          [--payment=CASH] [--exchange=1.1555] [--comment="..."] [--personal] \
+  //          [--receipt=<imageId>] [--fields='<extra-json>']
+  // policyId auto-resolves from the report. Some policies require extra required
+  // fields (e.g. custom8/custom24) — pass them via --fields '<json>'.
+  async 'new-expense'(reportId, ...rest) {
+    if (!reportId) {
+      console.error('Usage: concur new-expense <reportId> --type=<expenseTypeId> --date=YYYY-MM-DD --amount=NN.NN --currency=GBP --location=<locationId> [--vendor="..."] [--payment=CASH] [--exchange=1.1555] [--comment="..."] [--personal] [--receipt=<imageId>] [--fields=\'<extra-json>\']');
+      process.exit(1);
+    }
+    const flags = parseFlags(rest, { payment: 'CASH', currency: 'EUR' });
+    if (!flags.type || !flags.date || !flags.amount || !flags.location) {
+      console.error('new-expense requires --type, --date, --amount and --location');
+      process.exit(1);
+    }
+    const userId = await getUserId();
+    const policyId = flags.policy || await getReportPolicyId(reportId);
+    const fields = {
+      expenseTypeId: flags.type,
+      transactionDate: flags.date,
+      paymentTypeId: flags.payment,
+      transactionAmount: { value: Number(flags.amount), currencyCode: flags.currency },
+      locationId: flags.location,
+      isPersonalExpense: flags.personal === true || flags.personal === 'true',
+    };
+    if (flags.vendor) fields.vendorName = flags.vendor;
+    // Concur always expects an exchangeRate. For a same-currency (home) expense
+    // it must be 1.0; for a foreign currency pass the real rate via --exchange.
+    fields.exchangeRate = { operation: 'MULTIPLY', value: flags.exchange ? Number(flags.exchange) : 1.0 };
+    if (flags.comment) fields.comment = flags.comment;
+    if (flags.receipt) fields.receiptImageId = flags.receipt;
+    if (flags.fields) {
+      let extra; try { extra = JSON.parse(flags.fields); } catch { console.error('--fields must be valid JSON'); process.exit(1); }
+      Object.assign(fields, extra);
+    }
+    const data = await callOp('SaveNewExpenseEntry', {
+      taxFields: null, shouldIncludeRpeKey: false, userId, contextRole: 'TRAVELER',
+      isTrexEnabled: true, reportId, fields, expenseTypeId: flags.type, policyId,
+      expenseListDetailFormId: null,
+    });
+    const created = data?.createExpense || data;
+    return { expenseId: created?.id, expenseType: flags.type, amount: fields.transactionAmount, paymentTypeId: flags.payment };
   },
 
   async graphql(opName, varsJson, surface = 'spend') {


### PR DESCRIPTION
## What

Adds the ability to **create new out-of-pocket expense lines** and **change an entry's payment type** to the Concur skill — operations that were previously missing (the skill could create a report shell and move corporate-card transactions, but not add manual cash expenses).

Captured the real GraphQL operations from a live Concur session (HAR) and wired them into the CLI.

## New commands

- `concur new-expense <reportId> --type --date --amount --currency --location [--vendor --payment --exchange --comment --personal --receipt --fields]` — creates a cash/out-of-pocket expense via `SaveNewExpenseEntry` (`createExpense`). `policyId` auto-resolves from the report (`GetReportPageData`). Always sends an `exchangeRate` (defaults 1.0 same-currency; pass `--exchange` for foreign currency). Extra required policy fields (e.g. `custom8`/`custom24`, `taxRateLocation`, `receiptTypeId`) via `--fields 