### PR TITLE
feat(navan): Navan/TripActions travel skill (search, book, trips, invoice->expense)

### DIFF
--- a/skills/navan/SKILL.md
+++ b/skills/navan/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: navan
+description: >-
+  Automate Navan (formerly TripActions) corporate travel by replaying its REST
+  API — search and book flights and hotels, price itineraries, view trips, and
+  pull invoices for past bookings and push them to the expense system (Concur).
+  Use whenever the user mentions Navan, TripActions, booking a flight, booking a
+  hotel, corporate travel, a business trip, a travel itinerary, trip details, an
+  airport/city lookup for travel, a travel invoice, expensing a flight or hotel,
+  pushing a booking to Concur, or wants to check or manage their Navan trips
+  without clicking through app.navan.com. Triggers: "Navan", "TripActions",
+  "book a flight", "book a hotel", "search flights", "search hotels", "my
+  trips", "business trip", "itinerary", "corporate travel", "travel booking",
+  "travel invoice", "expense this flight/hotel", "push to Concur", "expense
+  report from travel".
+allowed-tools: bash
+---
+
+# Navan (TripActions) travel automation
+
+Search flights & hotels, price itineraries, view trips, and book — by calling
+Navan's own backend API (`https://app.navan.com/api/...`) from the logged-in
+Navan browser tab.
+
+## Command
+
+The script is `scripts/navan.jsh`; the shell command is `navan`.
+
+```
+navan whoami                       Logged-in user (name, email, user id)
+navan trips [--json]               List trips (name, dates, item counts, tripId)
+navan trip <tripId> [--json]       Trip detail: flights + hotels with bookingId / confirmation
+navan airports <query> [--json]    Airport/city autocomplete (code, name)
+
+navan flights search --from=BER --to=BSL --depart=YYYY-MM-DD [--return=YYYY-MM-DD] [--pax=1] [--cabin=ECONOMY]
+navan flights returns --search=<id> --departure=<departureId>
+navan flights price   --search=<id> --departure=<departureId> [--return=<returnId>]
+
+navan hotels search --city=Basel --checkin=YYYY-MM-DD --checkout=YYYY-MM-DD [--guests=1] [--rooms=1]
+navan hotels rooms  --search=<id> --hotel=<hotelId>
+navan hotels price  --search=<id> --hotel=<hotelId> --room=<roomId>
+
+navan book <flight|hotel> --search=<id> --contract=<id> [--confirm]
+navan help
+```
+
+```
+navan invoice <bookingId> [--download=<path>] [--json]   Invoice sync status + expense eligibility; optionally save the PDF
+navan push-expense <bookingId> [--confirm]                Push the booking + invoice to expense (Concur); gated
+```
+
+Add `--json` to any read command for machine-readable output.
+
+The `<bookingId>` used by `invoice` and `push-expense` is the **`bookingUuid`**
+shown by `navan trip <tripId>` (e.g. `6693f5ab-...`), not the airline PNR.
+
+## Authentication model (important)
+
+Navan's `/api/` endpoints are **not** plain cookie auth. Every request needs:
+
+- `Authorization: TripActions <JWT>`  — the literal scheme word `TripActions`,
+  a space, then a JWT.
+- `x-tripactions-locale: en-US`
+
+SLICC's own `fetch()` cannot carry these headers and uses a `localhost` origin,
+so **all calls run inside the logged-in Navan browser tab** via
+`playwright-cli eval-file`. The script:
+
+1. Finds the open `app.navan.com` tab (`playwright-cli tab-list`).
+2. Reads the JWT from the tab's `localStorage` — the Auth0 SPA cache key that
+   starts with `@@auth0spajs@@` holds `body.access_token`. (Fallback: any
+   localStorage value with an `access_token`, or a token captured off the app's
+   own XHR/fetch `Authorization` header.)
+3. Runs `fetch(url, { credentials:'include', headers:{ Authorization:'TripActions '+tok, 'x-tripactions-locale':'en-US' }})`
+   from the page context.
+
+If there is no Navan tab, open `https://app.navan.com` and log in. On **401/403**
+the token expired — open Navan, log in, and retry. Keep the Navan tab open.
+
+## Booking confirmation gate (spends real money)
+
+`navan book` is the only command that can spend money, and it is gated:
+
+- **Without `--confirm`** it fetches the priced contract, prints the itinerary
+  and total price, prints a message that nothing was booked, and **exits without
+  booking**.
+- **With `--confirm`** it assembles the passenger + payment data and POSTs to
+  the streaming booking endpoint, then prints `{status, bookingId,
+  confirmationNumber, tripId}` parsed from the final stream event.
+
+Always run `navan book ...` once **without** `--confirm` first, show the user the
+itinerary and total, and only re-run with `--confirm` after explicit approval.
+
+`navan push-expense` is gated the same way — it MUTATES your expense system
+(Concur). Without `--confirm` it prints eligibility and what would be pushed and
+stops; with `--confirm` it performs the `PUT .../expense`. If the push returns
+`EmailAccessRequiredException` (HTTP 400), Navan needs one-time email
+(Outlook/Gmail) access to send the invoice — grant it in the Navan UI, then
+retry.
+
+## End-to-end workflows
+
+### View trips
+1. `navan trips` — find the trip and its `tripId`.
+2. `navan trip <tripId>` — see flight route/times/airline + hotel name/dates and
+   each booking's `bookingId` / `confirmationNumber`.
+   - Checkpoint: confirmation numbers and a `[TICKETED]`/`[CONFIRMED]` status
+     mean the booking is live.
+
+### Book a flight
+1. `navan airports <city>` — resolve IATA codes if needed (e.g. Basel → BSL).
+2. `navan flights search --from=BER --to=BSL --depart=YYYY-MM-DD [--return=YYYY-MM-DD]`
+   — copy the chosen `departureId` (and, for round trips, run
+   `navan flights returns --search=<id> --departure=<departureId>` and copy a
+   `returnId`).
+   - Checkpoint: each option shows price, times, airline, flight number.
+3. `navan flights price --search=<id> --departure=<departureId> [--return=<returnId>]`
+   — get a `contractId` and total.
+   - Checkpoint: a `contractId` is returned. Flight fares expire quickly; if you
+     get "flight is no longer available" or "No fares found", re-run search →
+     price promptly.
+4. `navan book flight --search=<id> --contract=<contractId>` — review the
+   preview + total (NOT booked).
+5. After approval: `navan book flight --search=<id> --contract=<contractId> --confirm`
+   — prints `{status, bookingId, confirmationNumber, tripId}`.
+6. `navan trip <tripId>` — verify the new booking appears.
+
+### Book a hotel
+1. `navan hotels search --city=Basel --checkin=YYYY-MM-DD --checkout=YYYY-MM-DD`
+   — copy the chosen `hotelId`.
+   - Checkpoint: options show name, stars, total price.
+2. `navan hotels rooms --search=<id> --hotel=<hotelId>` — copy a `roomId`.
+3. `navan hotels price --search=<id> --hotel=<hotelId> --room=<roomId>` — get a
+   `contractId` and total.
+   - Checkpoint: a `contractId` is returned.
+4. `navan book hotel --search=<id> --contract=<contractId>` — review the preview
+   + total (NOT booked).
+5. After approval: `navan book hotel --search=<id> --contract=<contractId> --confirm`.
+6. `navan trip <tripId>` — verify.
+
+### Get an invoice and push a past booking to expense (Concur)
+1. `navan trips` → `navan trip <tripId>` — find the booking and copy its
+   **`bookingUuid`** (printed under each flight/hotel).
+2. `navan invoice <bookingUuid>` — check eligibility and invoice availability.
+   - Checkpoint: `provider_invoices` / `trip_fee_invoices` show `available`.
+     If everything shows `no`, the invoice has not synced yet — retry later.
+3. `navan invoice <bookingUuid> --download=<path>` — save the invoice PDF (the
+   download endpoint returns a binary PDF).
+4. `navan push-expense <bookingUuid>` — review eligibility + what would be pushed
+   (NOT pushed).
+5. After approval: `navan push-expense <bookingUuid> --confirm` — performs the
+   `PUT .../expense` and reports the result.
+   - Checkpoint: HTTP 200 = pushed. HTTP 400 `EmailAccessRequiredException` =
+     grant Navan email access once in the UI, then retry.
+
+## Notes
+
+- `searchId`s and priced contracts are short-lived (minutes). Re-search if a
+  later step reports an expired/unavailable error.
+- See `references/endpoints.md` for the full endpoint, payload, and response
+  documentation captured from a real Berlin → Basel booking.

--- a/skills/navan/references/endpoints.md
+++ b/skills/navan/references/endpoints.md
@@ -1,0 +1,252 @@
+# Navan (TripActions) API reference
+
+Base: `https://app.navan.com`. All endpoints below are the app's own backend.
+
+## Auth (required on every /api/ request)
+
+```
+Authorization: TripActions <JWT>
+x-tripactions-locale: en-US
+content-type: application/json
+```
+
+- The `<JWT>` is the Auth0 access token. In the Navan tab it lives in
+  `localStorage` under a key beginning `@@auth0spajs@@...`, at
+  `body.access_token`. It is a standard RS256 JWT
+  (`iss: https://login.navan.com/`, aud includes `https://app.navan.com/`).
+- The scheme word is literally `TripActions` (not `Bearer`).
+- These headers cannot be sent from SLICC's own fetch (cookie/origin limits) —
+  run all calls from the logged-in tab with `playwright-cli eval-file` using
+  `fetch(url, { credentials:'include', headers:{...} })`.
+- 401/403 → token expired; re-log-in in the browser.
+
+## Identity
+
+| Method | Path | Notes |
+|--------|------|-------|
+| GET | `/api/uaa/userinfo` | `{ sub, name, given_name, family_name, email, serverRegion }` |
+| GET | `/api/liberty/user/me` | fuller profile |
+| GET | `/api/user/passenger` | the traveler/passenger object used in booking payloads |
+| GET | `/api/user/paymentMethods` | array of payment methods; each has `uuid`, `validForPurchase`, `creditCard` |
+
+## Trips
+
+| Method | Path | Notes |
+|--------|------|-------|
+| GET | `/api/user/trips` | array of trip summaries: `uuid, name, startDate, endDate, flightCount, hotelCount, carCount, railCount, personal` |
+| GET | `/api/user/trips/active` | the currently-active trip summary |
+| GET | `/api/user/trips/{tripId}` | trip summary + counts (segments NOT included here) |
+| GET | `/api/user/trips/timeline?tripUuid={id}&tripItemMapIncluded=true` | full detail. Returns an array; `[0].tripItemsMap` maps tripItemUuid → booking. |
+
+`/api/user/trips/timeline` **without** a `tripUuid` returns HTTP 500 — always
+pass `tripUuid`.
+
+### Trip item shapes (in `tripItemsMap`)
+
+- Flight item: `bookingId`, `confirmationNumber`, `bookingStatus`
+  (e.g. `TICKETED`), `totalPrice`, `departureFlight.flight.flightSegments[]`,
+  `returnFlight.flight.flightSegments[]`. Each segment has `airlineCode`,
+  `airlineName`, `flightNumber`, `departureAirportCode`, `arrivalAirportCode`,
+  `departureDateAndTime`, `arrivalDateAndTime`.
+- Hotel item: `bookingId`, `confirmationNumber`, `bookingStatus`
+  (e.g. `CONFIRMED`), `totalPrice`, `hotel.name`, `startDate`, `endDate`,
+  `hotelRoom`, `hotelPaymentDescription[]`.
+
+## Autocomplete
+
+| Method | Path | Notes |
+|--------|------|-------|
+| GET | `/api/user/autocomplete/cityAirports?input=<q>&includeClusters=true&radiusMiles=50&maxLargeAirportPerCity=3&maxCloseAirportPerCity=2` | `_embedded.cityAirportses[]`; each has `mainAirport.{iata,name}` or a `location` with `placeId`/`placeName` |
+| GET | `/api/user/autocomplete/place?input=<q>&includeFavoriteHotels=true&addLocation=true` | `predictions[]`; each has `description`, `displayName`, `location.{placeId, placeName, geo.{latitude,longitude}, address}` — used to drive hotel search |
+
+## Flights — search → outbound → return → contract → book
+
+1. **Create search** (GET; all params in the query string; returns a `searchId`
+   with empty `options`):
+
+   ```
+   GET /api/v1/trip/flight/searches?emptyData=true&loadAmenities=false
+       &flexibleDepartureTime=true&includeTravelfusion=true&includeExpedia=true
+       &smartSearch=true&disableBlacklistedAirlineFlights=true
+       &appSupportsFareRefundPolicy=false&appSupportsFareExchangePolicy=false
+       &originAirportCode=BER&includeNearbyOriginAirports=false
+       &destinationAirportCode=BSL&includeNearbyDestinationAirports=false
+       &departureDate=2026-06-22&departureFromTime=00:00:00.000
+       &departureToTime=23:59:00.000&departureDaysBounds=SAME_DAY
+       &cabinClass=ECONOMY&adults=1&maxStops=10&runWithRecommendedStops=false
+       &includeDedupedFares=true
+       [&returnDate=2026-06-26&returnFromTime=00:00:00.000
+        &returnToTime=23:59:00.000&returnDaysBounds=SAME_DAY]
+   ```
+
+2. **Poll for outbound options** (POST, body `{}`; repeat until `options[]`
+   is non-empty):
+
+   ```
+   POST /api/v1/trip/flight/searches/{searchId}?offset=0&limit=20&loadAmenities=true&displayOnlyAffiliateFlights=false
+   body: {}
+   ```
+
+   Each `options[]` entry: `uuid` (the **departureId**), `selectedFareId`,
+   `flight.flightSegments[]`, `startingPrice.{basePrice,tax,agencyCurrency}`,
+   `providerStartingPrice.total.{amount,currency}`, `flightDuration`.
+
+3. **Return options for a chosen outbound** (POST, body `{}`):
+
+   ```
+   POST /api/v1/trip/flight/searches/{searchId}/departures/{departureId}/returns?offset=0&limit=20&loadAmenities=true&displayOnlyAffiliateFlights=false
+   body: {}
+   ```
+
+   Each option's `uuid` is the **returnId**; `selectedFareId` is its fare.
+
+4. **Price a contract** (POST, body `{}`; fareIds in the query string):
+
+   - Round trip:
+     ```
+     POST /api/v1/trip/flight/searches/{searchId}/departures/{departureId}/returns/{returnId}/contractV2?departureFareId={depFareId}&returnFareId={retFareId}&timestamp={ms}
+     ```
+   - One way:
+     ```
+     POST /api/v1/trip/flight/searches/{searchId}/departures/{departureId}/contractV2?departureFareId={depFareId}
+     ```
+
+   Success → `{ contract: {...}, duplicateBookingWarning }`. The contract has
+   `uuid` (**contractId**), `requiresApproval`, `totalPriceAndFee`,
+   `totalPriceWithCCFeeInAgencyCurrency.{amount,currency}`, `flightItinerary`.
+   Failure (common) → `{ status:400, errorCode:"GE00026", error:"No fares found
+   for booking class" }` or "flight is no longer available" — fares expire fast;
+   re-search and re-price.
+
+5. **Get a contract** (GET): `/api/v1/trip/flight/searches/{searchId}/contracts/{contractId}?currency=EUR`
+
+6. **Book** (POST, streaming SSE response):
+
+   ```
+   POST /api/v1/trip/flight/searches/{searchId}/contracts/{contractId}/book/streaming
+        ?paymentMethodUuid={pmUuid}&tripId=&tripUuid=&hold=false
+        &tripName={name}&platedBooking=false&locale=en-US
+   body: { passengerData:[ { airlineLoyaltyCards:{}, airlineDiscountCards:{},
+                             passenger:{ uuid, givenName, familyName, fullName,
+                                         birthdate, email, travelerType:"BUSINESS",
+                                         passenger:<full /api/user/passenger object> } } ],
+           customFieldValues:[], sendEmailToAll:true }
+   ```
+
+## Hotels — search → hotel → rooms → contract → book
+
+1. **Resolve location**: `GET /api/user/autocomplete/place?input=<city>&includeFavoriteHotels=true&addLocation=true`
+   → pick a prediction; use `location.placeId`, `location.geo.latitude/longitude`,
+   and `description`.
+
+2. **Create search** (GET; returns a `searchId`, poll `options[]`):
+
+   ```
+   GET /api/v1/trip/hotel/searches?includeSpecialRates=true&description=<desc>
+       &checkInDate=2026-06-22&checkOutDate=2026-06-26&numberOfRooms=1
+       &numberOfGuests=1&prefetchRooms=true&emptyData=false
+       &placeId=<placeId>&latitude=<lat>&longitude=<lon>
+   ```
+   Then poll `GET /api/v1/trip/hotel/searches/{searchId}` until `options[]` is
+   populated. Each option: `uuid`/`hotelId`, `name`, `hotelStarsRating`,
+   `totalPriceAndFee`, `dailyRate`.
+
+3. **Load rooms for a hotel** (POST, body is an array containing the hotelId):
+
+   ```
+   POST /api/v2/trip/hotel/searches/{searchId}/rooms
+   body: ["<hotelId>"]
+   ```
+   Rooms are at `_embedded.hotels[0].rooms[]`; each has `uuid` (**roomId**),
+   `displayName`, `priceInfo.{totalPriceAndFee,basePrice}`, `bookPolicy`.
+   (The UI also issues `PATCH /api/v2/trip/hotel/searches/{searchId}/hotel/{hotelId}/rooms`
+   with an array of room UUIDs to refine a specific room — usually unnecessary.)
+
+4. **Price a contract** (POST, body `{}`):
+
+   ```
+   POST /api/v1/trip/hotel/searches/{searchId}/hotels/{hotelId}/rooms/{roomId}/contract
+   ```
+   → contract with `uuid` (**contractId**), `requiresApproval`,
+   `totalPriceWithCCFeeInAgencyCurrency.{amount,currency}`.
+
+5. **Get a contract** (GET): `/api/v1/trip/hotel/searches/{searchId}/contracts/{contractId}`
+
+6. **Book** (POST, streaming SSE response):
+
+   ```
+   POST /api/v1/trip/hotel/searches/{searchId}/contracts/{contractId}/book/streaming
+        ?paymentMethodUuid={pmUuid}&tripId={existingTripId?}&tripName={name}&locale=en-US
+   body: { customFieldValues:[], sendEmailToAll:true,
+           passengerData:[ { passenger:{ ... same shape as flights ... } } ] }
+   ```
+
+## Booking streaming response (SSE)
+
+`book/streaming` returns Server-Sent Events, not JSON or NDJSON. Read the whole
+response body and split on blank lines (`\n\n`). Each block has `event:` and one
+or more `data:` lines (concatenate the `data:` lines, then `JSON.parse`).
+
+- Progress events: `event: periodic-event-booking-completion-update` with
+  `data: { percentageComplete, completed:false, bookResponses:null, bookingUuids:[] }`.
+- Final success event has `data.completed == true` and
+  `data.bookResponses[0]` = `{ tripId, bookingId, confirmationNumber,
+  flightItinerary/... , status segments CONFIRMED }`.
+- Error event: `event: error` with `data: { status:400, errorCode, message }`
+  (e.g. `FB0547` OB-fee increase). On error with no final success, treat the
+  booking as failed.
+
+Parse the **last** `completed:true` event for
+`{ status:"CONFIRMED", bookingId, confirmationNumber, tripId }`.
+
+## Trip-fee quote (optional, used by the UI before booking)
+
+```
+POST /api/v2/trip/tripFee/searches/{searchId}/contracts/{contractId}/paymentMethodUuid/{pmUuid}?displayCurrency=EUR&agencyCurrency=EUR
+```
+
+## Reference booking (the recorded Berlin → Basel trip)
+
+- tripId `8bc5c4e7-cf16-4147-85d8-87a8135532e8` ("Zurich Trip")
+- Flight: BER→ZRH LX963 (2026-06-22 07:15→08:40), ZRH→BER LX4408
+  (2026-06-26 20:15→21:40), Swiss; bookingId `2KX13T`, confirmation `YYWJXM`,
+  ~€708.35, status TICKETED.
+- Hotel: Mövenpick Hotel Basel, 2026-06-22→2026-06-26; bookingId `OVCCAZ`,
+  confirmation `B4T3AFL0630`, ~€1326.21, status CONFIRMED.
+
+## Invoices and push-to-expense (Concur)
+
+All keyed by the booking's **`bookingUuid`** (the `expenseFromTravel` id, e.g.
+`6693f5ab-7335-49e9-8c7a-a16221c7141c`) — this is the `bookingUuid` field on a
+trip item from `/api/user/trips/timeline?tripUuid=...`, **not** the airline PNR
+(`bookingId` like `2KX13T`). Same `TripActions` auth as everything else.
+
+| Method | Path | Notes |
+|--------|------|-------|
+| GET | `/api/v1/expenseFromTravel/{bookingId}/isEligible` | `{ "eligible": true\|false }` — can this booking be pushed to expense (false can mean already expensed / not eligible) |
+| GET | `/api/v1/expenseFromTravel/{bookingId}/wasBookedAfterBookingExpenseFeature` | `{ "bookedAfterBookingExpenseFeature": true\|false }` |
+| GET | `/api/invoices/v2/sync_status/{bookingId}` | `{ provider_invoices, trip_fee_invoices, service_fee_invoices, chloe_bot_invoices }` — booleans for which invoices have synced/are available |
+| GET | `/api/v1/invoicesinternal/download/{bookingId}?lng=en-US` | binary **PDF** of the invoice. Fetch as `arrayBuffer` and base64-encode in the page, then `base64 -d` to a file — do NOT use `response.text()` (corrupts binary). |
+| PUT | `/api/user/bookings/{bookingId}/expense` | **Push** the booking + invoice to the expense system (Concur). **No request body** (content-type `application/json`). |
+
+### PUT .../expense behaviour (from the capture)
+
+- **No body** is sent. The first captured attempt returned **HTTP 400** with
+  `exceptionClass: "EmailAccessRequiredException"`,
+  `message: "Email access is required."`, `provider: "MICROSOFT"`, and an
+  `authorizeUri` (Microsoft OAuth consent URL). This is a one-time email-access
+  grant so Navan can email the invoice into expense — it is **not** a body-shape
+  problem.
+- After the user granted email access, the identical retry returned **HTTP 200**
+  with the booking object (`uuid`, `instant`, `dateCreated`, `dateModified`,
+  `user`, ...). Treat 200 as "pushed".
+- Handle the 400 specially: surface the `provider` and `authorizeUri` and tell
+  the user to grant email access once, then retry with `--confirm`.
+
+### Example bookingUuids from the capture
+
+- `6693f5ab-...` — Zurich Trip flight (isEligible false, no invoices yet — booked recently)
+- `71286231-...` — Zurich Trip hotel
+- `c293de48-...` — an older booking with `provider_invoices`/`trip_fee_invoices`
+  available; PUT `.../expense` returned 400 (email access) then 200 on retry.
+- `3cd81f92-...` — another booking (status checks only)

--- a/skills/navan/scripts/navan.jsh
+++ b/skills/navan/scripts/navan.jsh
@@ -5,46 +5,45 @@
 // needs two headers that SLICC's own fetch() cannot carry:
 //   Authorization: TripActions <JWT>      (literal scheme word "TripActions")
 //   x-tripactions-locale: en-US
-// So ALL calls run INSIDE the logged-in Navan browser tab via
-// `playwright-cli eval-file`. The JWT is the Auth0 access_token stored in the
-// tab's localStorage under a key starting with "@@auth0spajs@@". If it is not
-// there we fall back to intercepting the Authorization header off the app's
-// own XHR/fetch traffic. On 401/403 we tell the user to re-log-in.
+// So ALL calls run INSIDE the logged-in Navan browser tab via the
+// `sliccy:browser` bridge's `evalAsync` (the page scripts are async IIFEs
+// that `await fetch(...)`, so the synchronous `browser.eval` is not usable
+// here — it does not await a returned Promise). The JWT is the Auth0
+// access_token stored in the tab's localStorage under a key starting with
+// "@@auth0spajs@@". If it is not there we fall back to intercepting the
+// Authorization header off the app's own XHR/fetch traffic. On 401/403 we
+// tell the user to re-log-in.
 //
 // BOOKING SAFETY: `navan book` spends real money. Without --confirm it only
 // prices the itinerary and prints a gate message; it never books.
+
+const browser = require('sliccy:browser'); // page-context CDP bridge (replaces playwright-cli eval-file)
+const fs = require('fs'); // VFS bridge (writeFileBinary for the invoice PDF download)
 
 const APP_HOST  = 'app.navan.com';
 const TRIPS_URL = 'https://app.navan.com/app/user2/trips';
 const LOCALE    = 'en-US';
 
-// ----------------- tiny fs helpers (via exec) -----------------
-async function writeFile(p, s) {
-  const delim = 'NAVAN_EOF_' + Math.random().toString(36).slice(2, 10);
-  await exec(`cat > "${p}" <<'${delim}'\n${s}\n${delim}`);
-}
-async function rmFile(p) { await exec(`rm -f "${p}"`); }
-function tmpPath() { return `/shared/.navan-${Date.now()}-${Math.random().toString(36).slice(2,8)}.js`; }
-
 // ----------------- tab management -----------------
 let _tabId = null;
-async function findNavanTab() {
-  const r = await exec('playwright-cli tab-list');
-  const re = /\[([A-F0-9]+)\]\s+https?:\/\/[^\s]*\bnavan\.com/gi;
-  const m = [...r.stdout.matchAll(re)];
-  return m.length ? m[0][1] : null;
-}
 async function ensureTab() {
   if (_tabId) return _tabId;
-  const existing = await findNavanTab();
-  if (existing) { _tabId = existing; return _tabId; }
-  console.error('No Navan tab found. Open ' + TRIPS_URL + ' in the browser and log in, then retry.');
-  process.exit(2);
+  const tab = await browser.findTab({ urlMatch: /navan\.com/i });
+  if (!tab) {
+    console.error('No Navan tab found. Open ' + TRIPS_URL + ' in the browser and log in, then retry.');
+    process.exit(2);
+  }
+  _tabId = tab;
+  return _tabId;
 }
 
 // ----------------- page-context API caller -----------------
-// Builds a self-contained in-page script that (1) extracts the JWT, (2) runs
-// the fetch with the TripActions Authorization header, (3) returns the raw text.
+// Builds a self-contained in-page async script that (1) extracts the JWT,
+// (2) runs the fetch with the TripActions Authorization header, (3) returns
+// the result directly (NOT JSON.stringify'd — browser.evalAsync serializes
+// the returned value on its own, and pre-stringifying here would make the
+// Node side have to guess whether it got a string or an already-parsed
+// value back; returning the raw object avoids the ambiguity entirely).
 function buildScript(method, path, bodyStr) {
   return `
 (async () => {
@@ -69,7 +68,7 @@ function buildScript(method, path, bodyStr) {
     return null;
   }
   const tok = findToken();
-  if (!tok) return JSON.stringify({ __navan: 'notoken' });
+  if (!tok) return { __navan: 'notoken' };
   const headers = {
     'Authorization': 'TripActions ' + tok,
     'x-tripactions-locale': ${JSON.stringify(LOCALE)},
@@ -79,9 +78,9 @@ function buildScript(method, path, bodyStr) {
   ${bodyStr != null ? `opts.body = ${JSON.stringify(bodyStr)};` : ''}
   let r;
   try { r = await fetch(${JSON.stringify(path)}, opts); }
-  catch (e) { return JSON.stringify({ __navan: 'network', message: String(e) }); }
+  catch (e) { return { __navan: 'network', message: String(e) }; }
   const text = await r.text();
-  return JSON.stringify({ __navan: 'ok', status: r.status, body: text });
+  return { __navan: 'ok', status: r.status, body: text };
 })()
 `.trim();
 }
@@ -91,16 +90,17 @@ async function api(method, path, body) {
   const tabId = await ensureTab();
   const bodyStr = body == null ? null : (typeof body === 'string' ? body : JSON.stringify(body));
   const script = buildScript(method, path, bodyStr);
-  const f = tmpPath();
-  await writeFile(f, script);
-  const r = await exec(`playwright-cli eval-file ${f} --tab=${tabId}`);
-  await rmFile(f);
-  if (r.exitCode !== 0) { console.error('eval-file failed:', r.stderr || r.stdout); process.exit(1); }
   let env;
-  const out = r.stdout.trim();
-  const s = out.indexOf('{'), e = out.lastIndexOf('}');
-  try { env = JSON.parse(s >= 0 ? out.slice(s, e + 1) : out); }
-  catch (err) { console.error('Could not parse eval result:', out.slice(0, 600)); process.exit(1); }
+  try {
+    env = await browser.evalAsync(tabId, script);
+  } catch (e) {
+    console.error('eval failed:', e && e.message ? e.message : String(e));
+    process.exit(1);
+  }
+  if (!env || typeof env !== 'object') {
+    console.error('Could not parse eval result:', JSON.stringify(env).slice(0, 600));
+    process.exit(1);
+  }
   if (env.__navan === 'notoken') {
     console.error('No Navan auth token found in the tab. Make sure you are logged into ' + TRIPS_URL + ' and the tab is open, then retry.');
     process.exit(1);
@@ -144,40 +144,39 @@ async function apiDownload(path) {
     return null;
   }
   const tok = findToken();
-  if (!tok) return JSON.stringify({ __navan: 'notoken' });
+  if (!tok) return { __navan: 'notoken' };
   let r;
   try {
     r = await fetch(${JSON.stringify(path)}, { credentials: 'include',
       headers: { 'Authorization': 'TripActions ' + tok, 'x-tripactions-locale': ${JSON.stringify(LOCALE)} } });
-  } catch (e) { return JSON.stringify({ __navan: 'network', message: String(e) }); }
-  if (!r.ok) { const t = await r.text(); return JSON.stringify({ __navan: 'ok', status: r.status, error: t.slice(0, 600) }); }
+  } catch (e) { return { __navan: 'network', message: String(e) }; }
+  if (!r.ok) { const t = await r.text(); return { __navan: 'ok', status: r.status, error: t.slice(0, 600) }; }
   const buf = await r.arrayBuffer();
   let bin = ''; const bytes = new Uint8Array(buf);
   for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
-  return JSON.stringify({ __navan: 'ok', status: r.status, contentType: r.headers.get('content-type') || '', base64: btoa(bin) });
+  return { __navan: 'ok', status: r.status, contentType: r.headers.get('content-type') || '', base64: btoa(bin) };
 })()
 `.trim();
-  const f = tmpPath();
-  await writeFile(f, script);
-  const r = await exec(`playwright-cli eval-file ${f} --tab=${tabId}`);
-  await rmFile(f);
-  if (r.exitCode !== 0) { console.error('eval-file failed:', r.stderr || r.stdout); process.exit(1); }
-  const out = r.stdout.trim();
-  const s = out.indexOf('{'), e = out.lastIndexOf('}');
-  let env; try { env = JSON.parse(s >= 0 ? out.slice(s, e + 1) : out); }
-  catch (err) { console.error('Could not parse download result:', out.slice(0, 400)); process.exit(1); }
+  let env;
+  try {
+    env = await browser.evalAsync(tabId, script);
+  } catch (e) {
+    console.error('eval failed:', e && e.message ? e.message : String(e));
+    process.exit(1);
+  }
+  if (!env || typeof env !== 'object') {
+    console.error('Could not parse download result:', JSON.stringify(env).slice(0, 400));
+    process.exit(1);
+  }
   if (env.__navan === 'notoken') { console.error('No Navan auth token found. Log into ' + TRIPS_URL + ' and retry.'); process.exit(1); }
   if (env.__navan === 'network') { console.error('Network error inside the Navan tab:', env.message); process.exit(1); }
   if (env.status === 401 || env.status === 403) { console.error('Navan session expired (HTTP ' + env.status + '). Re-login and retry.'); process.exit(1); }
   return { status: env.status, base64: env.base64, contentType: env.contentType, error: env.error };
 }
 
-// Write base64 content to a file via the shell.
+// Write base64 content to a file via the VFS binary bridge.
 async function writeBase64(path, b64) {
-  const tmp = tmpPath() + '.b64';
-  await writeFile(tmp, b64);
-  const r = await exec(`base64 -d "${tmp}" > "${path}" && rm -f "${tmp}"`);
-  if (r.exitCode !== 0) { await rmFile(tmp); throw new Error('Failed to write file: ' + (r.stderr || '')); }
+  await fs.writeFileBinary(path, Buffer.from(b64, 'base64'));
 }
 
 // ----------------- small helpers -----------------

--- a/skills/navan/scripts/navan.jsh
+++ b/skills/navan/scripts/navan.jsh
@@ -1,0 +1,792 @@
+// navan.jsh — Navan (formerly TripActions) corporate-travel API client
+// Generated via the secret-sauce skill from a recorded Berlin->Basel booking.
+//
+// AUTH: Navan's backend is at https://app.navan.com/api/... Every /api/ request
+// needs two headers that SLICC's own fetch() cannot carry:
+//   Authorization: TripActions <JWT>      (literal scheme word "TripActions")
+//   x-tripactions-locale: en-US
+// So ALL calls run INSIDE the logged-in Navan browser tab via
+// `playwright-cli eval-file`. The JWT is the Auth0 access_token stored in the
+// tab's localStorage under a key starting with "@@auth0spajs@@". If it is not
+// there we fall back to intercepting the Authorization header off the app's
+// own XHR/fetch traffic. On 401/403 we tell the user to re-log-in.
+//
+// BOOKING SAFETY: `navan book` spends real money. Without --confirm it only
+// prices the itinerary and prints a gate message; it never books.
+
+const APP_HOST  = 'app.navan.com';
+const TRIPS_URL = 'https://app.navan.com/app/user2/trips';
+const LOCALE    = 'en-US';
+
+// ----------------- tiny fs helpers (via exec) -----------------
+async function writeFile(p, s) {
+  const delim = 'NAVAN_EOF_' + Math.random().toString(36).slice(2, 10);
+  await exec(`cat > "${p}" <<'${delim}'\n${s}\n${delim}`);
+}
+async function rmFile(p) { await exec(`rm -f "${p}"`); }
+function tmpPath() { return `/shared/.navan-${Date.now()}-${Math.random().toString(36).slice(2,8)}.js`; }
+
+// ----------------- tab management -----------------
+let _tabId = null;
+async function findNavanTab() {
+  const r = await exec('playwright-cli tab-list');
+  const re = /\[([A-F0-9]+)\]\s+https?:\/\/[^\s]*\bnavan\.com/gi;
+  const m = [...r.stdout.matchAll(re)];
+  return m.length ? m[0][1] : null;
+}
+async function ensureTab() {
+  if (_tabId) return _tabId;
+  const existing = await findNavanTab();
+  if (existing) { _tabId = existing; return _tabId; }
+  console.error('No Navan tab found. Open ' + TRIPS_URL + ' in the browser and log in, then retry.');
+  process.exit(2);
+}
+
+// ----------------- page-context API caller -----------------
+// Builds a self-contained in-page script that (1) extracts the JWT, (2) runs
+// the fetch with the TripActions Authorization header, (3) returns the raw text.
+function buildScript(method, path, bodyStr) {
+  return `
+(async () => {
+  function findToken() {
+    // 1) Auth0 SPA cache in localStorage
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k && k.indexOf('@@auth0spajs@@') === 0) {
+        try { const v = JSON.parse(localStorage.getItem(k));
+          if (v && v.body && v.body.access_token) return v.body.access_token; } catch (e) {}
+      }
+    }
+    // 2) any localStorage value carrying an access_token
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      try { const v = JSON.parse(localStorage.getItem(k));
+        if (v && v.body && v.body.access_token) return v.body.access_token;
+        if (v && v.access_token) return v.access_token; } catch (e) {}
+    }
+    // 3) anything captured off the wire by a prior interceptor
+    if (window.__navanAuth) return window.__navanAuth.replace(/^TripActions\\s+/i, '');
+    return null;
+  }
+  const tok = findToken();
+  if (!tok) return JSON.stringify({ __navan: 'notoken' });
+  const headers = {
+    'Authorization': 'TripActions ' + tok,
+    'x-tripactions-locale': ${JSON.stringify(LOCALE)},
+    'content-type': 'application/json'
+  };
+  const opts = { method: ${JSON.stringify(method)}, credentials: 'include', headers };
+  ${bodyStr != null ? `opts.body = ${JSON.stringify(bodyStr)};` : ''}
+  let r;
+  try { r = await fetch(${JSON.stringify(path)}, opts); }
+  catch (e) { return JSON.stringify({ __navan: 'network', message: String(e) }); }
+  const text = await r.text();
+  return JSON.stringify({ __navan: 'ok', status: r.status, body: text });
+})()
+`.trim();
+}
+
+// Run an API call from the page. Returns { status, text, json }.
+async function api(method, path, body) {
+  const tabId = await ensureTab();
+  const bodyStr = body == null ? null : (typeof body === 'string' ? body : JSON.stringify(body));
+  const script = buildScript(method, path, bodyStr);
+  const f = tmpPath();
+  await writeFile(f, script);
+  const r = await exec(`playwright-cli eval-file ${f} --tab=${tabId}`);
+  await rmFile(f);
+  if (r.exitCode !== 0) { console.error('eval-file failed:', r.stderr || r.stdout); process.exit(1); }
+  let env;
+  const out = r.stdout.trim();
+  const s = out.indexOf('{'), e = out.lastIndexOf('}');
+  try { env = JSON.parse(s >= 0 ? out.slice(s, e + 1) : out); }
+  catch (err) { console.error('Could not parse eval result:', out.slice(0, 600)); process.exit(1); }
+  if (env.__navan === 'notoken') {
+    console.error('No Navan auth token found in the tab. Make sure you are logged into ' + TRIPS_URL + ' and the tab is open, then retry.');
+    process.exit(1);
+  }
+  if (env.__navan === 'network') { console.error('Network error inside the Navan tab:', env.message); process.exit(1); }
+  if (env.status === 401 || env.status === 403) {
+    console.error('Navan session expired or unauthorized (HTTP ' + env.status + '). Open ' + TRIPS_URL + ', log in, and retry.');
+    process.exit(1);
+  }
+  let json = null; try { json = JSON.parse(env.body); } catch (e) {}
+  return { status: env.status, text: env.body, json };
+}
+
+function fail(res, ctx) {
+  const msg = res.json && (res.json.message || res.json.error) ? (res.json.error || '') + ' ' + (res.json.message || '') : res.text.slice(0, 300);
+  console.error('HTTP ' + res.status + (ctx ? ' (' + ctx + ')' : '') + ': ' + msg.trim());
+  process.exit(1);
+}
+
+// Download a binary (e.g. PDF invoice) from the page context as base64.
+// Returns { status, base64, contentType }.
+async function apiDownload(path) {
+  const tabId = await ensureTab();
+  const script = `
+(async () => {
+  function findToken() {
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k && k.indexOf('@@auth0spajs@@') === 0) {
+        try { const v = JSON.parse(localStorage.getItem(k));
+          if (v && v.body && v.body.access_token) return v.body.access_token; } catch (e) {}
+      }
+    }
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      try { const v = JSON.parse(localStorage.getItem(k));
+        if (v && v.body && v.body.access_token) return v.body.access_token;
+        if (v && v.access_token) return v.access_token; } catch (e) {}
+    }
+    if (window.__navanAuth) return window.__navanAuth.replace(/^TripActions\\s+/i, '');
+    return null;
+  }
+  const tok = findToken();
+  if (!tok) return JSON.stringify({ __navan: 'notoken' });
+  let r;
+  try {
+    r = await fetch(${JSON.stringify(path)}, { credentials: 'include',
+      headers: { 'Authorization': 'TripActions ' + tok, 'x-tripactions-locale': ${JSON.stringify(LOCALE)} } });
+  } catch (e) { return JSON.stringify({ __navan: 'network', message: String(e) }); }
+  if (!r.ok) { const t = await r.text(); return JSON.stringify({ __navan: 'ok', status: r.status, error: t.slice(0, 600) }); }
+  const buf = await r.arrayBuffer();
+  let bin = ''; const bytes = new Uint8Array(buf);
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return JSON.stringify({ __navan: 'ok', status: r.status, contentType: r.headers.get('content-type') || '', base64: btoa(bin) });
+})()
+`.trim();
+  const f = tmpPath();
+  await writeFile(f, script);
+  const r = await exec(`playwright-cli eval-file ${f} --tab=${tabId}`);
+  await rmFile(f);
+  if (r.exitCode !== 0) { console.error('eval-file failed:', r.stderr || r.stdout); process.exit(1); }
+  const out = r.stdout.trim();
+  const s = out.indexOf('{'), e = out.lastIndexOf('}');
+  let env; try { env = JSON.parse(s >= 0 ? out.slice(s, e + 1) : out); }
+  catch (err) { console.error('Could not parse download result:', out.slice(0, 400)); process.exit(1); }
+  if (env.__navan === 'notoken') { console.error('No Navan auth token found. Log into ' + TRIPS_URL + ' and retry.'); process.exit(1); }
+  if (env.__navan === 'network') { console.error('Network error inside the Navan tab:', env.message); process.exit(1); }
+  if (env.status === 401 || env.status === 403) { console.error('Navan session expired (HTTP ' + env.status + '). Re-login and retry.'); process.exit(1); }
+  return { status: env.status, base64: env.base64, contentType: env.contentType, error: env.error };
+}
+
+// Write base64 content to a file via the shell.
+async function writeBase64(path, b64) {
+  const tmp = tmpPath() + '.b64';
+  await writeFile(tmp, b64);
+  const r = await exec(`base64 -d "${tmp}" > "${path}" && rm -f "${tmp}"`);
+  if (r.exitCode !== 0) { await rmFile(tmp); throw new Error('Failed to write file: ' + (r.stderr || '')); }
+}
+
+// ----------------- small helpers -----------------
+function arg(args, name, def) {
+  const pfx = '--' + name + '=';
+  for (const a of args) if (a.indexOf(pfx) === 0) return a.slice(pfx.length);
+  const i = args.indexOf('--' + name);
+  if (i >= 0 && args[i + 1] && args[i + 1].indexOf('--') !== 0) return args[i + 1];
+  return def;
+}
+function hasFlag(args, name) { return args.indexOf('--' + name) >= 0; }
+function money(m) {
+  if (!m) return '—';
+  if (typeof m === 'object') return (m.amount != null ? m.amount.toFixed ? m.amount.toFixed(2) : m.amount : '?') + ' ' + (m.currency || '');
+  return String(m);
+}
+function hhmm(s) { return s ? String(s).replace('T', ' ').slice(0, 16) : '—'; }
+function segLine(s) {
+  return `${s.departureAirportCode}->${s.arrivalAirportCode} ${s.airlineCode}${s.flightNumber}`
+    + ` ${hhmm(s.departureDateAndTime)} -> ${hhmm(s.arrivalDateAndTime)}`
+    + (s.airlineName ? ` (${s.airlineName})` : '');
+}
+
+// ----------------- commands: identity -----------------
+async function cmdWhoami(args) {
+  const json = hasFlag(args, 'json');
+  const r = await api('GET', '/api/uaa/userinfo');
+  if (r.status !== 200) fail(r, 'userinfo');
+  const u = r.json || {};
+  if (json) { console.log(JSON.stringify(u, null, 2)); return; }
+  console.log(`Name:    ${u.name || ((u.given_name||'') + ' ' + (u.family_name||''))}`);
+  console.log(`Email:   ${u.email || '—'}`);
+  console.log(`User ID: ${u.sub || '—'}`);
+  console.log(`Region:  ${u.serverRegion || '—'}`);
+}
+
+// ----------------- commands: trips -----------------
+async function cmdTrips(args) {
+  const json = hasFlag(args, 'json');
+  const r = await api('GET', '/api/user/trips');
+  if (r.status !== 200) fail(r, 'trips');
+  const list = Array.isArray(r.json) ? r.json : (r.json && r.json.content) || [];
+  const trips = list.map(t => ({
+    tripId: t.uuid, name: t.name, start: t.startDate, end: t.endDate,
+    flights: t.flightCount, hotels: t.hotelCount, cars: t.carCount, rail: t.railCount,
+    personal: t.personal,
+  }));
+  if (json) { console.log(JSON.stringify(trips, null, 2)); return; }
+  if (!trips.length) { console.log('No trips found.'); return; }
+  console.log(`Trips (${trips.length}):`);
+  for (const t of trips) {
+    const dates = (t.start || '') + (t.end ? ' -> ' + t.end : '');
+    const items = [t.flights && t.flights + 'F', t.hotels && t.hotels + 'H', t.cars && t.cars + 'C', t.rail && t.rail + 'R'].filter(Boolean).join(' ');
+    console.log(`  ${(t.name || '(unnamed)').padEnd(28)} ${dates.padEnd(26)} ${items}`);
+    console.log(`    ${t.tripId}`);
+  }
+}
+
+async function cmdTrip(args) {
+  const json = hasFlag(args, 'json');
+  const id = args.find(a => a.indexOf('--') !== 0);
+  if (!id) { console.error('Usage: navan trip <tripId> [--json]'); process.exit(2); }
+  const r = await api('GET', `/api/user/trips/timeline?tripUuid=${encodeURIComponent(id)}&tripItemMapIncluded=true`);
+  if (r.status !== 200) fail(r, 'trip detail');
+  const t = Array.isArray(r.json) ? r.json[0] : r.json;
+  if (!t) { console.log('Trip not found.'); return; }
+  const map = t.tripItemsMap || {};
+  const flights = [], hotels = [];
+  for (const k in map) {
+    const it = map[k];
+    if (it.departureFlight || it.returnFlight) {
+      const f = { bookingId: it.bookingId, bookingUuid: it.bookingUuid, confirmationNumber: it.confirmationNumber, status: it.bookingStatus, price: it.totalPrice, name: it.tripName, legs: [] };
+      const dseg = it.departureFlight && it.departureFlight.flight && it.departureFlight.flight.flightSegments || [];
+      const rseg = it.returnFlight && it.returnFlight.flight && it.returnFlight.flight.flightSegments || [];
+      dseg.forEach(s => f.legs.push({ dir: 'outbound', ...pickSeg(s) }));
+      rseg.forEach(s => f.legs.push({ dir: 'return', ...pickSeg(s) }));
+      flights.push(f);
+    }
+    if (it.hotelRoom || it.hotel) {
+      hotels.push({
+        bookingId: it.bookingId, bookingUuid: it.bookingUuid, confirmationNumber: it.confirmationNumber, status: it.bookingStatus,
+        name: it.hotel && it.hotel.name, checkIn: it.startDate, checkOut: it.endDate, price: it.totalPrice,
+        payment: it.hotelPaymentDescription && it.hotelPaymentDescription[0],
+      });
+    }
+  }
+  if (json) { console.log(JSON.stringify({ tripId: t.tripUuid, flights, hotels }, null, 2)); return; }
+  console.log(`Trip ${t.tripUuid}`);
+  for (const f of flights) {
+    console.log(`\nFlight  booking ${f.bookingId || '—'}  confirmation ${f.confirmationNumber || '—'}  [${f.status || '—'}]  ${money(f.price)} EUR`);
+    if (f.bookingUuid) console.log(`  bookingUuid ${f.bookingUuid}  (use for: navan invoice / navan push-expense)`);
+    for (const l of f.legs) console.log(`  ${l.dir.padEnd(8)} ${segLine(l)}`);
+  }
+  for (const h of hotels) {
+    console.log(`\nHotel   booking ${h.bookingId || '—'}  confirmation ${h.confirmationNumber || '—'}  [${h.status || '—'}]  ${money(h.price)} EUR`);
+    if (h.bookingUuid) console.log(`  bookingUuid ${h.bookingUuid}  (use for: navan invoice / navan push-expense)`);
+    console.log(`  ${h.name || '—'}   ${h.checkIn || '?'} -> ${h.checkOut || '?'}`);
+    if (h.payment) console.log(`  ${h.payment}`);
+  }
+  if (!flights.length && !hotels.length) console.log('  (no flight/hotel items)');
+}
+function pickSeg(s) {
+  return { airlineCode: s.airlineCode, airlineName: s.airlineName, flightNumber: s.flightNumber,
+    departureAirportCode: s.departureAirportCode, arrivalAirportCode: s.arrivalAirportCode,
+    departureDateAndTime: s.departureDateAndTime, arrivalDateAndTime: s.arrivalDateAndTime };
+}
+
+// ----------------- commands: airports -----------------
+async function cmdAirports(args) {
+  const json = hasFlag(args, 'json');
+  const q = args.filter(a => a.indexOf('--') !== 0).join(' ');
+  if (!q) { console.error('Usage: navan airports <query>'); process.exit(2); }
+  const qs = `input=${encodeURIComponent(q)}&includeClusters=true&flightDirection=&radiusMiles=50&maxLargeAirportPerCity=3&maxCloseAirportPerCity=2&preferDirectAirports=true`;
+  const r = await api('GET', `/api/user/autocomplete/cityAirports?${qs}`);
+  if (r.status !== 200) fail(r, 'airports');
+  const list = (r.json && r.json._embedded && r.json._embedded.cityAirportses) || [];
+  const out = [];
+  for (const c of list) {
+    const a = c.mainAirport || (c.location && { iata: c.location.airportCode, name: c.location.placeName }) || {};
+    out.push({ code: a.iata || null, name: a.name || (c.location && c.location.placeName) || null,
+      city: (c.location && c.location.address && c.location.address.locality) || (a.address && a.address.locality) || null });
+  }
+  if (json) { console.log(JSON.stringify(out, null, 2)); return; }
+  if (!out.length) { console.log('No matches.'); return; }
+  for (const o of out) console.log(`  ${(o.code || '   ').padEnd(5)} ${o.name || ''}${o.city ? '  (' + o.city + ')' : ''}`);
+}
+
+// ----------------- commands: flights -----------------
+function flightSearchQuery(o) {
+  const p = new URLSearchParams();
+  p.set('emptyData', 'true'); p.set('loadAmenities', 'false'); p.set('flexibleDepartureTime', 'true');
+  p.set('includeTravelfusion', 'true'); p.set('includeExpedia', 'true'); p.set('smartSearch', 'true');
+  p.set('disableBlacklistedAirlineFlights', 'true'); p.set('appSupportsFareRefundPolicy', 'false');
+  p.set('appSupportsFareExchangePolicy', 'false');
+  p.set('originAirportCode', o.from); p.set('includeNearbyOriginAirports', 'false');
+  p.set('destinationAirportCode', o.to); p.set('includeNearbyDestinationAirports', 'false');
+  p.set('departureDate', o.depart); p.set('departureFromTime', '00:00:00.000');
+  p.set('departureToTime', '23:59:00.000'); p.set('departureDaysBounds', 'SAME_DAY');
+  p.set('cabinClass', o.cabin || 'ECONOMY'); p.set('adults', String(o.pax || 1));
+  p.set('maxStops', '10'); p.set('runWithRecommendedStops', 'false');
+  p.set('includeDedupedFares', 'true');
+  if (o.ret) {
+    p.set('returnDate', o.ret); p.set('returnFromTime', '00:00:00.000');
+    p.set('returnToTime', '23:59:00.000'); p.set('returnDaysBounds', 'SAME_DAY');
+  }
+  return p.toString();
+}
+function optionRow(o) {
+  const segs = (o.flight && o.flight.flightSegments) || [];
+  const first = segs[0] || {}, last = segs[segs.length - 1] || {};
+  const price = (o.providerStartingPrice && o.providerStartingPrice.total) ||
+    (o.startingPrice && { amount: Math.round((o.startingPrice.basePrice || 0) + (o.startingPrice.tax || 0)), currency: o.startingPrice.agencyCurrency }) || null;
+  return {
+    departureId: o.uuid, fareId: o.selectedFareId || null,
+    airline: first.airlineCode, airlineName: first.airlineName,
+    flightNo: segs.map(s => s.airlineCode + s.flightNumber).join('/'),
+    from: first.departureAirportCode, to: last.arrivalAirportCode,
+    depart: first.departureDateAndTime, arrive: last.arrivalDateAndTime,
+    stops: Math.max(0, segs.length - 1), durationMin: o.flightDuration || o.flightTotalDuration,
+    price: price ? (price.amount + ' ' + (price.currency || '')) : null,
+  };
+}
+async function pollFlightOptions(searchId, kind) {
+  // kind: 'departures' (POST searches/{id}) — body {} ; returns 'options'
+  let last = null;
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const r = await api('POST', `/api/v1/trip/flight/searches/${searchId}?offset=0&limit=20&loadAmenities=true&displayOnlyAffiliateFlights=false`, {});
+    if (r.status !== 200) fail(r, 'flight poll');
+    last = r.json;
+    if (last && last.options && last.options.length) return last;
+    await new Promise(res => setTimeout(res, 1500));
+  }
+  return last;
+}
+async function cmdFlights(args) {
+  const sub = args[0];
+  const rest = args.slice(1);
+  const json = hasFlag(rest, 'json');
+  if (sub === 'search') {
+    const o = { from: arg(rest, 'from'), to: arg(rest, 'to'), depart: arg(rest, 'depart'),
+      ret: arg(rest, 'return'), pax: parseInt(arg(rest, 'pax', '1'), 10), cabin: arg(rest, 'cabin', 'ECONOMY') };
+    if (!o.from || !o.to || !o.depart) { console.error('Usage: navan flights search --from=BER --to=BSL --depart=YYYY-MM-DD [--return=YYYY-MM-DD] [--pax=1]'); process.exit(2); }
+    const cr = await api('GET', `/api/v1/trip/flight/searches?${flightSearchQuery(o)}`);
+    if (cr.status !== 200) fail(cr, 'flight search create');
+    const searchId = cr.json && cr.json.searchId;
+    if (!searchId) { console.error('No searchId returned.'); process.exit(1); }
+    const res = await pollFlightOptions(searchId);
+    const options = ((res && res.options) || []).map(optionRow);
+    if (json) { console.log(JSON.stringify({ searchId, options }, null, 2)); return; }
+    console.log(`searchId: ${searchId}`);
+    console.log(`${o.from} -> ${o.to} on ${o.depart}${o.ret ? '  (return ' + o.ret + ')' : ''}  ${options.length} outbound options:`);
+    for (const x of options) {
+      console.log(`  ${(x.price || '—').padStart(12)}  ${x.flightNo.padEnd(12)} ${hhmm(x.depart)} -> ${hhmm(x.arrive)}  ${x.stops}stop  ${x.airlineName || ''}`);
+      console.log(`     departureId ${x.departureId}`);
+    }
+    console.log('\nNext: navan flights returns --search=' + searchId + ' --departure=<departureId>');
+    return;
+  }
+  if (sub === 'returns') {
+    const searchId = arg(rest, 'search'), depId = arg(rest, 'departure');
+    if (!searchId || !depId) { console.error('Usage: navan flights returns --search=<id> --departure=<departureId>'); process.exit(2); }
+    const r = await api('POST', `/api/v1/trip/flight/searches/${searchId}/departures/${depId}/returns?offset=0&limit=20&loadAmenities=true&displayOnlyAffiliateFlights=false`, {});
+    if (r.status !== 200) fail(r, 'returns');
+    const options = ((r.json && r.json.options) || []).map(optionRow);
+    if (json) { console.log(JSON.stringify({ searchId, departureId: depId, returns: options }, null, 2)); return; }
+    console.log(`${options.length} return options:`);
+    for (const x of options) {
+      console.log(`  ${(x.price || '—').padStart(12)}  ${x.flightNo.padEnd(12)} ${hhmm(x.depart)} -> ${hhmm(x.arrive)}  ${x.airlineName || ''}`);
+      console.log(`     returnId ${x.departureId}`);
+    }
+    console.log('\nNext: navan flights price --search=' + searchId + ' --departure=' + depId + ' --return=<returnId>');
+    return;
+  }
+  if (sub === 'price') {
+    const searchId = arg(rest, 'search'), depId = arg(rest, 'departure'), retId = arg(rest, 'return');
+    if (!searchId || !depId) { console.error('Usage: navan flights price --search=<id> --departure=<departureId> [--return=<returnId>]'); process.exit(2); }
+    // resolve fareIds from the option listings
+    let depFare = arg(rest, 'departure-fare'), retFare = arg(rest, 'return-fare');
+    if (!depFare) {
+      const dl = await pollFlightOptions(searchId);
+      const dopt = ((dl && dl.options) || []).find(o => o.uuid === depId);
+      depFare = dopt && dopt.selectedFareId;
+    }
+    if (retId && !retFare) {
+      const rl = await api('POST', `/api/v1/trip/flight/searches/${searchId}/departures/${depId}/returns?offset=0&limit=20&loadAmenities=true&displayOnlyAffiliateFlights=false`, {});
+      const ropt = ((rl.json && rl.json.options) || []).find(o => o.uuid === retId);
+      retFare = ropt && ropt.selectedFareId;
+    }
+    let path;
+    if (retId) {
+      const qp = new URLSearchParams(); if (depFare) qp.set('departureFareId', depFare); if (retFare) qp.set('returnFareId', retFare); qp.set('timestamp', String(Date.now()));
+      path = `/api/v1/trip/flight/searches/${searchId}/departures/${depId}/returns/${retId}/contractV2?${qp.toString()}`;
+    } else {
+      const qp = new URLSearchParams(); if (depFare) qp.set('departureFareId', depFare);
+      path = `/api/v1/trip/flight/searches/${searchId}/departures/${depId}/contractV2?${qp.toString()}`;
+    }
+    const r = await api('POST', path, {});
+    if (r.status !== 200) fail(r, 'price contract');
+    const c = (r.json && r.json.contract) || r.json;
+    const out = { contractId: c && c.uuid, total: c && (c.totalPriceWithCCFeeInAgencyCurrency || c.totalPriceAndFee), requiresApproval: c && c.requiresApproval };
+    if (json) { console.log(JSON.stringify(out, null, 2)); return; }
+    console.log(`contractId: ${out.contractId}`);
+    console.log(`total:      ${money(out.total)}`);
+    console.log(`approval:   ${out.requiresApproval ? 'required' : 'no'}`);
+    console.log('\nNext: navan book flight --search=' + searchId + ' --contract=' + out.contractId + ' --confirm');
+    return;
+  }
+  console.error('Usage: navan flights <search|returns|price> ...');
+  process.exit(2);
+}
+
+// ----------------- commands: hotels -----------------
+async function resolvePlace(city) {
+  const r = await api('GET', `/api/user/autocomplete/place?input=${encodeURIComponent(city)}&includeFavoriteHotels=true&addLocation=true`);
+  if (r.status !== 200) fail(r, 'place lookup');
+  const preds = (r.json && r.json.predictions) || [];
+  // prefer a city/locality prediction over a specific premise
+  const pick = preds.find(p => p.location && p.location.placeId && !(p.types || []).includes('premise')) || preds[0];
+  if (!pick || !pick.location) { console.error('No place found for "' + city + '".'); process.exit(1); }
+  const loc = pick.location;
+  return { placeId: loc.placeId, description: pick.description, lat: loc.geo && loc.geo.latitude, lon: loc.geo && loc.geo.longitude,
+    name: pick.displayName || loc.placeName };
+}
+function hotelRow(o) {
+  return { hotelId: o.uuid || o.hotelId, name: o.name, stars: o.hotelStarsRating,
+    total: o.totalPriceAndFee, daily: o.dailyRate, currency: 'EUR' };
+}
+async function cmdHotels(args) {
+  const sub = args[0]; const rest = args.slice(1); const json = hasFlag(rest, 'json');
+  if (sub === 'search') {
+    const city = arg(rest, 'city'), checkin = arg(rest, 'checkin'), checkout = arg(rest, 'checkout');
+    const guests = arg(rest, 'guests', '1'), rooms = arg(rest, 'rooms', '1');
+    if (!city || !checkin || !checkout) { console.error('Usage: navan hotels search --city=Basel --checkin=YYYY-MM-DD --checkout=YYYY-MM-DD'); process.exit(2); }
+    const place = await resolvePlace(city);
+    const p = new URLSearchParams();
+    p.set('includeSpecialRates', 'true'); p.set('description', place.description || city);
+    p.set('checkInDate', checkin); p.set('checkOutDate', checkout);
+    p.set('numberOfRooms', rooms); p.set('numberOfGuests', guests);
+    p.set('prefetchRooms', 'true'); p.set('emptyData', 'false'); p.set('placeId', place.placeId);
+    if (place.lat != null) p.set('latitude', String(place.lat));
+    if (place.lon != null) p.set('longitude', String(place.lon));
+    const cr = await api('GET', `/api/v1/trip/hotel/searches?${p.toString()}`);
+    if (cr.status !== 200) fail(cr, 'hotel search create');
+    const searchId = cr.json && cr.json.searchId;
+    let res = cr.json;
+    for (let i = 0; i < 8 && (!res || !res.options || !res.options.length); i++) {
+      await new Promise(r => setTimeout(r, 1500));
+      const pr = await api('GET', `/api/v1/trip/hotel/searches/${searchId}`);
+      if (pr.status === 200) res = pr.json;
+    }
+    const hotels = ((res && res.options) || []).map(hotelRow);
+    if (json) { console.log(JSON.stringify({ searchId, place: place.name, hotels }, null, 2)); return; }
+    console.log(`searchId: ${searchId}`);
+    console.log(`${place.name || city}  ${checkin} -> ${checkout}  ${hotels.length} hotels:`);
+    for (const h of hotels) {
+      console.log(`  ${String(h.total != null ? h.total.toFixed(0) + ' EUR' : '—').padStart(10)}  ${'*'.repeat(Math.round(h.stars || 0)).padEnd(5)} ${h.name}`);
+      console.log(`     hotelId ${h.hotelId}`);
+    }
+    console.log('\nNext: navan hotels rooms --search=' + searchId + ' --hotel=<hotelId>');
+    return;
+  }
+  if (sub === 'rooms') {
+    const searchId = arg(rest, 'search'), hotelId = arg(rest, 'hotel');
+    if (!searchId || !hotelId) { console.error('Usage: navan hotels rooms --search=<id> --hotel=<hotelId>'); process.exit(2); }
+    // Rooms load via POST /api/v2/.../rooms with the hotelId; results live at _embedded.hotels[].rooms
+    const r = await api('POST', `/api/v2/trip/hotel/searches/${searchId}/rooms`, [hotelId]);
+    if (r.status !== 200) fail(r, 'hotel rooms');
+    const hotelsArr = (r.json && r.json._embedded && r.json._embedded.hotels) || [];
+    const h = hotelsArr.find(x => (x.uuid === hotelId || x.hotelId === hotelId)) || hotelsArr[0] || {};
+    const roomArr = h.rooms || [];
+    const rooms = roomArr.map(rm => ({ roomId: rm.uuid, name: rm.displayName || rm.fullDisplayName || rm.rawRoomName || rm.shortDescription,
+      total: rm.priceInfo && (rm.priceInfo.totalPriceAndFee || rm.priceInfo.basePrice),
+      refundable: rm.bookPolicy }));
+    if (json) { console.log(JSON.stringify({ searchId, hotelId, hotel: h.name, rooms }, null, 2)); return; }
+    console.log(`${h.name || hotelId}  ${rooms.length} rooms:`);
+    for (const rm of rooms) {
+      console.log(`  ${String(rm.total != null ? Math.round(rm.total) + ' EUR' : '—').padStart(10)}  ${rm.name || ''}`);
+      console.log(`     roomId ${rm.roomId}`);
+    }
+    console.log('\nNext: navan hotels price --search=' + searchId + ' --hotel=' + hotelId + ' --room=<roomId>');
+    return;
+  }
+  if (sub === 'price') {
+    const searchId = arg(rest, 'search'), hotelId = arg(rest, 'hotel'), roomId = arg(rest, 'room');
+    if (!searchId || !hotelId || !roomId) { console.error('Usage: navan hotels price --search=<id> --hotel=<hotelId> --room=<roomId>'); process.exit(2); }
+    const r = await api('POST', `/api/v1/trip/hotel/searches/${searchId}/hotels/${hotelId}/rooms/${roomId}/contract`, {});
+    if (r.status !== 200) fail(r, 'hotel contract');
+    const c = (r.json && r.json.contract) || r.json;
+    const out = { contractId: c && c.uuid, total: c && (c.totalPriceWithCCFeeInAgencyCurrency || c.totalPriceAndFee), requiresApproval: c && c.requiresApproval };
+    if (json) { console.log(JSON.stringify(out, null, 2)); return; }
+    console.log(`contractId: ${out.contractId}`);
+    console.log(`total:      ${money(out.total)}`);
+    console.log(`approval:   ${out.requiresApproval ? 'required' : 'no'}`);
+    console.log('\nNext: navan book hotel --search=' + searchId + ' --contract=' + out.contractId + ' --confirm');
+    return;
+  }
+  console.error('Usage: navan hotels <search|rooms|price> ...');
+  process.exit(2);
+}
+
+// ----------------- commands: book (gated) -----------------
+function parseSSE(text) {
+  const events = [];
+  for (const block of text.replace(/\r/g, '').split('\n\n')) {
+    let ev = null; const data = [];
+    for (const ln of block.split('\n')) {
+      if (ln.indexOf('event:') === 0) ev = ln.slice(6).trim();
+      else if (ln.indexOf('data:') === 0) data.push(ln.slice(5));
+    }
+    if (data.length) events.push({ event: ev, data: data.join('\n') });
+  }
+  return events;
+}
+function bookResultFromSSE(text) {
+  const evs = parseSSE(text);
+  let final = null, error = null;
+  for (const e of evs) {
+    let d; try { d = JSON.parse(e.data); } catch (x) { continue; }
+    if (e.event === 'error' || (d && d.status >= 400)) error = d;
+    if (d && d.completed && d.bookResponses && d.bookResponses.length) {
+      const b = d.bookResponses[0];
+      final = { status: 'CONFIRMED', bookingId: b.bookingId, confirmationNumber: b.confirmationNumber, tripId: b.tripId };
+    }
+  }
+  return { final, error };
+}
+async function getContract(type, searchId, contractId) {
+  const path = type === 'flight'
+    ? `/api/v1/trip/flight/searches/${searchId}/contracts/${contractId}?currency=EUR`
+    : `/api/v1/trip/hotel/searches/${searchId}/contracts/${contractId}`;
+  const r = await api('GET', path);
+  if (r.status !== 200) fail(r, 'get contract');
+  return (r.json && r.json.contract) || r.json;
+}
+function summarizeContract(type, c) {
+  const total = c.totalPriceWithCCFeeInAgencyCurrency || c.totalPriceAndFee;
+  const lines = [];
+  if (type === 'flight') {
+    const it = c.flightItinerary || {};
+    const all = (it.allSegments) ||
+      [].concat(((it.departureFlight && it.departureFlight.flight && it.departureFlight.flight.flightSegments) || []),
+                ((it.returnFlight && it.returnFlight.flight && it.returnFlight.flight.flightSegments) || []));
+    for (const s of all) lines.push('  ' + segLine(s));
+  } else {
+    lines.push('  ' + (c.hotelName || (c.hotel && c.hotel.name) || 'Hotel') + '  room ' + (c.roomUuid || ''));
+  }
+  return { total, lines };
+}
+async function cmdBook(args) {
+  const type = args[0];
+  const rest = args.slice(1);
+  const searchId = arg(rest, 'search'), contractId = arg(rest, 'contract');
+  const confirm = hasFlag(rest, 'confirm');
+  const json = hasFlag(rest, 'json');
+  if (type !== 'flight' && type !== 'hotel') { console.error('Usage: navan book <flight|hotel> --search=<id> --contract=<id> [--confirm]'); process.exit(2); }
+  if (!searchId || !contractId) { console.error('Usage: navan book ' + type + ' --search=<id> --contract=<id> [--confirm]'); process.exit(2); }
+
+  const c = await getContract(type, searchId, contractId);
+  const sum = summarizeContract(type, c);
+
+  // ---- confirmation gate ----
+  if (!confirm) {
+    console.log('=== BOOKING PREVIEW (not booked) ===');
+    console.log(type.toUpperCase() + ' contract ' + contractId);
+    sum.lines.forEach(l => console.log(l));
+    console.log('  TOTAL: ' + money(sum.total));
+    if (c.requiresApproval) console.log('  NOTE: this booking requires approval.');
+    console.log('');
+    console.log('Booking spends real money and was NOT performed.');
+    console.log('To book, re-run with --confirm:');
+    console.log('  navan book ' + type + ' --search=' + searchId + ' --contract=' + contractId + ' --confirm');
+    return;
+  }
+
+  // ---- actual booking (only with --confirm) ----
+  const pr = await api('GET', '/api/user/passenger');
+  if (pr.status !== 200) fail(pr, 'passenger');
+  const passenger = pr.json;
+  const pmr = await api('GET', '/api/user/paymentMethods');
+  const pms = Array.isArray(pmr.json) ? pmr.json : [];
+  const pm = pms.find(m => m.validForPurchase) || pms[0];
+  if (!pm) { console.error('No payment method available on the account.'); process.exit(1); }
+  const paymentMethodUuid = pm.uuid;
+
+  const passengerData = [{
+    airlineLoyaltyCards: {}, airlineDiscountCards: {},
+    passenger: Object.assign({
+      uuid: passenger.uuid, givenName: passenger.givenName, middleName: passenger.middleName,
+      familyName: passenger.familyName, fullName: ((passenger.givenName || '') + ' ' + (passenger.familyName || '')).trim(),
+      birthdate: passenger.birthdate, email: passenger.contact && passenger.contact.email,
+      travelerType: 'BUSINESS', passenger: passenger,
+    }),
+  }];
+  const body = type === 'flight'
+    ? { passengerData, customFieldValues: [], sendEmailToAll: true }
+    : { customFieldValues: [], sendEmailToAll: true, passengerData };
+
+  const tripName = (c.flightItinerary && c.flightItinerary.tripName) || 'Trip';
+  const q = new URLSearchParams();
+  q.set('paymentMethodUuid', paymentMethodUuid);
+  q.set('tripName', tripName);
+  q.set('locale', LOCALE);
+  if (type === 'flight') { q.set('tripId', ''); q.set('tripUuid', ''); q.set('hold', 'false'); q.set('platedBooking', 'false'); }
+  const path = `/api/v1/trip/${type}/searches/${searchId}/contracts/${contractId}/book/streaming?${q.toString()}`;
+  const r = await api('POST', path, body);
+  const parsed = bookResultFromSSE(r.text);
+  if (parsed.error && !parsed.final) {
+    console.error('Booking failed: ' + (parsed.error.message || parsed.error.error || JSON.stringify(parsed.error).slice(0, 300)));
+    process.exit(1);
+  }
+  const out = parsed.final || { status: 'UNKNOWN', raw: r.text.slice(0, 300) };
+  if (json) { console.log(JSON.stringify(out, null, 2)); return; }
+  console.log('Booking ' + (out.status || 'UNKNOWN'));
+  console.log('  bookingId:          ' + (out.bookingId || '—'));
+  console.log('  confirmationNumber: ' + (out.confirmationNumber || '—'));
+  console.log('  tripId:             ' + (out.tripId || '—'));
+}
+
+// ----------------- commands: invoice + push-to-expense (Concur) -----------------
+// All keyed by the booking's bookingUuid (e.g. 6693f5ab-...), shown by `navan trip`.
+async function expenseStatus(bookingId) {
+  const elig = await api('GET', `/api/v1/expenseFromTravel/${bookingId}/isEligible`);
+  const after = await api('GET', `/api/v1/expenseFromTravel/${bookingId}/wasBookedAfterBookingExpenseFeature`);
+  const sync = await api('GET', `/api/invoices/v2/sync_status/${bookingId}`);
+  return {
+    eligible: elig.json ? elig.json.eligible : null,
+    eligibleStatus: elig.status,
+    bookedAfterFeature: after.json ? after.json.bookedAfterBookingExpenseFeature : null,
+    invoices: sync.status === 200 ? sync.json : null,
+    invoicesStatus: sync.status,
+  };
+}
+function invoiceFlags(inv) {
+  if (!inv) return [];
+  return Object.keys(inv).filter(k => inv[k] === true);
+}
+async function cmdInvoice(args) {
+  const json = hasFlag(args, 'json');
+  const bookingId = args.find(a => a.indexOf('--') !== 0);
+  const download = arg(args, 'download');
+  if (!bookingId) { console.error('Usage: navan invoice <bookingId> [--download=<path>] [--json]\n  <bookingId> is the bookingUuid shown by `navan trip <tripId>`.'); process.exit(2); }
+  const st = await expenseStatus(bookingId);
+  const available = invoiceFlags(st.invoices);
+  let saved = null;
+  if (download) {
+    const dl = await apiDownload(`/api/v1/invoicesinternal/download/${bookingId}?lng=${LOCALE}`);
+    if (dl.status !== 200 || !dl.base64) {
+      console.error('Invoice download failed (HTTP ' + dl.status + ')' + (dl.error ? ': ' + dl.error.slice(0, 200) : '. No invoice available yet.'));
+      process.exit(1);
+    }
+    let outPath = download;
+    if (!/\.[a-z0-9]{2,4}$/i.test(outPath)) outPath += (dl.contentType.indexOf('pdf') >= 0 ? '.pdf' : '');
+    await writeBase64(outPath, dl.base64);
+    saved = outPath;
+  }
+  if (json) { console.log(JSON.stringify({ bookingId, ...st, invoicesAvailable: available, downloaded: saved }, null, 2)); return; }
+  console.log(`Booking ${bookingId}`);
+  console.log(`  Eligible for expense push: ${st.eligible === null ? 'unknown' : st.eligible}`);
+  console.log(`  Booked after expense feature: ${st.bookedAfterFeature === null ? 'unknown' : st.bookedAfterFeature}`);
+  if (st.invoices) {
+    console.log('  Invoice availability:');
+    for (const k of Object.keys(st.invoices)) console.log(`    ${k.padEnd(22)} ${st.invoices[k] ? 'available' : 'no'}`);
+  } else {
+    console.log('  Invoice availability: unavailable (sync_status HTTP ' + st.invoicesStatus + ')');
+  }
+  if (saved) console.log(`  Invoice saved to: ${saved}`);
+  else if (available.length) console.log('  To save the invoice PDF: navan invoice ' + bookingId + ' --download=<path>');
+}
+
+async function cmdPushExpense(args) {
+  const json = hasFlag(args, 'json');
+  const confirm = hasFlag(args, 'confirm');
+  const bookingId = args.find(a => a.indexOf('--') !== 0);
+  if (!bookingId) { console.error('Usage: navan push-expense <bookingId> [--confirm]\n  <bookingId> is the bookingUuid shown by `navan trip <tripId>`.'); process.exit(2); }
+  const st = await expenseStatus(bookingId);
+  const available = invoiceFlags(st.invoices);
+
+  // ---- confirmation gate ----
+  if (!confirm) {
+    console.log('=== PUSH-TO-EXPENSE PREVIEW (not pushed) ===');
+    console.log('Booking ' + bookingId);
+    console.log('  Eligible for expense push: ' + (st.eligible === null ? 'unknown' : st.eligible));
+    console.log('  Invoices available: ' + (available.length ? available.join(', ') : 'none reported yet'));
+    console.log('  Would: PUT /api/user/bookings/' + bookingId + '/expense  -> push this booking + its invoice(s) to your expense system (Concur).');
+    if (st.eligible === false) console.log('  NOTE: isEligible is false — the push may be rejected (e.g. already expensed or not eligible).');
+    console.log('');
+    console.log('This MUTATES your expense system (Concur) and was NOT performed.');
+    console.log('To push, re-run with --confirm:');
+    console.log('  navan push-expense ' + bookingId + ' --confirm');
+    return;
+  }
+
+  // ---- perform the push (only with --confirm) ----
+  const r = await api('PUT', `/api/user/bookings/${bookingId}/expense`, null);
+  if (r.status === 400 && r.json && r.json.exceptionClass === 'EmailAccessRequiredException') {
+    console.error('Push failed: Navan needs email (Outlook/Gmail) access to send the invoice to expense.');
+    console.error('Grant it once in the Navan UI, then retry. Provider: ' + (r.json.provider || '?'));
+    if (r.json.authorizeUri) console.error('Authorize URL: ' + r.json.authorizeUri);
+    process.exit(1);
+  }
+  if (r.status !== 200) fail(r, 'push-expense');
+  const out = { bookingId, status: r.status, result: 'PUSHED', expenseUuid: r.json && r.json.uuid, dateModified: r.json && r.json.dateModified };
+  if (json) { console.log(JSON.stringify(out, null, 2)); return; }
+  console.log('Pushed to expense (Concur): ' + bookingId);
+  if (out.expenseUuid) console.log('  expense/booking uuid: ' + out.expenseUuid);
+  if (out.dateModified) console.log('  dateModified:         ' + out.dateModified);
+}
+
+// ----------------- help -----------------
+function cmdHelp() {
+  console.log(`navan — Navan (TripActions) corporate travel: search, view trips, and book.
+
+Usage:
+  navan whoami                              Show the logged-in user
+  navan trips [--json]                      List trips (name, dates, item counts, tripId)
+  navan trip <tripId> [--json]              Trip detail: flights + hotels with bookingId/confirmation
+  navan airports <query> [--json]           Airport/city autocomplete (code, name)
+
+  navan flights search --from=BER --to=BSL --depart=YYYY-MM-DD [--return=YYYY-MM-DD] [--pax=1] [--cabin=ECONOMY]
+                                            Search flights -> outbound options (departureId, price)
+  navan flights returns --search=<id> --departure=<departureId>
+                                            Return options for a chosen outbound (returnId, price)
+  navan flights price   --search=<id> --departure=<departureId> [--return=<returnId>]
+                                            Price a chosen pair -> contractId + total
+
+  navan hotels search --city=Basel --checkin=YYYY-MM-DD --checkout=YYYY-MM-DD [--guests=1] [--rooms=1]
+                                            Search hotels -> options (hotelId, price, stars)
+  navan hotels rooms  --search=<id> --hotel=<hotelId>     Rooms for a hotel (roomId, price)
+  navan hotels price  --search=<id> --hotel=<hotelId> --room=<roomId>   Price a room -> contractId + total
+
+  navan book <flight|hotel> --search=<id> --contract=<id> [--confirm]
+                                            WITHOUT --confirm: print itinerary + total and STOP (no booking).
+                                            WITH --confirm: book and print {status, bookingId, confirmationNumber, tripId}.
+
+  navan invoice <bookingId> [--download=<path>] [--json]
+                                            Report invoice sync_status + expense eligibility for a booking.
+                                            With --download, save the invoice PDF to <path>.
+  navan push-expense <bookingId> [--confirm]
+                                            Push the booking + invoice to the expense system (Concur).
+                                            WITHOUT --confirm: print eligibility + what would be pushed and STOP.
+                                            WITH --confirm: perform the PUT and report the result.
+  navan help                                Show this help
+
+Booking ids:
+  - <bookingId> for invoice / push-expense is the bookingUuid shown by
+    "navan trip <tripId>" (e.g. 6693f5ab-...), NOT the airline PNR.
+
+Auth & safety:
+  - Requires a logged-in Navan tab (${TRIPS_URL}) open in the browser. All calls run
+    inside that tab and use the "Authorization: TripActions <JWT>" header.
+  - On 401/403 the session expired: open Navan, log in, and retry.
+  - BOOKING SPENDS REAL MONEY. The book command never books without --confirm.
+  - PUSH-EXPENSE MUTATES your expense system (Concur). It never pushes without --confirm.`);
+}
+
+// ----------------- dispatch -----------------
+const argv = process.argv.slice(2);
+const cmd = argv[0];
+const rest = argv.slice(1);
+try {
+  if (cmd === 'whoami') await cmdWhoami(rest);
+  else if (cmd === 'trips') await cmdTrips(rest);
+  else if (cmd === 'trip') await cmdTrip(rest);
+  else if (cmd === 'airports') await cmdAirports(rest);
+  else if (cmd === 'flights') await cmdFlights(rest);
+  else if (cmd === 'hotels') await cmdHotels(rest);
+  else if (cmd === 'book') await cmdBook(rest);
+  else if (cmd === 'invoice') await cmdInvoice(rest);
+  else if (cmd === 'push-expense') await cmdPushExpense(rest);
+  else if (!cmd || cmd === 'help' || cmd === '--help' || cmd === '-h') cmdHelp();
+  else { console.error('Unknown command: ' + cmd); cmdHelp(); process.exit(2); }
+} catch (e) { console.error('Error:', e && e.message ? e.message : String(e)); process.exit(1); }


### PR DESCRIPTION
## What

Adds a new **`navan`** skill: a full API client for Navan (formerly TripActions) corporate travel, reverse-engineered from a live booking session via the secret-sauce methodology.

## Capabilities

- **Search:** `navan airports <q>`, `navan flights search/returns/price`, `navan hotels search/rooms/price`
- **Book (gated):** `navan book <flight|hotel> --confirm` — without `--confirm` it previews itinerary + total and refuses to book
- **Trips:** `navan trips`, `navan trip <id>` (surfaces airline PNR + bookingUuid)
- **Invoice → expense (Concur):** `navan invoice <bookingId> [--download=<path>]` (eligibility + sync status + PDF download) and `navan push-expense <bookingId> --confirm` (`PUT /api/user/bookings/{bookingUuid}/expense`, also gated)
- `navan whoami`, `navan help`; all commands support `--json`

## Auth

Cookie session is insufficient — Navan requires `Authorization: TripActions <JWT>` + `x-tripactions-locale: en-US`. The JWT is the Auth0 access token in the logged-in tab's localStorage (`@@auth0spajs@@`). All calls therefore run **page-context** inside the open `app.navan.com` tab via `playwright-cli eval-file`. 401/403 → re-login message.

## Safety

Both money-spending / state-mutating actions (`book`, `push-expense`) are **gated behind an explicit `--confirm`** flag. Booking responses are Server-Sent Events; the final `completed` event carries `{status, bookingId, confirmationNumber, tripId}`.

## Notes / gotchas documented

- Flight pricing contracts (`contractV2`) expire within minutes — re-search promptly (matches Navan's real behavior).
- The invoice download endpoint returns a **binary PDF** (handled via arrayBuffer→base64, not text()).
- `PUT …/expense` takes **no body**; a first-time 400 `EmailAccessRequiredException` means Navan needs a one-time Outlook/Gmail OAuth grant — the command surfaces the authorize link.

## Validation

Verified read-only against a live session (no real booking/push performed): whoami, trips (67 trips), trip detail, airports (Basel→BSL/EuroAirport), flight search (20 BER→BSL options), a live hotel contract reaching the booking gate, and the invoice flow (incl. a 193 KB PDF download). SKILL.md includes end-to-end workflow sections; references/endpoints.md documents the full API.