### PR TITLE
fix(linkedin): flag reposts/reshares in list output

### DIFF
--- a/skills/linkedin/SKILL.md
+++ b/skills/linkedin/SKILL.md
@@ -176,6 +176,17 @@ caption and optional alt text.
 
 List recent posts with engagement statistics (comments, likes, reposts).
 
+Each post includes an `isRepost` flag. When the page reshares another author's
+post (rather than publishing original content), `isRepost` is `true` and two
+extra fields are populated:
+
+- `repostHeader` — the reshare attribution, e.g. `"AI Ecoverse reposted this"`
+- `originalAuthor` — the name of the original author whose post was reshared
+
+For reposts, the `text` field holds the **original author's** words, not the
+page's own copy. Filter on `isRepost` when auditing only the content the page
+authored itself (e.g. content-log entries, cadence tracking, voice analysis).
+
 ### linkedin comments \<activityId\>
 
 View comments on a specific post.

--- a/skills/linkedin/scripts/linkedin.jsh
+++ b/skills/linkedin/scripts/linkedin.jsh
@@ -36,6 +36,7 @@ try {
 
 var COMPANY_URN = config.companyUrn || 'urn:li:fsd_company:122314561';
 var COMPANY_ID = config.companyId || '122314561';
+var COMPANY_NAME = config.name || '';
 var AUTH_MODE = config.auth || 'session'; // 'session' or 'oauth'
 
 // ─── Argument Parsing ────────────────────────────────────────────────────────
@@ -600,6 +601,25 @@ async function listPosts(limit) {
 
         var stats = activityCounts[activityUrn] || {};
 
+        // Detect reshares/reposts. A genuine page post has the company as the
+        // actor and no reshare header. A repost surfaces the ORIGINAL author as
+        // the actor and carries a header such as "AI Ecoverse reposted this", so
+        // its commentary text is the original author's words, not the page's.
+        // Flag these so callers don't mistake a reshare for an original post.
+        function readText(t) {
+          if (!t) return '';
+          return (typeof t === 'string' ? t : (t.text || '')) || '';
+        }
+        var repostHeader = item.header ? readText(item.header.text) : '';
+        var actorName = item.actor ? readText(item.actor.name) : '';
+        var isRepost = /\b(reposted|reshared)\b/i.test(repostHeader);
+        // Fallback: if a company name is configured and the actor is someone
+        // else, treat it as a repost even if the header text is absent.
+        if (!isRepost && COMPANY_NAME && actorName &&
+            actorName.toLowerCase() !== COMPANY_NAME.toLowerCase()) {
+          isRepost = true;
+        }
+
         // Resolve a published timestamp. Check the post item first, then walk
         // included for related update/share/activity entries.
         function pickTs(o) {
@@ -628,6 +648,9 @@ async function listPosts(limit) {
         posts.push({
           activityUrn: activityUrn,
           text: text,
+          isRepost: isRepost,
+          repostHeader: isRepost ? (repostHeader || null) : null,
+          originalAuthor: isRepost ? (actorName || null) : null,
           comments: stats.comments || 0,
           reposts: stats.reposts || 0,
           likes: stats.likes || 0,

--- a/skills/linkedin/scripts/linkedin.jsh
+++ b/skills/linkedin/scripts/linkedin.jsh
@@ -13,6 +13,39 @@
 //   linkedin watches                   List active watches
 //   linkedin monday [--limit N] [--date Nd]  Monday protocol aggregation
 //   linkedin help                      Show this help
+//
+// ┌─────────────────────────────────────────────────────────────────────────────┐
+// │ FIX — explicit sliccy: module imports (this commit)                        │
+// │                                                                             │
+// │ The `.jsh` runtime no longer injects `exec` (or `skill`/`cli`/`fmt`/`c`/    │
+// │ `http`/`browser`/`time`/`pool`) as a bare global. It still exists and      │
+// │ works exactly as before — it must now be obtained explicitly via          │
+// │ `require('sliccy:exec')`. This script (pre-existing, unrelated to this     │
+// │ PR's original repost/reshare feature) had zero `require('sliccy:...')`     │
+// │ calls and crashed immediately on every command. Concretely:               │
+// │  • Added `const exec = require('sliccy:exec');` at the top of the file.   │
+// │    Checked via grep before importing anything (same discipline as the     │
+// │    gh.jsh/gmail.jsh/outlook.jsh ports this session): this script does not  │
+// │    use `skill`, `cli`, `fmt`, `c`/`color`, `http`, `browser`, `time`, or    │
+// │    `pool` anywhere — it drives the LinkedIn tab entirely through          │
+// │    `exec('playwright-cli ...')` shell-outs, not the `sliccy:browser`       │
+// │    bridge — so none of those were imported.                               │
+// │  • Added `const fs = require('fs');` (VFS bridge, not a `sliccy:` module). │
+// │    This script's `fs.readFile` / `fs.writeFile` / `fs.stat` / `fs.rm` call │
+// │    sites needed no further changes beyond the import — those methods      │
+// │    exist directly on the `require('fs')` object, not only under           │
+// │    `.promises` (same finding as the other ports this session).            │
+// │  • `process.argv.parseFlags()` is NOT used anywhere in this script — its   │
+// │    argument parsing (see "Argument Parsing" below) was already a fully    │
+// │    manual local loop over `process.argv.slice(2)`, so no local            │
+// │    replacement was needed here.                                           │
+// │  • No other call sites changed. Every command, subcommand, and flag       │
+// │    behaves exactly as before — this is a runtime-API port, not a feature  │
+// │    or logic change.                                                       │
+// └─────────────────────────────────────────────────────────────────────────────┘
+
+const exec = require('sliccy:exec');
+const fs = require('fs'); // VFS bridge, not a sliccy: module
 
 // ─── Configuration ───────────────────────────────────────────────────────────
 
@@ -36,7 +69,13 @@ try {
 
 var COMPANY_URN = config.companyUrn || 'urn:li:fsd_company:122314561';
 var COMPANY_ID = config.companyId || '122314561';
-var COMPANY_NAME = config.name || '';
+// Read the same key `linkedin setup ... --name="..."` persists (config.companyName,
+// see the `cmd === 'setup'` handler below) — NOT `config.name`, which nothing ever
+// writes. Fixes review comment 3422836755: the repost-fallback detection in
+// listPosts() compares the post's actor name against this constant, and with the
+// wrong key it read undefined/'' for every normally-configured setup, silently
+// disabling the fallback whenever LinkedIn's reshare-header text was absent/changed.
+var COMPANY_NAME = config.companyName || '';
 var AUTH_MODE = config.auth || 'session'; // 'session' or 'oauth'
 
 // ─── Argument Parsing ────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

`linkedin list` flagged reshared posts (where the page reposts another author'''s content) indistinguishably from original page posts. Worse, for a pure repost the `text` field held the **original author'''s** commentary, so anything iterating posts (content-log auditing, cadence tracking, voice analysis, the monday dispatcher) treated a reshare as if the page had authored it.

## Change

`listPosts()` now detects reshares and adds three fields to each post:

- `isRepost` (boolean)
- `repostHeader` — the reshare attribution string, e.g. `"AI Ecoverse reposted this"` (null unless `isRepost`)
- `originalAuthor` — the name of the reshared post'''s author (null unless `isRepost`)

Detection is primarily driven by the update'''s reshare header text (matching reposted/reshared), which LinkedIn populates only on reshares. A secondary fallback flags a post when a `name` is configured for the page and the update'''s actor differs from it. Original posts are unaffected.

SKILL.md documents the new fields under `linkedin list`.

## Testing

Verified live against the AI Ecoverse company page: a real reshare of an external author'''s keynote post is now correctly flagged (`isRepost: true`, `repostHeader: "AI Ecoverse reposted this"`, `originalAuthor` set) while all original posts in the same listing remain `isRepost: false`. `linkedin help` parses clean.

---

## Additional fix (this session): `.jsh` runtime-API migration

`skills/linkedin/scripts/linkedin.jsh` had zero `require('sliccy:...')` calls anywhere in the file. Under the current `.jsh` runtime, bare globals like `exec` and `fs` no longer exist — they must be obtained via `require('sliccy:exec')` / `require('fs')`. Without this, **every** `linkedin` command crashed immediately on invocation, regardless of this PR's own changes.

This is a **pre-existing gap affecting the whole script**, unrelated to this PR's original repost/reshare-flagging feature or its author — it predates this PR and would block testing any command, not just `list`. Same class of fix already applied to `gh.jsh`, `gmail.jsh`, and `outlook.jsh` this session (and in progress on `strava.jsh`). Landed here as a prerequisite so this PR's own `list` changes could actually be exercised and reviewed live.

- Added `const exec = require('sliccy:exec');` and `const fs = require('fs');` at the top of the file — the only two old bare globals this script uses (verified via grep first: it drives the LinkedIn tab entirely through `exec('playwright-cli ...')` shell-outs, not the `sliccy:browser` bridge, and doesn't use `skill`/`cli`/`fmt`/`color`/`http`/`time`/`pool` anywhere).
- No other call sites changed — every command, subcommand, and flag behaves exactly as before. Verified with `esbuild --transform` (clean) and live against the real, logged-in AI Ecoverse company page: `linkedin list`, `linkedin comments <id>`, `linkedin watches`, `linkedin auth status`, and `linkedin help` all ran successfully post-migration, including a real repost correctly flagged via this PR's own primary (header-text) detection path.

## Additional fix (this session): repost-fallback dead-config-key bug

Fixed per [review comment](https://github.com/ai-ecoverse/skills/pull/147#discussion_r3422836755): the repost-fallback `COMPANY_NAME` constant read `config.name`, but `linkedin setup <companyId> --name="..."` persists the value as `config.companyName` (confirmed directly against the `setup` command's own implementation, and consistent with `monday()`'s pre-existing, correct `config.companyName` read). This left the fallback dead for every normally-configured setup. Now reads `config.companyName` to match what `setup` actually writes.
