### PR TITLE
ci: allow tessl review on fork PRs via gated environment

### DIFF
--- a/.github/workflows/tessl-review.yml
+++ b/.github/workflows/tessl-review.yml
@@ -1,7 +1,12 @@
 name: Tessl Skill Review
 
+# Uses pull_request_target so the review job can access TESSLIO_TOKEN on PRs
+# from forks (secrets are never exposed to plain `pull_request` fork runs).
+# The token lives in the `tessl-review` deployment environment, which is
+# configured with required reviewers — a maintainer must approve each fork
+# run before the secret is exposed to PR-supplied content.
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     paths:
       - 'skills/**'
@@ -17,14 +22,21 @@ jobs:
       skills: ${{ steps.detect.outputs.skills }}
       has_skills: ${{ steps.detect.outputs.has_skills }}
     steps:
+      # Check out the PR merge ref so detection sees the merged result that
+      # will land on main (works for fork PRs under pull_request_target).
       - uses: actions/checkout@v6
         with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 0
 
       - name: Detect changed skills in tile
         id: detect
+        # base.sha and head.sha are hex SHAs (safe to interpolate) and are both
+        # reachable from the merge commit, so this diff is exactly the PR changes.
         run: |
-          CHANGED_FILES=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+          CHANGED_FILES=$(git diff --name-only \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}")
 
           # Unique skill dirs touched in this PR
           CHANGED_SKILLS=$(echo "$CHANGED_FILES" \
@@ -75,12 +87,19 @@ jobs:
     needs: detect
     if: needs.detect.outputs.has_skills == 'true'
     runs-on: ubuntu-latest
+    # Required-reviewer gate: TESSLIO_TOKEN is an environment secret on
+    # `tessl-review`, so a maintainer must approve the run before the token
+    # is available to the (PR-supplied) skill content being reviewed.
+    environment: tessl-review
     strategy:
       fail-fast: false
       matrix:
         skill: ${{ fromJSON(needs.detect.outputs.skills) }}
     steps:
+      # Review the merged result (the PR content) rather than the base branch.
       - uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - uses: tesslio/setup-tessl@v2
         with:


### PR DESCRIPTION
## Problem

The **Tessl Skill Review** workflow can't run on PRs opened from forks. It uses the `secrets.TESSLIO_TOKEN` repo secret, and GitHub deliberately withholds secrets from workflows triggered by `pull_request` events on forks (the token is empty, so `tessl` fails with exit code 1). Approving the fork workflow run does **not** lift this — approval only lets a secret-less run start.

## Fix

Switch the trigger from `pull_request` to `pull_request_target`, which runs in the base-repo context and therefore has secret access, and gate the token behind a protected **deployment environment** so a maintainer must approve each fork run before the token is exposed to PR-supplied content.

Changes to `.github/workflows/tessl-review.yml`:

- `on: pull_request_target` (was `pull_request`).
- `detect` and `review` jobs now check out the PR **merge ref** (`refs/pull/<n>/merge`) so they operate on the merged result, and the diff uses the PR `base.sha`/`head.sha` (hex SHAs, safe to interpolate).
- The `review` job declares `environment: tessl-review`.
- `permissions` stays `contents: read`.

## Required setup before merge (maintainer action)

1. **Settings → Environments → New environment** named exactly `tessl-review`.
2. Enable **Required reviewers** and add the trusted maintainers.
3. Add an **environment secret** `TESSLIO_TOKEN` on that environment (the value currently stored as a repo secret). The repo-level secret can be removed afterwards.

With this in place, a fork PR that touches `skills/**` pauses at the `review` job until a maintainer approves the deployment; only then is `TESSLIO_TOKEN` available.

## Security note

`pull_request_target` + checking out PR content means untrusted files are present while the token is in scope, which is why the run is gated on manual maintainer approval per PR. This is acceptable if `tessl skill review` only scores/reads the skill files. If it executes skill content, we should instead move to the two-stage `workflow_run` pattern — worth confirming against the Tessl docs.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KWXYJBXM2RWCZGNSMX5Y1RDR&panel=chat)