### PR TITLE
docs(gmail): document oauth-token --intercept bootstrap path using well-known Thunderbird client

### DIFF
--- a/skills/gmail/SKILL.md
+++ b/skills/gmail/SKILL.md
@@ -56,6 +56,19 @@ Required environment variables:
 | `GWS_REFRESH_TOKEN` | Long-lived refresh token |
 | `GWS_TYPE` | Literal `authorized_user` (not used by the script) |
 
+If your organization already has a Google Cloud OAuth client and has provisioned
+these three as real secrets, set them and skip the rest of this section.
+
+### Obtaining credentials inside SLICC
+
+If you don't already have `GWS_*` values provisioned, you can bootstrap them
+yourself from inside a SLICC session using `oauth-token --intercept` and a
+well-known, publicly-documented OAuth client (no new Google Cloud project or
+app-review needed). See [`references/oauth-bootstrap.md`](references/oauth-bootstrap.md)
+for the full, tested walkthrough — including the exact intercept config, the
+token-exchange command, and a curl gotcha you'll likely hit if you improvise it
+yourself.
+
 ## Commands
 
 ### gmail mail [options]

--- a/skills/gmail/references/oauth-bootstrap.md
+++ b/skills/gmail/references/oauth-bootstrap.md
@@ -1,0 +1,128 @@
+# Bootstrapping Gmail OAuth credentials inside SLICC
+
+`gmail.jsh` needs `GWS_CLIENT_ID`, `GWS_CLIENT_SECRET`, and `GWS_REFRESH_TOKEN`
+(see the table in `SKILL.md`). If your org already has a real Google Cloud OAuth
+client with these provisioned as secrets, use those and ignore this document —
+it exists only for the case where you're starting from nothing and need to
+obtain a working set of credentials from inside a SLICC session, where there's
+no way to pre-provision arbitrary env vars and no browser session of your own
+outside SLICC's `oauth-token` command.
+
+This is **one option**, not the only way to get Gmail OAuth credentials. It
+trades "no Google Cloud project needed" for "depends on a public client ID
+whose consent screen you don't control."
+
+## The technique: a well-known public OAuth client
+
+`oauth-token --intercept` can drive an arbitrary OAuth authorization-code flow
+— it opens a real browser tab at an `authorizeUrl` you supply, a human
+completes the consent screen, and it captures the redirect URL (containing the
+`code`) once it matches a `redirectUriPattern`. It doesn't require the OAuth
+client to be pre-registered with SLICC; you just need a client ID/secret pair
+that Google has already approved for the scope you want.
+
+Rather than registering a new Google Cloud OAuth app (which requires app
+verification for sensitive Gmail scopes), this uses the OAuth client ID and
+secret that Mozilla Thunderbird ships for its "Sign in with Google" flow.
+These are public by design — desktop/native-app OAuth clients are not
+confidential clients, and Google secures them via PKCE and redirect-URI
+matching rather than secrecy of the "secret." They are checked into Mozilla's
+own public source tree:
+
+- Source: `https://hg.mozilla.org/comm-central/raw-file/tip/mailnews/base/src/OAuth2Providers.sys.mjs`,
+  under the `kIssuers` map, key `"accounts.google.com"`.
+- `clientId: "406964657835-aq8lmia8j95dhl1a2bvharmfk3t1hgqj.apps.googleusercontent.com"`
+- `clientSecret: "kSmqreRr0qwBWJgbf5Y-PjSU"`
+- `authorizationEndpoint: "https://accounts.google.com/o/oauth2/auth"`
+- `tokenEndpoint: "https://www.googleapis.com/oauth2/v3/token"`
+
+If Google ever revokes or rotates this specific client, re-check that source
+file for the current values — Thunderbird actively maintains it.
+
+Note: `https://www.googleapis.com/oauth2/v3/token` (used below for the
+authorization-code exchange) and `https://oauth2.googleapis.com/token` (what
+`gmail.jsh` itself uses for the refresh-token grant) are both Google's token
+endpoint — v3 path vs. the newer canonical alias. Not a discrepancy; either
+works for either grant type.
+
+## Step by step
+
+### 1. Build an intercept config
+
+```json
+{
+  "authorizeUrl": "https://accounts.google.com/o/oauth2/auth?client_id=406964657835-aq8lmia8j95dhl1a2bvharmfk3t1hgqj.apps.googleusercontent.com&redirect_uri=http%3A%2F%2F127.0.0.1%3A56121&response_type=code&access_type=offline&prompt=consent&scope=https%3A%2F%2Fmail.google.com%2F",
+  "redirectUriPattern": "http://127.0.0.1:56121/*",
+  "timeoutMs": 120000
+}
+```
+
+Save it to a file in the VFS, e.g. `/tmp/gmail-intercept.json`.
+
+Key query parameters and why they're there:
+
+- `access_type=offline` — required to get a `refresh_token` back at all; without
+  it you only get a short-lived access token.
+- `prompt=consent` — forces the consent screen even for a Google account that's
+  already logged in / previously authorized this client, which is needed to
+  reliably get a *fresh* refresh token on repeat runs.
+- `scope=https://mail.google.com/` — the full-access (IMAP-equivalent) Gmail
+  scope, matching what the Thunderbird client is pre-approved for. This is the
+  only scope that's actually been tested with this client. A narrower scope
+  such as `gmail.readonly` might work but hasn't been verified — don't assume it
+  does.
+
+### 2. Run the intercept
+
+```bash
+oauth-token --from-file /tmp/gmail-intercept.json
+```
+
+This opens a real browser tab at the authorize URL. A human must complete the
+Google consent screen (this step is inherently interactive — there's no way
+around it for a brand-new grant). On success, it prints the captured redirect
+URL to stdout, e.g.:
+
+```
+http://127.0.0.1:56121/?iss=https://accounts.google.com&code=4/0AdkVLPwb...&scope=https://mail.google.com/
+```
+
+Extract the `code` query parameter from that URL.
+
+### 3. Exchange the code for tokens
+
+```bash
+curl -s -X POST "https://www.googleapis.com/oauth2/v3/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "client_id=406964657835-aq8lmia8j95dhl1a2bvharmfk3t1hgqj.apps.googleusercontent.com" \
+  --data-urlencode "client_secret=kSmqreRr0qwBWJgbf5Y-PjSU" \
+  --data-urlencode "code=<the captured code>" \
+  --data-urlencode "grant_type=authorization_code" \
+  --data-urlencode "redirect_uri=http://127.0.0.1:56121"
+```
+
+On success this returns a `200` with a JSON body containing `access_token`,
+`refresh_token`, `expires_in`, `scope`, and `token_type`.
+
+**Gotcha:** passing the same fields as multiple separate `-d` flags (the
+"naive curl example" you'll see in most online OAuth walkthroughs) fails in
+the SLICC sandbox shell with a `400 INVALID_ARGUMENT` / "Invalid JSON payload"
+error from Google's endpoint — something about how multiple `-d` args get
+concatenated or interpreted goes wrong here. Using `--data-urlencode` for
+every field, as shown above, avoids this and returns a clean response.
+
+### 4. Set the env vars
+
+The response's `refresh_token`, together with the same `client_id` and
+`client_secret` used above, are exactly the three values `gmail.jsh` needs:
+
+| From the token response / request | Maps to |
+|---|---|
+| `client_id` used in the exchange | `GWS_CLIENT_ID` |
+| `client_secret` used in the exchange | `GWS_CLIENT_SECRET` |
+| `refresh_token` field in the response | `GWS_REFRESH_TOKEN` |
+
+Set those three as environment variables and `gmail.jsh` works immediately —
+no code changes needed. This has been verified live: `gmail mail --limit 3`
+and `gmail mail --search "older_than:30d"` both returned real message data
+using credentials obtained this way.


### PR DESCRIPTION
## The gap this fixes

`skills/gmail/SKILL.md` documents the three env vars `gmail.jsh` reads
(`GWS_CLIENT_ID`, `GWS_CLIENT_SECRET`, `GWS_REFRESH_TOKEN`) and how the script
uses them for an OAuth2 refresh-token grant — but it never explains how an
agent running inside SLICC is supposed to *obtain* those values in the first
place. SLICC has no mechanism to pre-provision arbitrary env vars, and no
interactive browser session outside SLICC's own `oauth-token` command, so
anyone reading only `SKILL.md` had no path to bootstrap Gmail access at all
if they didn't already have a Google Cloud OAuth client provisioned.

## What changed

- **`skills/gmail/SKILL.md`** — kept the existing `GWS_*` env var table as-is
  (still accurate, still required), and added a short "Obtaining credentials
  inside SLICC" pointer under Authentication explaining that if you don't
  already have credentials provisioned, you can bootstrap them yourself via
  `oauth-token --intercept`, with a link to the new reference doc for the
  full walkthrough. Kept this inline addition short to avoid bloating
  `SKILL.md` with a long narrative, per the existing convention in this repo
  (see e.g. `skills/github/SKILL.md`'s short "Gotchas" pointer +
  `skills/github/references/gotchas.md`).
- **`skills/gmail/references/oauth-bootstrap.md`** (new) — the full, tested
  walkthrough:
  - Uses `oauth-token --intercept` (or `--from-file`) to drive a real Google
    consent screen without registering a new Google Cloud OAuth app, by
    reusing the well-known, publicly-documented OAuth client ID/secret that
    Mozilla Thunderbird ships for its own Gmail sign-in (sourced from
    Mozilla's public `comm-central` tree, linked in the doc, so it can be
    re-verified/refreshed if Google ever revokes that specific client).
  - The exact intercept JSON config shape (`authorizeUrl`,
    `redirectUriPattern`, `timeoutMs`) with `access_type=offline` and
    `prompt=consent` called out as required for getting a refresh token back
    reliably, and `scope=https://mail.google.com/` as the only scope that's
    actually been tested against this client.
  - The token-exchange `curl` command, using `--data-urlencode` for every
    field — and a documented gotcha: passing the same fields as multiple
    separate `-d` flags (the "obvious" naive approach, and what most online
    OAuth examples show) fails with a `400 INVALID_ARGUMENT` /
    "Invalid JSON payload" error from Google's endpoint in this sandbox.
  - How the token response maps directly onto `GWS_CLIENT_ID` /
    `GWS_CLIENT_SECRET` / `GWS_REFRESH_TOKEN`, with no code changes needed.
  - An explicit framing note that this is *one* option (a public client from
    an existing open-source app), not the only one — anyone with a real
    Google Cloud OAuth client and pre-provisioned `GWS_*` secrets should just
    use those directly and can ignore the whole document.

## What did NOT change

- `skills/gmail/scripts/gmail.jsh` — untouched. This is documentation-only;
  the script's actual auth logic (reading `GWS_*` from `process.env`, refresh-
  token grant against `https://oauth2.googleapis.com/token`) was already
  correct and needed no changes, only the docs about *obtaining* credentials
  were missing.
- The `--search` fix from #144 — out of scope here, not touched.

## How this was verified

The bootstrap sequence documented here was run live in a real SLICC session
prior to this PR: a human completed the Google consent screen via
`oauth-token --intercept`, the authorization code was exchanged for tokens
using the documented `curl --data-urlencode` command, and the resulting
`GWS_*` values were set and confirmed working — `gmail mail --limit 3` and
`gmail mail --search "older_than:30d"` both returned real Gmail data using
credentials obtained exactly this way.

The two files in this PR were uploaded via the Contents API and then pulled
back down from `raw.githubusercontent.com` on this branch; the downloaded
copies are byte-identical (diff-clean, matching SHA-256) to what was
uploaded.