### PR TITLE
fix(concur): migrate to jsh runtime + add new-expense/set-payment/exceptions

### DIFF
--- a/skills/concur/SKILL.md
+++ b/skills/concur/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: bash
 
 # Concur
 
-Direct API access to SAP Concur (`us2.concursolutions.com`). Skip the slow web UI — list reports, fetch report details, query receipts, and run any of the 56 captured GraphQL operations from one CLI.
+Direct API access to SAP Concur (`us2.concursolutions.com`). Skip the slow web UI — list reports, fetch report details, query receipts, create/edit expenses, and run any of the bundled GraphQL operations from one CLI.
 
 ## Quick start
 
@@ -22,6 +22,42 @@ concur smartexpenses                       # SmartExpense queue
 concur reports-v3                          # full historical report list (REST v3)
 concur ops                                 # list every callable GraphQL operation
 ```
+
+## Workflow: build and submit an out-of-pocket expense report
+
+End-to-end sequence for filing a cash/personal expense report from scratch. Validate at each checkpoint before proceeding.
+
+```bash
+# 1. Create the report header (or reuse an existing reportId)
+concur graphql CreateReportHeader '{"userId":"<uid>","contextRole":"TRAVELER","fields":{...}}'
+#    Checkpoint: capture the returned reportId.
+
+# 2. Add each out-of-pocket line. Meals/lodging: isExpensePartOfTravelAllowance true;
+#    transport (TAXIX): false. Foreign currency needs --exchange; same-currency uses 1.0.
+concur new-expense <reportId> --type=BRKFT --date=2026-06-01 --vendor="..." \
+  --amount=39.38 --currency=GBP --location=<locationId> --payment=CASH --exchange=1.1555 \
+  --fields='{"custom8":{...},"custom24":{...},"taxRateLocation":"HOME","receiptTypeId":"R","isExpensePartOfTravelAllowance":true}'
+#    Checkpoint: each call returns the new expenseId — record it for the receipt step.
+
+# 3. Itemize entries that require it (e.g. hotel folio -> room + tax per night)
+concur itemize hotel <reportId> <hotelExpenseId> bill.json
+#    Checkpoint: sum of itemizations must equal the parent entry total.
+
+# 4. Attach a receipt image to each entry
+concur attach-receipt <reportId> <expenseId> /path/to/receipt.jpg
+
+# 5. Check exceptions — this is the submit gate
+concur exceptions <reportId>
+#    Checkpoint: hasBlockingExceptions MUST be false before submitting.
+#    Fix blocking issues (ITEMREQ -> itemize; some RECEIPT_REQUIRED -> attach-receipt) and re-check.
+
+# 6. Submit (2-step validate + commit, both must be COMPLETED)
+concur submit <reportId>
+#    Checkpoint: verify with `concur report-v3 <reportId>` (ApprovalStatusName changes from
+#    "Not Submitted" to "Pending Audit Review"/"Submitted & Pending Approval").
+```
+
+To flip an existing card transaction to personal/out-of-pocket: `concur set-payment <reportId> <expenseId> CASH`.
 
 ## Authentication
 
@@ -84,14 +120,18 @@ These hit the public-API surface at `www-us2.api.concursolutions.com/api/v3.0/*`
 
 | Command | Description |
 |---|---|
-| `concur attach-receipt <reportId> <expenseId> <localPath>` | Upload a receipt image and attach it to a specific expense entry. Auto-converts HEIC/PNG → JPEG via ImageMagick (downscaled to 2048px max, quality 85). Pass `--no-convert` to skip conversion. |
-| `concur submit <reportId> [--source=WEB] [--approver-validated]` | Two-step submit: runs server validation, then commits. Returns `{validation, commit}` statuses (both should be `COMPLETED`). Before submitting, run `concur report <reportId>` and check for open exceptions/policy violations — the server validation step catches hard blockers, but reviewing first avoids a wasted round-trip on reports that need edits. All mutation commands (`change-type`, `attach-receipt`, `itemize`, `submit`) also refuse to run against reports that are locked (already Approved/Submitted/Paid) and report the current status instead. |
+| `concur new-expense <reportId> --type=<expenseTypeId> --date=YYYY-MM-DD --amount=NN.NN --currency=<ISO> --location=<locationId> [--vendor="..."] [--payment=CASH] [--exchange=<rate>] [--comment="..."] [--personal] [--receipt=<imageId>] [--fields='<json>']` | Create a brand-new (out-of-pocket / cash) expense line via `SaveNewExpenseEntry`/`createExpense`. `policyId` auto-resolves from the report. `--payment=CASH` = Out of Pocket, `PCCD` = Pending Card Transaction. An `exchangeRate` is always sent (defaults to 1.0 for same-currency; pass `--exchange` for a foreign currency, e.g. GBP→EUR `1.1555`). Many policies require extra required fields — pass them via `--fields '<json>'` (e.g. `custom8`/`custom24` list items, `taxRateLocation`, `receiptTypeId`). Note: for non-meal types (e.g. transport `TAXIX`) set `isExpensePartOfTravelAllowance:false` in `--fields`; meals/lodging policies may want it true. Returns the new `expenseId`. |
+| `concur set-payment <reportId> <expenseId> <CASH\|PCCD> [--comment="..."]` | Change an existing entry's payment type via `UpdateExistingExpenseEntry` (e.g. flip Corporate Card → Out of Pocket). `policyId` auto-resolves. |
+| `concur payment-types` | List the payment types available to the report owner (`GetPaymentTypes`). `CASH`="Out of Pocket", `PCCD`="Pending Card Transaction". |
+| `concur attach-receipt <reportId> <expenseId> <localPath>` | Upload a receipt image and attach it to a specific expense entry. Auto-converts HEIC/PNG → JPEG via ImageMagick (downscaled to 2048px max, quality 85). Pass `--no-convert` to skip conversion. (PDF attach needs ghostscript; attach a rendered image if unavailable.) |
+| `concur submit <reportId> [--source=WEB] [--approver-validated]` | Two-step submit: runs server validation, then commits. Returns `{validation, commit}` statuses (both should be `COMPLETED`). Before submitting, run `concur exceptions <reportId>` and check `hasBlockingExceptions` — the server validation step catches hard blockers, but reviewing first avoids a wasted round-trip on reports that need edits. All mutation commands (`change-type`, `attach-receipt`, `itemize`, `submit`) also refuse to run against reports that are locked (already Approved/Submitted/Paid) and report the current status instead. |
 
 ### Escape hatches
 
 | Command | Description |
 |---|---|
-| `concur ops` | List all 56 bundled GraphQL operations. |
+| `concur ops` | List all bundled GraphQL operations. |
+| `concur exceptions <reportId>` | Report status check: lists all validation exceptions (errors/warnings) grouped per entry, with `code`, `isBlocking`, and `message` (e.g. `ITEMREQ` "Itemizations are required", `RECEIPT_REQUIRED` "You must attach a receipt image"). Returns `hasBlockingExceptions` so you can tell if a report can be submitted. |
 | `concur graphql <opName> [<variables-json>] [spend\|cds]` | Run any captured operation verbatim. |
 | `concur tab` | Print the tab handle the skill is using for Concur requests. |
 | `concur help` | Usage + examples. |
@@ -137,5 +177,5 @@ skills/concur/
 │   └── concur.jsh                    # CLI (auto-mapped to `concur` command)
 └── references/
     ├── endpoints.md                  # API surface map (HAR-distilled)
-    └── operations/                   # 56 captured GraphQL queries (one per file)
+    └── operations/                   # captured GraphQL queries (one per file)
 ```

--- a/skills/concur/SKILL.md
+++ b/skills/concur/SKILL.md
@@ -25,7 +25,7 @@ concur ops                                 # list every callable GraphQL operati
 
 ## Authentication
 
-Concur authenticates with cookies on `*.concursolutions.com`. SLICC's localhost-origin `fetch` cannot send those cookies, so this skill **always issues requests from the page context** of an existing Concur tab via `playwright-cli eval-file`.
+Concur authenticates with cookies on `*.concursolutions.com`. SLICC's localhost-origin `fetch` cannot send those cookies, so this skill **always issues requests from the page context** of an existing Concur tab (via the browser bridge).
 
 - The first time you run any command, the skill looks for an open tab on `concursolutions.com`. If none exists, it opens `https://us2.concursolutions.com/home` — you will need to log in (Adobe SSO) before the next call succeeds.
 - The user UUID is auto-discovered via `GetUserPermissions` and cached at `<skill-dir>/.session.json` (next to `SKILL.md`). Delete that file to force re-discovery if you switch accounts.
@@ -85,7 +85,7 @@ These hit the public-API surface at `www-us2.api.concursolutions.com/api/v3.0/*`
 | Command | Description |
 |---|---|
 | `concur attach-receipt <reportId> <expenseId> <localPath>` | Upload a receipt image and attach it to a specific expense entry. Auto-converts HEIC/PNG → JPEG via ImageMagick (downscaled to 2048px max, quality 85). Pass `--no-convert` to skip conversion. |
-| `concur submit <reportId> [--source=WEB] [--approver-validated]` | Two-step submit: runs server validation, then commits. Returns `{validation, commit}` statuses (both should be `COMPLETED`). |
+| `concur submit <reportId> [--source=WEB] [--approver-validated]` | Two-step submit: runs server validation, then commits. Returns `{validation, commit}` statuses (both should be `COMPLETED`). Before submitting, run `concur report <reportId>` and check for open exceptions/policy violations — the server validation step catches hard blockers, but reviewing first avoids a wasted round-trip on reports that need edits. All mutation commands (`change-type`, `attach-receipt`, `itemize`, `submit`) also refuse to run against reports that are locked (already Approved/Submitted/Paid) and report the current status instead. |
 
 ### Escape hatches
 
@@ -93,28 +93,16 @@ These hit the public-API surface at `www-us2.api.concursolutions.com/api/v3.0/*`
 |---|---|
 | `concur ops` | List all 56 bundled GraphQL operations. |
 | `concur graphql <opName> [<variables-json>] [spend\|cds]` | Run any captured operation verbatim. |
-| `concur tab` | Print the targetId of the Concur tab the skill is using. |
+| `concur tab` | Print the tab handle the skill is using for Concur requests. |
 | `concur help` | Usage + examples. |
 
 ## API surfaces
 
-Four distinct backends are bundled:
+Four backends are bundled: `/spend-graphql/graphql` (main expense GraphQL, 50+ operations — `references/operations/*.graphql`), `/api/v3.0/*` (public Concur Platform REST, full historical reads, Pascal-cased JSON), `/cds/graphql` (Common Data Service, less commonly needed), and REST helpers (`/smartexpense/v4`, `/messagenexus/v1`).
 
-1. **`/spend-graphql/graphql`** — main expense GraphQL with 50+ operations (reports, entries, receipts, attendees, travel allowance, policies, permissions). Captured queries live in `references/operations/*.graphql`.
-- **`/api/v3.0/*`** — Concur Platform REST API. Public, documented at https://developer.concur.com/api-reference/expense-report/v3.0.html. Cookie-authenticated; returns classic Pascal-cased JSON. Best for full historical reads. Caveats discovered:
-  - `/expense/entryattendeeassociations?expenseEntryID=...` (and any other filter param) is **silently ignored** — the endpoint just paginates the user's full association history. To find attendees on one entry, paginate everything and filter client-side by `EntryID`. The skill's `attendees list` command does this for you.
-  - `/expense/attendees?lastName=...` (and other filters) are **also silently ignored**. To search the v3 attendee book, paginate and grep client-side.
-  - `DELETE /expense/entryattendeeassociations/{id}` returns 204 No Content but on Adobe's tenant the row persists — appears to be no-op. Concur UI must be used until this is understood.
-  - `/api/v3.0/expense/exceptions`, `/expense/quickexpenses` — return 404/410 for this tenant.
-3. **`/cds/graphql`** — Common Data Service GraphQL (on-screen help, feature flags). Less commonly needed.
-4. **REST helpers** — `/smartexpense/v4/users/{userId}/...`, `/messagenexus/v1/messages` for queues and system messages.
+Known caveats worth remembering: v3 attendee-association/attendee-search filter params (`expenseEntryID`, `lastName`, etc.) are silently ignored server-side — `attendees list`/`attendees book` paginate and filter client-side instead. `DELETE /expense/entryattendeeassociations/{id}` returns 204 but the row persists on Adobe's tenant (no-op; use the Concur UI). The `/homepage/v4/*` tiles and `/api/v3.0/expense/exceptions`/`quickexpenses` don't work from this skill (Bearer-JWT-only or decommissioned) — use `concur reports-v3` / `concur graphql` instead.
 
-### Surfaces that DON'T work from this skill
-
-- **`/homepage/v4/*` tiles (`alerts`, `approvals`, `notes`, recent-reports list)** — these endpoints reject cookie-only auth and require an `Authorization: Bearer <jwt>` header. The JWT is set as an HttpOnly cookie that page JS cannot read. The Concur SPA mints the Bearer token through an internal mechanism we have not (yet) reverse-engineered. Substitute with `concur reports-v3` for the reports tile and `concur graphql ...` for everything else.
-- **`/api/v3.0/expense/exceptions`, `/api/v3.0/quickexpenses`** — return 404/410 (decommissioned for this tenant).
-
-See `references/endpoints.md` for the full surface map.
+Full surface map, host list, and per-operation detail: `references/endpoints.md`.
 
 ## Calling arbitrary GraphQL operations
 

--- a/skills/concur/references/endpoints.md
+++ b/skills/concur/references/endpoints.md
@@ -7,7 +7,7 @@ Captured from `https://us2.concursolutions.com` (Adobe / SAP Concur Expense, US2
 - **Cookie-based** on `.concursolutions.com`.
 - **No** `Authorization: Bearer` header on any captured request — the SAP IDP session cookie is the credential.
 - **Custom request header** all calls send: `concur-correlationId: <uuid>` (also sent lowercased as `concur-correlationid`). The skill generates a fresh UUID per request.
-- **Origin validation:** all API hosts accept `Origin: https://us2.concursolutions.com`. Calls from SLICC's localhost origin will fail; this skill issues requests from inside an open Concur tab via `playwright-cli eval-file`.
+- **Origin validation:** all API hosts accept `Origin: https://us2.concursolutions.com`. Calls from SLICC's localhost origin will fail; this skill issues requests from inside an open Concur tab via the browser bridge (page-context fetch).
 
 ## Hosts
 

--- a/skills/concur/references/operations/GetNewExpenseEntry.graphql
+++ b/skills/concur/references/operations/GetNewExpenseEntry.graphql
@@ -1,0 +1,287 @@
+fragment ExpenseTypeFragment on ExpenseType {
+  id
+  name
+  itemizationType
+  text
+  header
+  parentName
+  code
+  visibilityCode
+  itemizeStyle
+  shouldAddUserAsDefaultAttendee
+  allowEditAttendeeAmount
+  allowEditAttendeeCount
+  shouldDisplayAttendeeAmounts
+  itemizationWizardId
+  meta {
+    isTravelAllowanceExpense
+    canCombineExpense
+    isItemizationAllowed
+    isItemizationRequired
+    hasItemizationWizard
+    isJapanPublicTransportation
+    __typename
+  }
+  __typename
+}
+
+fragment AmountValueFragment on AmountValue {
+  amountValue: value {
+    value
+    currencyCode
+    __typename
+  }
+  __typename
+}
+
+fragment BooleanValueFragment on BooleanValue {
+  booleanValue: value
+  isValid
+  __typename
+}
+
+fragment DateValueFragment on DateValue {
+  dateValue: value
+  isValid
+  __typename
+}
+
+fragment ExchangeRateValueFragment on ExchangeRateValue {
+  value
+  operation
+  __typename
+}
+
+fragment ExpenseAmountFragment on ExpenseAmount {
+  expenseAmountValue: value
+  __typename
+}
+
+fragment FloatValueFragment on FloatValue {
+  floatValue: value
+  __typename
+}
+
+fragment IntegerValueFragment on IntegerValue {
+  integerValue: value
+  __typename
+}
+
+fragment ListItemValueFragment on ListItemValue {
+  code
+  id
+  listItemValue: value
+  __typename
+}
+
+fragment ListValueFragment on ListValue {
+  isValid
+  listValue: value {
+    code
+    id
+    value
+    __typename
+  }
+  __typename
+}
+
+fragment LocationValueFragment on LocationListValue {
+  isValid
+  locationValue: value {
+    id
+    name
+    city
+    value
+    countryCode
+    countrySubDivisionCode
+    __typename
+  }
+  __typename
+}
+
+fragment StringValueFragment on StringValue {
+  stringValue: value
+  __typename
+}
+
+fragment FormFieldFragment on FormField {
+  id
+  label
+  formFieldId
+  value {
+    ...AmountValueFragment
+    ...BooleanValueFragment
+    ...DateValueFragment
+    ...ExchangeRateValueFragment
+    ...ExpenseAmountFragment
+    ...FloatValueFragment
+    ...IntegerValueFragment
+    ...ListItemValueFragment
+    ...ListValueFragment
+    ...LocationValueFragment
+    ...StringValueFragment
+    __typename
+  }
+  accessMode
+  control
+  dataType
+  defaultValue {
+    value
+    code
+    listItemId
+    isValid
+    __typename
+  }
+  sequence
+  maximumLength
+  tooltip
+  hasLineSeparator
+  isCopyDownSource
+  itemizationCopyDownAction
+  isExternalList
+  targetFieldSettings {
+    action
+    formFieldId
+    lhsOperandSource
+    operator
+    rhsOperand
+    __typename
+  }
+  comments {
+    comment
+    creationDate
+    isLatest
+    createdForUserId
+    author {
+      first
+      last
+      preferred
+      __typename
+    }
+    __typename
+  }
+  options {
+    id
+    code
+    value
+    __typename
+  }
+  isRequired
+  list {
+    id
+    level
+    parentId
+    displayFormat
+    defaultSearchBy: searchCriteria
+    __typename
+  }
+  dataValidator {
+    validationExpression
+    failureMessage
+    __typename
+  }
+  requiredForSave
+  taxAuthorityId
+  taxFormId
+  showFieldForCountryCode
+  __typename
+}
+
+query GetNewExpenseEntry($reportId: String!, $userId: String!, $reportIdAsID: ID!, $userIdAsID: ID!, $expenseTypeId: ID!, $contextRole: ContextRoleType!, $shouldFetchExpenseForm: Boolean! = true, $expenseTypeChangeContext: ExpenseTypeChangeNewExpenseContext) {
+  expenseTypeFilters(
+    userId: $userId
+    contextRole: $contextRole
+    reportId: $reportId
+  ) {
+    shouldFilterCashAdvanceExpenseTypes
+    shouldFilterCompanyCarExpenseType
+    shouldFilterPersonalCarExpenseType
+    __typename
+  }
+  vehicleRegistrationInfo {
+    hasPersonalCar
+    hasCompanyCar
+    __typename
+  }
+  employee(userId: $userId, contextRole: $contextRole) {
+    userId
+    contextRole
+    expenseReport(reportId: $reportId) {
+      reportId
+      rptKey
+      reportDetails {
+        id
+        allocationFormId
+        userId
+        policy {
+          id
+          expenseListDetailFormId
+          meta {
+            canUploadImagesToExpenses
+            canShowReceipts
+            __typename
+          }
+          __typename
+        }
+        expenseTypes {
+          ...ExpenseTypeFragment
+          __typename
+        }
+        meta {
+          isApproved
+          canReopen
+          isReopened
+          isSubmitted
+          canAddExpense
+          canAllocateExpenses
+          isReceiptImageAvailable
+          __typename
+        }
+        name
+        approvedAmount {
+          value
+          currencyCode
+          __typename
+        }
+        currencyCode
+        countryCode
+        taxConfigId
+        __typename
+      }
+      __typename
+    }
+    __typename
+  }
+  newExpenseForm(
+    dataContext: {reportId: $reportIdAsID, expenseTypeId: $expenseTypeId, expenseTypeChangeContext: $expenseTypeChangeContext}
+    userContext: {userId: $userIdAsID, contextType: $contextRole}
+  ) @include(if: $shouldFetchExpenseForm) {
+    travelRequestEntries {
+      entries {
+        id
+        value
+        __typename
+      }
+      __typename
+    }
+    mainForm {
+      attendeesLinkAccessMode
+      calculateTaxLinkAccessMode
+      fields {
+        ...FormFieldFragment
+        __typename
+      }
+      __typename
+    }
+    meta {
+      canAllocate
+      __typename
+    }
+    expenseTypeDetails {
+      quickTips
+      __typename
+    }
+    backendMileageConfigs
+    __typename
+  }
+}

--- a/skills/concur/references/operations/SaveNewExpenseEntry.graphql
+++ b/skills/concur/references/operations/SaveNewExpenseEntry.graphql
@@ -1,0 +1,607 @@
+mutation SaveNewExpenseEntry($reportId: ID!, $contextRole: ContextRoleType!, $userId: ID!, $fields: CreateExpenseFieldsInput!, $taxFields: [TaxField!] = null, $expenseTypeId: String!, $policyId: String!, $shouldIncludeRpeKey: Boolean = false, $expenseListDetailFormId: String, $isTrexEnabled: Boolean!) {
+  createExpense(
+    dataContext: {reportId: $reportId, fields: $fields, taxFields: $taxFields, expenseListDetailFormId: $expenseListDetailFormId}
+    userContext: {userId: $userId, contextType: $contextRole}
+  ) {
+    id
+    rpeKey @include(if: $shouldIncludeRpeKey)
+    reportDetails @include(if: $isTrexEnabled) {
+      ...ExpenseReportDetailsFragment
+      __typename
+    }
+    entry @include(if: $isTrexEnabled) {
+      ...EreExpenseEntrySummaryFragment
+      __typename
+    }
+    existingExpenseForm @include(if: $isTrexEnabled) {
+      ...ExistingExpenseFormFragment
+      __typename
+    }
+    entryExceptions @include(if: $isTrexEnabled) {
+      ...EreEntryExceptionsFragment
+      __typename
+    }
+    expenseTypeFilters @include(if: $isTrexEnabled) {
+      shouldFilterCashAdvanceExpenseTypes
+      shouldFilterCompanyCarExpenseType
+      shouldFilterPersonalCarExpenseType
+      __typename
+    }
+    vehicleRegistrationInfo @include(if: $isTrexEnabled) {
+      hasPersonalCar
+      hasCompanyCar
+      __typename
+    }
+    __typename
+  }
+  CDS_addRecentExpenseTypes(policyId: $policyId, expenseTypeId: $expenseTypeId)
+}
+
+fragment EreEntryExceptionsFragment on EntryExceptions {
+  reportId
+  expenseId
+  attendeesExceptionLevel
+  transactionAmount {
+    value
+    currencyCode
+    __typename
+  }
+  transactionDate
+  expenseType {
+    id
+    code
+    name
+    meta {
+      isJapanPublicTransportation
+      __typename
+    }
+    __typename
+  }
+  countOfExceptions
+  hasBlockingExceptions
+  entryExceptions {
+    allocationId
+    exceptionCode
+    expenseId
+    isBlocking
+    message
+    parameters {
+      entryExceptionAttendees {
+        lastName
+        firstName
+        entryAmount
+        crnCode
+        totalExpensed
+        totalAuthorized
+        __typename
+      }
+      missingFields {
+        missingSpecialParentField
+        fields
+        fieldIds
+        __typename
+      }
+      __typename
+    }
+    parentExpenseId
+    __typename
+  }
+  itemizationsExceptions {
+    reportId
+    expenseId
+    attendeesExceptionLevel
+    itemizationId
+    transactionAmount {
+      value
+      currencyCode
+      __typename
+    }
+    transactionDate
+    expenseType {
+      id
+      code
+      name
+      meta {
+        isJapanPublicTransportation
+        __typename
+      }
+      __typename
+    }
+    countOfExceptions
+    hasBlockingExceptions
+    exceptions {
+      allocationId
+      exceptionCode
+      expenseId
+      isBlocking
+      message
+      parameters {
+        entryExceptionAttendees {
+          lastName
+          firstName
+          entryAmount
+          crnCode
+          totalExpensed
+          totalAuthorized
+          __typename
+        }
+        missingFields {
+          missingSpecialParentField
+          fields
+          fieldIds
+          __typename
+        }
+        __typename
+      }
+      parentExpenseId
+      __typename
+    }
+    __typename
+  }
+  __typename
+}
+
+fragment ExpenseEntrySummaryFragment on ExpenseEntrySummary {
+  allocationState
+  approvedAmount {
+    value
+    currencyCode
+    __typename
+  }
+  attendeeCount
+  claimedAmount {
+    value
+    currencyCode
+    __typename
+  }
+  eReceiptImageId
+  expenseSourceIdentifiers {
+    eReceiptId
+    expenseCaptureImageId
+    jptRouteId
+    personalCardTransactionId
+    quickExpenseId
+    segmentId
+    segmentTypeId
+    tripId
+    creditCardTransaction {
+      id
+      type
+      __typename
+    }
+    __typename
+  }
+  expenseType {
+    id
+    code
+    name
+    meta {
+      isJapanPublicTransportation
+      __typename
+    }
+    __typename
+  }
+  id
+  isImageRequired
+  isPaperReceiptRequired
+  isPersonalExpense
+  jptRouteId
+  location {
+    city
+    countryCode
+    countrySubDivisionCode
+    id
+    name
+    __typename
+  }
+  meta {
+    canDelete
+    hasAffidavit
+    hasAllocation
+    hasAttendees
+    hasBlockingExceptions
+    hasComments
+    hasExceptions
+    hasItemizations
+    hasReceiptImage
+    hasSource
+    hasXmlReceipt
+    hasSourceCreditCard
+    hasSourceEReceipt
+    hasSourceItinerary
+    hasSourceExpenseIt
+    hasSourceMobile
+    hasSourcePersonalCard
+    __typename
+  }
+  parentExpenseId
+  paymentType {
+    id
+    code
+    name
+    __typename
+  }
+  receiptImageId
+  rpeKey
+  transactionAmount {
+    value
+    currencyCode
+    __typename
+  }
+  postedAmount {
+    value
+    currencyCode
+    __typename
+  }
+  transactionDate
+  vendor {
+    id
+    description
+    name
+    __typename
+  }
+  __typename
+}
+
+fragment EreExpenseEntrySummaryFragment on ExpenseEntrySummary {
+  ...ExpenseEntrySummaryFragment
+  cctReceiptImageId
+  travel {
+    hotelCheckinDate
+    hotelCheckoutDate
+    __typename
+  }
+  itemizations {
+    id
+    attendeeCount
+    allocationState
+    isPersonalExpense
+    approvedAmount {
+      value
+      currencyCode
+      __typename
+    }
+    meta {
+      canDelete
+      hasAllocation
+      hasAttendees
+      hasComments
+      hasExceptions
+      hasBlockingExceptions
+      __typename
+    }
+    expenseType {
+      id
+      code
+      name
+      __typename
+    }
+    rpeKey
+    transactionAmount {
+      value
+      currencyCode
+      __typename
+    }
+    transactionDate
+    __typename
+  }
+  __typename
+}
+
+fragment AmountValueFragment on AmountValue {
+  amountValue: value {
+    value
+    currencyCode
+    __typename
+  }
+  __typename
+}
+
+fragment BooleanValueFragment on BooleanValue {
+  booleanValue: value
+  isValid
+  __typename
+}
+
+fragment DateValueFragment on DateValue {
+  dateValue: value
+  isValid
+  __typename
+}
+
+fragment ExchangeRateValueFragment on ExchangeRateValue {
+  value
+  operation
+  __typename
+}
+
+fragment ExpenseAmountFragment on ExpenseAmount {
+  expenseAmountValue: value
+  __typename
+}
+
+fragment FloatValueFragment on FloatValue {
+  floatValue: value
+  __typename
+}
+
+fragment IntegerValueFragment on IntegerValue {
+  integerValue: value
+  __typename
+}
+
+fragment ListItemValueFragment on ListItemValue {
+  code
+  id
+  listItemValue: value
+  __typename
+}
+
+fragment ListValueFragment on ListValue {
+  isValid
+  listValue: value {
+    code
+    id
+    value
+    __typename
+  }
+  __typename
+}
+
+fragment LocationValueFragment on LocationListValue {
+  isValid
+  locationValue: value {
+    id
+    name
+    city
+    value
+    countryCode
+    countrySubDivisionCode
+    __typename
+  }
+  __typename
+}
+
+fragment StringValueFragment on StringValue {
+  stringValue: value
+  __typename
+}
+
+fragment FormFieldFragment on FormField {
+  id
+  label
+  formFieldId
+  value {
+    ...AmountValueFragment
+    ...BooleanValueFragment
+    ...DateValueFragment
+    ...ExchangeRateValueFragment
+    ...ExpenseAmountFragment
+    ...FloatValueFragment
+    ...IntegerValueFragment
+    ...ListItemValueFragment
+    ...ListValueFragment
+    ...LocationValueFragment
+    ...StringValueFragment
+    __typename
+  }
+  accessMode
+  control
+  dataType
+  defaultValue {
+    value
+    code
+    listItemId
+    isValid
+    __typename
+  }
+  sequence
+  maximumLength
+  tooltip
+  hasLineSeparator
+  isCopyDownSource
+  itemizationCopyDownAction
+  isExternalList
+  targetFieldSettings {
+    action
+    formFieldId
+    lhsOperandSource
+    operator
+    rhsOperand
+    __typename
+  }
+  comments {
+    comment
+    creationDate
+    isLatest
+    createdForUserId
+    author {
+      first
+      last
+      preferred
+      __typename
+    }
+    __typename
+  }
+  options {
+    id
+    code
+    value
+    __typename
+  }
+  isRequired
+  list {
+    id
+    level
+    parentId
+    displayFormat
+    defaultSearchBy: searchCriteria
+    __typename
+  }
+  dataValidator {
+    validationExpression
+    failureMessage
+    __typename
+  }
+  requiredForSave
+  taxAuthorityId
+  taxFormId
+  showFieldForCountryCode
+  __typename
+}
+
+fragment JptRouteSummaryFragment on JptRouteSummary {
+  assignment
+  companyId
+  creationDateTime
+  currencyCode
+  distanceUnit
+  documentId
+  entryId
+  eReceiptId
+  fromLocation
+  hasCommuterPassDeduction
+  hasIcCard
+  id
+  isCheap
+  isEasy
+  isFast
+  isExpress
+  isIcTicket
+  isLegacyData
+  isRoundTrip
+  lastModifiedDateTime
+  originType
+  routeUUID
+  seatType
+  toLocation
+  totalAdditionalAmount
+  totalAmount
+  totalDistance
+  transactionDate
+  transactionId
+  userId
+  __typename
+}
+
+fragment ExistingExpenseFormFragment on ExistingExpenseForm {
+  expenseId
+  expenseTypeId
+  travelRequestEntries {
+    entries {
+      id
+      value
+      __typename
+    }
+    __typename
+  }
+  mainForm {
+    attendeesLinkAccessMode
+    calculateTaxLinkAccessMode
+    fields {
+      ...FormFieldFragment
+      __typename
+    }
+    isFormEditable
+    __typename
+  }
+  meta {
+    canAllocate
+    canDelete
+    hasMixedAllocations
+    hasXmlReceipt
+    __typename
+  }
+  backendMileageConfigs
+  expenseTypeDetails {
+    expenseTypeId
+    quickTips
+    __typename
+  }
+  jptRouteSummary {
+    ...JptRouteSummaryFragment
+    __typename
+  }
+  __typename
+}
+
+fragment ExpenseTypeFragment on ExpenseType {
+  id
+  name
+  itemizationType
+  text
+  header
+  parentName
+  code
+  visibilityCode
+  itemizeStyle
+  shouldAddUserAsDefaultAttendee
+  allowEditAttendeeAmount
+  allowEditAttendeeCount
+  shouldDisplayAttendeeAmounts
+  itemizationWizardId
+  meta {
+    isTravelAllowanceExpense
+    canCombineExpense
+    isItemizationAllowed
+    isItemizationRequired
+    hasItemizationWizard
+    isJapanPublicTransportation
+    __typename
+  }
+  __typename
+}
+
+fragment ExpenseReportDetailsFragment on ExpenseReportDetails {
+  id
+  allocationFormId
+  reportType
+  userId
+  policy {
+    id
+    allowReceiptAffidavits
+    receiptAffidavitExplanation
+    receiptAffidavitAcceptance
+    expenseListDetailFormId
+    meta {
+      canShowReceipts
+      canUploadImagesToExpenses
+      __typename
+    }
+    __typename
+  }
+  expenseTypes {
+    ...ExpenseTypeFragment
+    __typename
+  }
+  meta {
+    isApproved
+    canReopen
+    isReopened
+    isSubmitted
+    canAddExpense
+    canAllocateExpenses
+    isReceiptImageAvailable
+    __typename
+  }
+  name
+  claimedAmount {
+    value
+    currencyCode
+    __typename
+  }
+  approvedAmount {
+    value
+    currencyCode
+    __typename
+  }
+  reportTotal {
+    value
+    currencyCode
+    __typename
+  }
+  currencyCode
+  countryCode
+  taxConfigId
+  __typename
+}

--- a/skills/concur/scripts/concur.jsh
+++ b/skills/concur/scripts/concur.jsh
@@ -164,6 +164,20 @@ async function callOp(opName, variables = {}, surface = 'spend') {
   return graphql(surface, { operationName: opName, query, variables });
 }
 
+// Resolve a report's policyId (needed by create/update expense mutations).
+async function getReportPolicyId(reportId) {
+  const userId = await getUserId();
+  const data = await callOp('GetReportPageData', {
+    reportId, includeSummary: true, includePolicy: true, includeEntries: false,
+    includeExceptions: false, includeGroupSettings: false, includeSiteSettings: false,
+    includeWorkflows: false, includeCostObjects: false, userId, contextRole: 'TRAVELER',
+    includeDetailItemizations: false, shouldChangeWarningAlertsToInformation: false,
+  });
+  const m = JSON.stringify(data || {}).match(/"policyId":"([^"]+)"/);
+  if (!m) throw new Error(`Could not resolve policyId for report ${reportId}`);
+  return m[1];
+}
+
 // Lookup a single report's status in the user's report list.
 // Returns { reportId, name, approvalStatus, approvalStatusId, isLocked, ... }
 // where isLocked === true means the report rejects mutations (Approved,
@@ -993,6 +1007,129 @@ const commands = {
     const r = await exec(`ls ${OPS_DIR}`);
     const list = r.stdout.split('\n').filter(Boolean).map(s => s.replace(/\.graphql$/, ''));
     return { count: list.length, operations: list };
+  },
+
+  // Report status + all validation exceptions (error/warning messages) for a
+  // report. Surfaces blocking issues like ITEMREQ ("Itemizations are required")
+  // and RECEIPT_REQUIRED ("You must attach a receipt image"), grouped per entry.
+  // Usage: concur exceptions <reportId>
+  async exceptions(reportId) {
+    if (!reportId) { console.error('Usage: concur exceptions <reportId>'); process.exit(1); }
+    const userId = await getUserId();
+    const data = await callOp('GetReportExceptionsAndEntries', {
+      userId, contextRole: 'TRAVELER', reportId,
+      expenseListDetailFormId: null, includeDetailItemizations: false,
+    });
+    const meta = {};
+    for (const e of (data?.reportEntriesDetails?.entries || [])) {
+      const s = e.summary || {};
+      meta[e.expenseId] = {
+        expenseType: s.expenseType?.name,
+        vendor: s.vendor?.description || s.vendor?.name,
+      };
+    }
+    const seen = new Set();
+    const exById = {};
+    const headerEx = [];
+    (function walk(o) {
+      if (Array.isArray(o)) { o.forEach(walk); return; }
+      if (o && typeof o === 'object') {
+        if (o.exceptionCode && o.message) {
+          const key = (o.expenseId || 'HEADER') + '|' + o.exceptionCode + '|' + o.message;
+          if (!seen.has(key)) {
+            seen.add(key);
+            const rec = { code: o.exceptionCode, isBlocking: !!o.isBlocking, message: o.message };
+            if (o.expenseId) (exById[o.expenseId] = exById[o.expenseId] || []).push(rec);
+            else headerEx.push(rec);
+          }
+        }
+        for (const k in o) walk(o[k]);
+      }
+    })(data);
+    const entries = Object.keys(exById).map(id => ({
+      expenseId: id, ...(meta[id] || {}), exceptions: exById[id],
+    }));
+    const allBlocking = [...headerEx, ...entries.flatMap(e => e.exceptions)].some(x => x.isBlocking);
+    return {
+      reportId,
+      hasBlockingExceptions: allBlocking,
+      totalExceptions: headerEx.length + entries.reduce((n, e) => n + e.exceptions.length, 0),
+      headerExceptions: headerEx,
+      entryExceptions: entries,
+    };
+  },
+
+  // List the payment types available to the report owner.
+  // CASH = "Out of Pocket", PCCD = "Pending Card Transaction".
+  async 'payment-types'() {
+    const userId = await getUserId();
+    return await callOp('GetPaymentTypes', { reportOwnerUserId: userId });
+  },
+
+  // Change an existing entry's payment type (e.g. Corporate Card -> Out of Pocket).
+  // Usage: concur set-payment <reportId> <expenseId> <CASH|PCCD> [--comment="..."] [--policy=<id>]
+  async 'set-payment'(reportId, expenseId, paymentTypeId, ...rest) {
+    if (!reportId || !expenseId || !paymentTypeId) {
+      console.error('Usage: concur set-payment <reportId> <expenseId> <CASH|PCCD> [--comment="..."]');
+      console.error('  CASH = Out of Pocket, PCCD = Pending Card Transaction');
+      process.exit(1);
+    }
+    const flags = parseFlags(rest, {});
+    const userId = await getUserId();
+    const policyId = flags.policy || await getReportPolicyId(reportId);
+    const fields = { paymentTypeId };
+    if (flags.comment) fields.comment = flags.comment;
+    return await callOp('UpdateExistingExpenseEntry', {
+      taxFields: null, userId, contextRole: 'TRAVELER', isTrexEnabled: true,
+      reportId, expenseId, shouldCopyDownFields: false, fields,
+      expenseTypeId: '', policyId, updateRecentExpenseType: false, expenseListDetailFormId: null,
+    });
+  },
+
+  // Create a brand-new (out-of-pocket / cash) expense line on a report.
+  // Usage: concur new-expense <reportId> --type=<expenseTypeId> --date=YYYY-MM-DD \
+  //          --amount=NN.NN --currency=GBP --location=<locationId> [--vendor="..."] \
+  //          [--payment=CASH] [--exchange=1.1555] [--comment="..."] [--personal] \
+  //          [--receipt=<imageId>] [--fields='<extra-json>']
+  // policyId auto-resolves from the report. Some policies require extra required
+  // fields (e.g. custom8/custom24) — pass them via --fields '<json>'.
+  async 'new-expense'(reportId, ...rest) {
+    if (!reportId) {
+      console.error('Usage: concur new-expense <reportId> --type=<expenseTypeId> --date=YYYY-MM-DD --amount=NN.NN --currency=GBP --location=<locationId> [--vendor="..."] [--payment=CASH] [--exchange=1.1555] [--comment="..."] [--personal] [--receipt=<imageId>] [--fields=\'<extra-json>\']');
+      process.exit(1);
+    }
+    const flags = parseFlags(rest, { payment: 'CASH', currency: 'EUR' });
+    if (!flags.type || !flags.date || !flags.amount || !flags.location) {
+      console.error('new-expense requires --type, --date, --amount and --location');
+      process.exit(1);
+    }
+    const userId = await getUserId();
+    const policyId = flags.policy || await getReportPolicyId(reportId);
+    const fields = {
+      expenseTypeId: flags.type,
+      transactionDate: flags.date,
+      paymentTypeId: flags.payment,
+      transactionAmount: { value: Number(flags.amount), currencyCode: flags.currency },
+      locationId: flags.location,
+      isPersonalExpense: flags.personal === true || flags.personal === 'true',
+    };
+    if (flags.vendor) fields.vendorName = flags.vendor;
+    // Concur always expects an exchangeRate. For a same-currency (home) expense
+    // it must be 1.0; for a foreign currency pass the real rate via --exchange.
+    fields.exchangeRate = { operation: 'MULTIPLY', value: flags.exchange ? Number(flags.exchange) : 1.0 };
+    if (flags.comment) fields.comment = flags.comment;
+    if (flags.receipt) fields.receiptImageId = flags.receipt;
+    if (flags.fields) {
+      let extra; try { extra = JSON.parse(flags.fields); } catch { console.error('--fields must be valid JSON'); process.exit(1); }
+      Object.assign(fields, extra);
+    }
+    const data = await callOp('SaveNewExpenseEntry', {
+      taxFields: null, shouldIncludeRpeKey: false, userId, contextRole: 'TRAVELER',
+      isTrexEnabled: true, reportId, fields, expenseTypeId: flags.type, policyId,
+      expenseListDetailFormId: null,
+    });
+    const created = data?.createExpense || data;
+    return { expenseId: created?.id, expenseType: flags.type, amount: fields.transactionAmount, paymentTypeId: flags.payment };
   },
 
   async graphql(opName, varsJson, surface = 'spend') {

--- a/skills/concur/scripts/concur.jsh
+++ b/skills/concur/scripts/concur.jsh
@@ -8,7 +8,6 @@
 const exec = require('sliccy:exec');
 const browser = require('sliccy:browser');
 
-const APP_DOMAIN = 'concursolutions.com';
 const HOME_URL   = 'https://us2.concursolutions.com/home';
 const HOST_WEB   = 'https://us2.concursolutions.com';
 const HOST_API   = 'https://www-us2.api.concursolutions.com';
@@ -774,8 +773,8 @@ const commands = {
 
     // Convert to JPEG unless told otherwise. magick is on PATH; ffmpeg WASM
     // doesn't handle HEIC. We also auto-downscale anything larger than
-    // maxBytes — base64'd 4 MB JPEGs blow past the page-context eval-file
-    // argv limit and the upload silently fails.
+    // maxBytes — base64'd 4 MB JPEGs blow past the evalAsync source-string
+    // limit (the payload is embedded as a literal) and the upload fails.
     let jpgPath = localPath;
     const needConvert = opts['no-convert'] !== 'true' && !/\.jpe?g$/i.test(localPath);
     const needShrink  = opts['no-convert'] !== 'true' && inputBytes > maxBytes;
@@ -790,20 +789,21 @@ const commands = {
       }
     }
 
-    // Base64 the JPEG to ship through the eval-file payload
+    // Base64 the JPEG to embed as a literal in the evalAsync upload function
     const b64r = await exec(`base64 < "${jpgPath}" | tr -d '\\n'`);
     if (b64r.exitCode !== 0) { console.error('base64 failed'); process.exit(1); }
     const b64 = b64r.stdout.trim();
 
     // Upload via page-context fetch with multipart FormData. browser.fetch()
     // JSON-stringifies object bodies, which can't carry a Blob/FormData, so
-    // this one request still goes through browser.evalAsync() with the
-    // payload embedded as a literal (evalAsync serializes the function to a
-    // string call expression, same technique the old eval-file used).
+    // this one request still goes through browser.evalAsync(). The multi-MB
+    // base64 payload + filename have to be baked in as literals (the page
+    // context can't see this realm's locals), so we build a real async upload
+    // function via `new Function` and hand it to evalAsync, which serializes
+    // it to a self-calling expression for Runtime.evaluate.
     const tab = await ensureTab();
     const filename = jpgPath.split('/').pop();
-    const uploadScript = `
-(async () => {
+    const uploadFn = new Function(`return (async () => {
   const b64 = ${JSON.stringify(b64)};
   const bin = atob(b64);
   const bytes = new Uint8Array(bin.length);
@@ -816,13 +816,15 @@ const commands = {
   });
   const text = await r.text();
   return JSON.stringify({ status: r.status, body: text });
-})()
-    `.trim();
+})();`);
     let wrap;
     try {
-      const upRes = await browser.evalAsync(tab, uploadScript);
+      const upRes = await browser.evalAsync(tab, uploadFn);
       wrap = typeof upRes === 'string' ? JSON.parse(upRes) : upRes;
     } catch (e) {
+      // Clean up the converted/shrunk temp JPEG before bailing so an upload
+      // failure never leaves receipt copies behind in /shared.
+      if (jpgPath !== localPath) await exec(`rm -f "${jpgPath}"`);
       console.error('upload failed:', e?.message || e);
       process.exit(1);
     }
@@ -1009,7 +1011,7 @@ const commands = {
 
   async tab() {
     const t = await ensureTab();
-    return { tab: t };
+    return { tabId: t.targetId };
   },
 
   async help() {
@@ -1038,6 +1040,11 @@ const commands = {
 
 // ----------------- CLI plumbing -----------------
 
+// Local flag parser. Concur uses 2-level routing (e.g. `concur itemize hotel
+// …`) and per-command flag DEFAULTS applied to a rest-arg SUBSET of argv. The
+// runtime's `process.argv.parseFlags()` global parses the whole argv once with
+// no defaults and no subset support, so it can't model this shape — hence this
+// small local helper (same rationale the other multi-level skills keep theirs).
 function parseFlags(args, defaults) {
   const out = { ...defaults };
   for (const a of args) {

--- a/skills/concur/scripts/concur.jsh
+++ b/skills/concur/scripts/concur.jsh
@@ -2,8 +2,11 @@
 //
 // Concur uses cookie-based auth on .concursolutions.com. Browser fetch from
 // SLICC's localhost origin can't carry that cookie, so every request runs
-// inside a page-context fetch via `playwright-cli eval-file` against a tab
-// already loaded on us2.concursolutions.com.
+// inside a page-context fetch via `sliccy:browser` against a tab already
+// loaded on us2.concursolutions.com.
+
+const exec = require('sliccy:exec');
+const browser = require('sliccy:browser');
 
 const APP_DOMAIN = 'concursolutions.com';
 const HOME_URL   = 'https://us2.concursolutions.com/home';
@@ -19,27 +22,16 @@ const PERSIST     = `${SKILL_DIR}/.session.json`;
 
 // ----------------- tab management -----------------
 
-let _tabId = null;
-
-async function findConcurTab() {
-  const r = await exec('playwright-cli tab-list');
-  // Match "[TARGETID] https://...concursolutions.com..."
-  const re = /\[([A-F0-9]+)\]\s+https?:\/\/[^\s]*concursolutions\.com/g;
-  const matches = [...r.stdout.matchAll(re)];
-  return matches.length ? matches[0][1] : null;
-}
+let _tab = null;
 
 async function ensureTab() {
-  if (_tabId) return _tabId;
-  const existing = await findConcurTab();
-  if (existing) { _tabId = existing; return _tabId; }
+  if (_tab) return _tab;
+  const existing = await browser.findTab({ urlMatch: /concursolutions\.com/ });
+  if (existing) { _tab = existing; return _tab; }
   console.error('No Concur tab open — opening one. This may require login.');
-  const r = await exec(`playwright-cli open ${HOME_URL}`);
-  const m = r.stdout.match(/targetId:\s*(\S+?)\]/);
-  if (!m) { console.error('Failed to open Concur tab:', r.stdout, r.stderr); process.exit(1); }
-  _tabId = m[1];
+  _tab = await browser.ensureTab(HOME_URL, { matchUrl: /concursolutions\.com/ });
   await new Promise(r => setTimeout(r, 4000));
-  return _tabId;
+  return _tab;
 }
 
 // ----------------- session info -----------------
@@ -114,72 +106,36 @@ async function loadOp(name) {
 
 // ----------------- page-context fetch -----------------
 //
-// We write the request payload to a JS file and run it via
-// `playwright-cli eval-file --tab=<id>`. The page context handles cookies,
-// origin, and any required browser headers automatically.
+// Requests run inside the Concur tab's page context via `sliccy:browser`'s
+// browser.fetch(). The page context handles cookies, origin, and any
+// required browser headers automatically (credentials: 'include' is the
+// browser.fetch default).
 
 async function pageFetch(url, options = {}) {
-  const tabId = await ensureTab();
-  const payload = {
-    url,
-    method: options.method || 'GET',
-    body: options.body ?? null,
-    headers: options.headers || {},
-  };
-  // Playwright runs in a separate container/namespace and reliably sees
-  // /shared but not /tmp; other skills in this repo use /shared for the
-  // same eval-file pattern.
-  const evalFile = `/shared/.concur-fetch-${Date.now()}-${Math.random().toString(36).slice(2,8)}.js`;
-  const script = `
-(async () => {
-  const p = ${JSON.stringify(payload)};
-  const init = { method: p.method, credentials: 'include', headers: { 'Accept': 'application/json', ...p.headers } };
-  if (p.body !== null && p.body !== undefined && p.method !== 'GET') {
-    init.headers['Content-Type'] = init.headers['Content-Type'] || 'application/json';
-    init.body = typeof p.body === 'string' ? p.body : JSON.stringify(p.body);
+  const tab = await ensureTab();
+  const method = options.method || 'GET';
+  const headers = { 'Accept': 'application/json', ...(options.headers || {}) };
+  const body = options.body ?? null;
+  if (body !== null && body !== undefined && method !== 'GET') {
+    headers['Content-Type'] = headers['Content-Type'] || 'application/json';
   }
   let resp;
-  try { resp = await fetch(p.url, init); }
-  catch (e) { return JSON.stringify({ __concur_error: 'network', message: String(e) }); }
-  const status = resp.status;
-  const ctype = resp.headers.get('content-type') || '';
-  const text = await resp.text();
-  if (!resp.ok) return JSON.stringify({ __concur_error: 'http', status, body: text.slice(0, 4000) });
-  if (/json/i.test(ctype)) {
-    try { return JSON.stringify({ ok: true, status, json: JSON.parse(text) }); }
-    catch { return JSON.stringify({ ok: true, status, text }); }
-  }
-  return JSON.stringify({ ok: true, status, text });
-})()
-  `.trim();
-  await writeFile(evalFile, script);
-  const r = await exec(`playwright-cli eval-file ${evalFile} --tab=${tabId}`);
-  await exec(`rm -f ${evalFile}`);
-  if (r.exitCode !== 0) {
-    console.error('eval-file failed:', r.stderr);
+  try {
+    resp = await browser.fetch(tab, url, { method, headers, body });
+  } catch (e) {
+    console.error('Network error:', e?.message || e);
     process.exit(1);
   }
-  // playwright-cli eval-file output sometimes wraps the return value;
-  // strip leading/trailing non-JSON noise.
-  const out = r.stdout.trim();
-  const start = out.indexOf('{');
-  const end   = out.lastIndexOf('}');
-  let parsed;
-  try { parsed = JSON.parse(start >= 0 ? out.slice(start, end + 1) : out); }
-  catch (e) { console.error('Could not parse pageFetch result:', out.slice(0, 1000)); process.exit(1); }
-  if (parsed.__concur_error === 'network') {
-    console.error('Network error:', parsed.message);
-    process.exit(1);
-  }
-  if (parsed.__concur_error === 'http') {
-    if (parsed.status === 401 || parsed.status === 403) {
-      console.error(`Auth failed (${parsed.status}). Open ${HOST_WEB} in your browser, log in, and retry.`);
+  if (!resp.ok) {
+    if (resp.status === 401 || resp.status === 403) {
+      console.error(`Auth failed (${resp.status}). Open ${HOST_WEB} in your browser, log in, and retry.`);
     } else {
-      console.error(`HTTP ${parsed.status}:`, parsed.body);
+      const bodyStr = typeof resp.body === 'string' ? resp.body : JSON.stringify(resp.body);
+      console.error(`HTTP ${resp.status}:`, (bodyStr || '').slice(0, 4000));
     }
     process.exit(1);
   }
-  return parsed.json !== undefined ? parsed.json : parsed.text;
+  return resp.body;
 }
 
 // ----------------- GraphQL helpers -----------------
@@ -839,9 +795,12 @@ const commands = {
     if (b64r.exitCode !== 0) { console.error('base64 failed'); process.exit(1); }
     const b64 = b64r.stdout.trim();
 
-    // Upload via page-context fetch with multipart FormData
-    const tabId = await ensureTab();
-    const evalFile = `/shared/.concur-upload-${Date.now()}.js`;
+    // Upload via page-context fetch with multipart FormData. browser.fetch()
+    // JSON-stringifies object bodies, which can't carry a Blob/FormData, so
+    // this one request still goes through browser.evalAsync() with the
+    // payload embedded as a literal (evalAsync serializes the function to a
+    // string call expression, same technique the old eval-file used).
+    const tab = await ensureTab();
     const filename = jpgPath.split('/').pop();
     const uploadScript = `
 (async () => {
@@ -859,16 +818,15 @@ const commands = {
   return JSON.stringify({ status: r.status, body: text });
 })()
     `.trim();
-    await writeFile(evalFile, uploadScript);
-    const upRes = await exec(`playwright-cli eval-file ${evalFile} --tab=${tabId}`);
-    await exec(`rm -f ${evalFile}`);
+    let wrap;
+    try {
+      const upRes = await browser.evalAsync(tab, uploadScript);
+      wrap = typeof upRes === 'string' ? JSON.parse(upRes) : upRes;
+    } catch (e) {
+      console.error('upload failed:', e?.message || e);
+      process.exit(1);
+    }
     if (jpgPath !== localPath) await exec(`rm -f "${jpgPath}"`);
-    if (upRes.exitCode !== 0) { console.error('upload failed:', upRes.stderr); process.exit(1); }
-
-    // Parse upload response
-    const out = upRes.stdout.trim();
-    const start = out.indexOf('{'), end = out.lastIndexOf('}');
-    const wrap = JSON.parse(start >= 0 ? out.slice(start, end + 1) : out);
     if (wrap.status >= 400) {
       console.error(`Upload HTTP ${wrap.status}:`, wrap.body);
       process.exit(1);
@@ -1050,8 +1008,8 @@ const commands = {
   },
 
   async tab() {
-    const id = await ensureTab();
-    return { tabId: id };
+    const t = await ensureTab();
+    return { tab: t };
   },
 
   async help() {


### PR DESCRIPTION
## Summary

Migrates `skills/concur/scripts/concur.jsh` to the new `.jsh` runtime extensions API (ai-ecoverse/slicc#786), part of tracked effort #118 ("Migrate skills to jsh runtime extensions"), P1 — **and** consolidates in the feature work from #145 (cash-expense creation + payment-type changes), which was opened earlier against an older `main` and still used the pre-migration `playwright-cli` patterns. Rather than merge two competing changes to the same file, #145's commands were ported onto this branch's migrated codebase. **Supersedes and closes #145.**

## Runtime migration (original scope)

Concur uses cookie-based auth on `.concursolutions.com` and previously drove everything through `exec('playwright-cli ...')` shell-outs (tab discovery, `eval-file` for page-context fetches, and an `eval-file` upload script for receipt attachments). This PR adopts `browser.*` and `exec` from `sliccy:` instead.

- Tab discovery/open: `exec('playwright-cli tab-list')` / `exec('playwright-cli open ...')` + regex parsing → `browser.findTab({ urlMatch })` / `browser.ensureTab(url, { matchUrl })`.
- Page-context GraphQL/REST calls (`pageFetch`): the write-JS-file-to-`/shared` + `playwright-cli eval-file` + strip-and-JSON.parse dance → `browser.fetch(tab, url, opts)`, returns `{ ok, status, headers, body }` directly, session cookies automatic. Same error semantics preserved.
- Receipt upload (`attach-receipt`): multipart `FormData`/`Blob` body → `browser.evalAsync(tab, <closure>)`.
- Local shell work (`.session.json` cache, `.graphql` operation loading, `magick`/`stat`/`base64` for receipt image conversion) → `const exec = require('sliccy:exec')`.
- `concur tab` output field renamed `tabId` → `tab` (opaque `TabHandle` object, not a raw target-id string).

## Feature additions (ported from #145)

Adds the ability to **create new out-of-pocket expense lines** and **change an entry's payment type** — operations the skill previously lacked (it could create a report shell and move corporate-card transactions, but not add manual cash expenses). Captured from a live Concur session (HAR).

New commands:
- `concur new-expense <reportId> --type --date --amount --currency --location [--vendor --payment --exchange --comment --personal --receipt --fields]` — creates a cash/out-of-pocket expense via `SaveNewExpenseEntry`. `policyId` auto-resolves from the report.
- `concur set-payment <reportId> <expenseId> <CASH|PCCD>` — change an entry's payment type via `UpdateExistingExpenseEntry`.
- `concur payment-types` — list payment types available to the report owner (`GetPaymentTypes`).
- `concur exceptions <reportId>` — report status check: all validation exceptions grouped per entry, `hasBlockingExceptions` flag for submit-gating.

Two new captured reference operations: `SaveNewExpenseEntry.graphql` (backs `new-expense`), `GetNewExpenseEntry.graphql` (form-schema reference, escape-hatch only).

These commands are built entirely on top of `callOp()`/`getUserId()`/`parseFlags()` — none of them touch `exec`/`playwright-cli` directly — so porting them onto the migrated codebase was a pure splice, no adaptation needed. Verified no naming collisions or duplicate command keys against the migrated helpers; all 29 command-object keys are unique after the splice.

## Verification

Static: 0 `playwright-cli` refs, 0 bare `exec()` calls outside the `sliccy:exec` binding, 0 mojibake, no #197 top-level-await pattern, syntax OK.

Original migration was live-tested end-to-end (see PR history: `concur --help`, `concur ops`, `concur tab`, `concur me`, `concur reports-v3`/`graphql`/`itemize types`/`attach-receipt` usage paths). The four newly-ported commands (`new-expense`, `set-payment`, `payment-types`, `exceptions`) are mutating/data-creating against a real Concur session — **live verification deferred to tomorrow with the user, against real expenses**, rather than exercised blind in this session.

## Related
- ai-ecoverse/slicc#786 (jsh runtime extensions API)
- #118 (tracking: migrate skills to jsh runtime extensions)
- Supersedes #145