### PR TITLE
fix(swarm): re-migrate swarm.jsh to require('sliccy:*') bridges

### DIFF
--- a/skills/swarm/scripts/swarm.jsh
+++ b/skills/swarm/scripts/swarm.jsh
@@ -9,6 +9,12 @@
 //  • Date formatting: custom formatDate() → fmt.date(ts*1000, 'locale')
 //  • Error handling: console.error + process.exit → cli.die / cli.help
 
+// ─── Runtime bridges (sliccy: virtual modules; bare globals hard-cut in slicc#786) ──
+const browser = require('sliccy:browser');
+const cli = require('sliccy:cli');
+const c = require('sliccy:color');
+const fmt = require('sliccy:fmt');
+
 const { positional, flags } = process.argv.parseFlags();
 const command = positional[0];
 


### PR DESCRIPTION
## Summary

Re-migrates `skills/swarm/scripts/swarm.jsh` (Foursquare/Swarm check-in history CLI) to the current `.jsh` runtime after the bare-global hard-cut in ai-ecoverse/slicc#786. Part of tracked effort #118 (Wave 0).

`swarm.jsh` was migrated in #117 while the runtime still exposed the bespoke bare globals (`browser`, `cli`, `c`, `fmt`). Those globals were later hard-cut; only `gh` had been re-fixed (#150). swarm therefore threw `ReferenceError` at runtime — it was regressed/broken.

## Change

Purely mechanical — add explicit bridge requires at the top of the script:

```js
const browser = require('sliccy:browser');
const cli = require('sliccy:cli');
const c = require('sliccy:color');
const fmt = require('sliccy:fmt');
```

Nothing else changed: `+6` lines total. Every subcommand (`checkins`, `history`, `search`, `venue`, `stats`), flag, output string, error message, `{ prefix: 'swarm' }` stderr formatting, and exit code is preserved byte-for-byte. `process.argv.parseFlags()` was already in use (now a real bare global) and all `browser.fetch` behavior is unchanged.

## APIs adopted

- `require('sliccy:browser')` — `browser.findTab` / `browser.fetch` (already used; now explicitly bridged)
- `require('sliccy:cli')` — `cli.die` / `cli.help`
- `require('sliccy:color')` — bound to `c` (the variable name every call site already uses)
- `require('sliccy:fmt')` — `fmt.date`

No `time` / `pool` / `http` / `skill` / `exec` are used by this script, so none were added.

## Verification

- `grep -c "require('sliccy" swarm.jsh` → 4 (browser, cli, color, fmt)
- Bridge usage audit: only `browser.` (4), `cli.` (10), `c.` (36), `fmt.` (2) — all have a matching require.
- `grep -n playwright-cli swarm.jsh` → only 2 hits, both in the historical migration-notes header comment (arrows describing what #117 already replaced with `browser.*`); no `playwright-cli` shell-outs remain in code.
- Syntax: `node --check` (copied to `.js`) passes; `esbuild --bundle --format=esm --external:sliccy:*` parses clean.
- `swarm --help` prints usage and exits 0; `swarm search` without a Foursquare tab hits `getTab()` → `cli.die('No Foursquare tab found…', { prefix: 'swarm' })` (exit 1) with no `ReferenceError` for browser/cli/c/fmt.

Do not merge — leaving open for review per the migration workflow.

Closes #160

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author