### PR TITLE
fix(aem-edge-functions): migrate jsh to sliccy: runtime bridges

### DIFF
--- a/skills/aem-edge-functions/scripts/aem-edge-functions.jsh
+++ b/skills/aem-edge-functions/scripts/aem-edge-functions.jsh
@@ -22,6 +22,13 @@
 //
 // Options: --stage (cloudmanager stage domain), --json (raw JSON output)
 
+// Runtime bridges: former bare globals are now require('sliccy:<name>') (issue #168).
+const cli = require('sliccy:cli');
+const browser = require('sliccy:browser');
+const fmt = require('sliccy:fmt');
+const c = require('sliccy:color'); // former bare `c` color global
+const fs = require('fs'); // plain node-ish builtin, not a sliccy: module
+
 const { positional, flags } = process.argv.parseFlags();
 const cmd = positional[0];
 


### PR DESCRIPTION
Part of #168

## Problem

The jsh realm no longer injects bare globals. Script code runs in an
AsyncFunction whose only params are `process` / `console` / `require` /
`module` / `exports` / `fetch` / `__dirname` / `__filename`. Every former
bare global (`cli`, `browser`, `fmt`, the `c` color object, `fs`) is now
undefined, so `aem-edge-functions.jsh` throws `ReferenceError: cli is not
defined` on its first line of real work.

## Fix

Add the minimal bridge requires at the top of the script — no logic changes:

```js
const cli = require('sliccy:cli');
const browser = require('sliccy:browser');
const fmt = require('sliccy:fmt');
const c = require('sliccy:color'); // former bare `c` color global
const fs = require('fs'); // plain node-ish builtin, not a sliccy: module
```

`c` is bound to `sliccy:color` (rather than renaming to `color`) to keep the
diff to added lines only — the existing `c.*` call sites are unchanged.

## Verification

A Node harness reproducing the realm's exact AsyncFunction param set + the
`require('sliccy:<name>')` resolver:

- **Before:** `REFERENCE-ERROR  cli is not defined`
- **After:** `HELP-REACHED` (no args) and `DIE-REACHED "no credentials…"`
  (`list`) — the script resolves and reaches its business logic.

No mojibake (0 `c3a2` byte sequences).
