### PR TITLE
fix(da-live): migrate jsh to sliccy: runtime bridges

### DIFF
--- a/skills/da-live/da-live.jsh
+++ b/skills/da-live/da-live.jsh
@@ -3,6 +3,11 @@
 //        da-live schema <path> [--sheet <name>]
 //        da-live recalc <path>
 
+// Runtime bridges: former bare globals are now require('sliccy:<name>') (issue #168).
+const cli = require('sliccy:cli');
+const c = require('sliccy:color'); // former bare `c` color global
+const fs = require('fs'); // plain node-ish builtin, not a sliccy: module
+
 const { positional, flags } = process.argv.parseFlags();
 const [cmd, filePath, rowsArg] = positional;
 


### PR DESCRIPTION
Part of #168

## Problem

The jsh realm no longer injects bare globals. Script code runs in an
AsyncFunction whose only params are `process` / `console` / `require` /
`module` / `exports` / `fetch` / `__dirname` / `__filename`. Every former
bare global (`cli`, the `c` color object, `fs`) is now undefined, so
`da-live.jsh` throws `ReferenceError: cli is not defined`.

## Fix

Add the minimal bridge requires at the top of the script — no logic changes:

```js
const cli = require('sliccy:cli');
const c = require('sliccy:color'); // former bare `c` color global
const fs = require('fs'); // plain node-ish builtin, not a sliccy: module
```

`c` is bound to `sliccy:color` (rather than renaming to `color`) to keep the
diff to added lines only — the existing `c.*` call sites are unchanged.

## Verification

A Node harness reproducing the realm's exact AsyncFunction param set + the
`require('sliccy:<name>')` resolver:

- **Before:** `REFERENCE-ERROR  cli is not defined`
- **After:** `HELP-REACHED` (no args) and `DIE-REACHED "Usage: da-live write…"`
  (`write`) — the script resolves and reaches its business logic.

No mojibake (0 `c3a2` byte sequences).
