### PR TITLE
fix(jira): migrate jsh to sliccy: runtime bridges

### DIFF
--- a/skills/jira/jira.jsh
+++ b/skills/jira/jira.jsh
@@ -7,6 +7,11 @@
 //   jira comments <issue-key>
 //   jira create --project <key> --type <type> --summary <text> [--description <text>] [--assignee <name>]
 
+// Runtime bridges: former bare globals are now require('sliccy:<name>') (issue #168).
+const cli = require('sliccy:cli');
+const browser = require('sliccy:browser');
+const c = require('sliccy:color'); // former bare `c` color global
+
 // --- Tab management ---
 
 let _tab = null;


### PR DESCRIPTION
Part of #168

## Problem

The jsh realm no longer injects bare globals. Script code runs in an
AsyncFunction whose only params are `process` / `console` / `require` /
`module` / `exports` / `fetch` / `__dirname` / `__filename`. Every former
bare global (`cli`, `browser`, the `c` color object) is now undefined, so
`jira.jsh` throws `ReferenceError: browser is not defined` as soon as a
command (e.g. `jira detect`) touches the browser bridge.

## Fix

Add the minimal bridge requires at the top of the script — no logic changes:

```js
const cli = require('sliccy:cli');
const browser = require('sliccy:browser');
const c = require('sliccy:color'); // former bare `c` color global
```

`c` is bound to `sliccy:color` (rather than renaming to `color`) to keep the
diff to added lines only — the existing `c.*` call sites are unchanged.

## Verification

A Node harness reproducing the realm's exact AsyncFunction param set + the
`require('sliccy:<name>')` resolver:

- **Before:** `REFERENCE-ERROR  browser is not defined` (`detect`)
- **After:** `PROCESS-EXIT 0` (help path) and `DIE-REACHED "No Jira tab found…"`
  (`detect`) — the script resolves and reaches its business logic.

No mojibake (0 `c3a2` byte sequences).
