### PR TITLE
fix(monday): migrate monday.jsh to jsh runtime bridges

### DIFF
--- a/skills/monday/scripts/monday.jsh
+++ b/skills/monday/scripts/monday.jsh
@@ -10,6 +10,11 @@
 //
 // With no positional args, auto-discovers monday-compatible commands on PATH.
 
+// Runtime bridges: the jsh runtime no longer injects `exec`/`fs` as bare
+// globals; obtain them explicitly. `exec` is callable directly.
+const exec = require('sliccy:exec');
+const fs = require('fs');
+
 // ─── Argument Parsing ────────────────────────────────────────────────────────
 
 const args = process.argv.slice(2); // argv[0]=node, argv[1]=script path, argv[2+]=actual args


### PR DESCRIPTION
## Summary

Mechanical jsh-runtime migration for `skills/monday/scripts/monday.jsh`.

The current jsh runtime no longer injects bare `exec`/`fs` globals. This binds
them explicitly at the top of the script:

```js
const exec = require('sliccy:exec'); // directly callable → {stdout, stderr, exitCode}
const fs = require('fs');
```

No behavior changes: subcommands, flag parsing (`--flag`, `--flag=value`, bare
positionals), auto-discovery, rating flow, output format, and exit codes are all
preserved. `playwright-cli` shell-outs: none present (already 0).

## Verification

- **Realm-accurate harness** (reproduces the SLICC realm's AsyncFunction param
  set + `sliccy:` require resolver):
  - pre-migration (`origin/main`): `REFERENCE-ERROR — exec is not defined`
  - post-migration: `RAN-CLEAN` for no-args (auto-discover), single source,
    source + flags, and rating path
- **Bare-global scan**: only bound `exec(...)`/`fs.writeFile(...)` call sites
  remain (backed by the two `require` bindings).
- **Mojibake byte-scan**: `C3A2: 0`, `C382: 0`; box-drawing chars intact.

Closes #169


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author