### PR TITLE
fix(github): avoid false top-level-await detection in gh.jsh help text

### DIFF
--- a/skills/github/scripts/gh.jsh
+++ b/skills/github/scripts/gh.jsh
@@ -1406,7 +1406,7 @@ ${color.bold('COMMANDS')}
 ${color.bold('AUTH')}
   Uses skill.token('github') (preferred), falls back to:
   git config github.token <PAT>               # persistent PAT
-  export GITHUB_TOKEN=<PAT>                   # session PAT
+  exp${''}ort GITHUB_TOKEN=<PAT>                   # session PAT
 
 ${color.bold('REPO')}
   Defaults to current git remote origin. Pass owner/repo to override.`);


### PR DESCRIPTION
## Problem

Running the `github` skill's `gh` command (`gh.jsh`) fails entirely with:

```
Failed to transpile entry source: Transform failed with 6 errors:
.../gh.jsh:178:18: ERROR: Top-level await is currently not supported with the "cjs" output format
.../gh.jsh:181:23: ERROR: Top-level await is currently not supported with the "cjs" output format
.../gh.jsh:1426:22: ERROR: Top-level await is currently not supported with the "cjs" output format
.../gh.jsh:1427:21: ERROR: Top-level await is currently not supported with the "cjs" output format
.../gh.jsh:1428:24: ERROR: Top-level await is currently not supported with the "cjs" output format
```

## Root cause

The `.jsh` runtime's transpile step does a raw-text scan for `export NAME=` style syntax to decide whether a script already uses ES-module semantics (in which case it skips its normal top-level-`await` auto-wrapping). That scan strips `'...'`/"..." quoted strings before searching, but **not backtick template literals**.

`gh.jsh`'s `showHelp()` function has a line of plain documentation text inside a template literal:

```
export GITHUB_TOKEN=<PAT>                   # session PAT
```

That raw `export GITHUB_TOKEN=` substring (just help text, not real code) false-triggers the scanner, which then skips the auto-wrapping for the *entire file* and breaks every genuine top-level `await` in `gh.jsh` (auth bootstrap + the command router at the bottom).

I bisected this by binary-searching cut-down copies of the file until isolating the exact trigger line (confirmed by swapping the word `export` for a same-length non-matching string, which fixed it, and reproducing it again by restoring the literal word).

## Fix

Split the literal word across a no-op template interpolation so it renders identically at runtime but no longer appears as a raw `export IDENT=` token to the naive scanner:

```diff
-  export GITHUB_TOKEN=<PAT>                   # session PAT
+  exp${''}ort GITHUB_TOKEN=<PAT>                   # session PAT
```

Verified `gh --help`, `gh auth`, and `gh pr list` all work correctly after this change (previously all three failed with the transpile error above).

Only `skills/github/scripts/gh.jsh` is touched — no other files.