### PR TITLE
feat(streamyard): StreamYard live-studio API client (secret-sauce)

### DIFF
--- a/skills/streamyard/SKILL.md
+++ b/skills/streamyard/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: streamyard
+description: >-
+  Interact with a StreamYard live-streaming studio via its API — read the
+  broadcast title/status, connected destinations (YouTube/LinkedIn/etc), live
+  viewer comments, and starred comments, and watch for new comments in real
+  time. Use when the user wants to check a StreamYard broadcast, monitor live
+  stream comments, build a comment overlay/ticker, or automate anything in a
+  StreamYard studio. Triggers on mentions of StreamYard, live stream comments,
+  broadcast status, studio, or a streamyard.com studio tab.
+allowed-tools: bash
+---
+
+# StreamYard
+
+Direct API access to a StreamYard live studio. All calls run **inside the open
+studio browser tab** (`streamyard.com/<id>`) via the `sliccy:browser` bridge —
+StreamYard's backend is same-origin cookie-authed REST, so the page context
+carries the session automatically. Open your studio and sign in first.
+
+## Quick start
+
+```bash
+streamyard info          # broadcast title, status, destinations, durations
+streamyard comments      # live viewer comments across connected platforms
+streamyard starred       # starred/featured comments
+streamyard watch         # stream new comments as they arrive (poll)
+streamyard watch --scoop=my-watcher   # also POST new comments to a scoop
+streamyard raw /api/broadcasts/<id>/workspace   # escape hatch
+```
+
+Add `--json` to `info`/`comments`/`starred` for machine-readable output.
+
+## How it works
+
+- The broadcast id is the studio URL path (`streamyard.com/<bid>`), auto-detected
+  from the open tab.
+- Live viewer comments per platform live at
+  `/api/broadcasts/<bid>/destinations/<destinationId>/platform_comments`, where
+  `destinationId` = `outputs[].destinationId` in the broadcast object (not the
+  output `id`). `comments` resolves this automatically for every connected output.
+- Comments only appear while the broadcast is live on a platform that has a
+  comment feed (e.g. YouTube). A `available`/`scheduled` studio returns none.
+
+See `references/endpoints.md` for the full discovered surface.
+
+## Auth
+
+Cookie session on `streamyard.com`. If a call returns 401/403, reload the studio
+tab and sign in again. Nothing is written to disk; the session lives only in the
+browser tab.

--- a/skills/streamyard/references/endpoints.md
+++ b/skills/streamyard/references/endpoints.md
@@ -1,0 +1,44 @@
+# StreamYard API — discovered surface
+
+Reverse-engineered from a live studio session (secret-sauce). All endpoints are
+**same-origin** on `https://streamyard.com`, **cookie-authenticated** (session
+cookies + `csrfToken`), and must be called from the studio tab's page context
+(SLICC's localhost-origin fetch can't carry the cookies). `<bid>` is the studio
+URL path segment (e.g. `hrva5pvcuz`).
+
+## Endpoints (GET)
+
+| Path | Returns |
+|---|---|
+| `/api/broadcasts/<bid>` | Broadcast object: `title`, `status`, `hostDisplayName`, `outputs[]`, `shownCommentIds[]`, `cumulativeDurationInMs`, `lastEpisodeDurationInMs`, `lastStartedAt`, `selectedBrandId`, … |
+| `/api/broadcasts/<bid>/destinations/<destinationId>/platform_comments` | `{ comments: [...], nextPageToken }` — live viewer comments for one connected platform |
+| `/api/broadcasts/<bid>/starred_comments` | `{ starredComments: [...] }` |
+| `/api/broadcasts/<bid>/workspace` | Workspace metadata |
+| `/api/broadcasts/<bid>/team` | Team metadata |
+| `/api/broadcasts/<bid>/token` | Studio/session token |
+| `/api/ws/auth` | Realtime websocket auth (studio state + comments push) |
+
+## `outputs[]` (connected destinations)
+
+Each output describes one streaming destination:
+
+- `id` — the output id
+- `destinationId` — the connected-account id **used for `platform_comments`**
+- `platform` — `youtube` | `linkedin` | `facebook` | …
+- `platformUsername`, `platformLink`, `platformChatId`, `platformStreamId`
+- `title`, `description`, `category`, `plannedStartTime`
+- `status` — `scheduled` | `live` | …
+
+## Realtime
+
+The studio pushes live state and comments over a WebSocket authorized via
+`/api/ws/auth`. The socket is opened at page load. For a scripted client, polling
+`platform_comments` on an interval (see `streamyard watch`) is simpler and
+sufficient; hook `window.WebSocket` in the page context if you need push latency.
+
+## Notes
+
+- Comments require the broadcast to be live on a platform with a comment feed.
+- `shownCommentIds` on the broadcast = comments the host has put on screen.
+- Everything here is read-only in this skill; broadcast controls (go-live,
+  banners, layout) were intentionally not wired up to avoid disrupting a live show.

--- a/skills/streamyard/scripts/streamyard.jsh
+++ b/skills/streamyard/scripts/streamyard.jsh
@@ -1,0 +1,247 @@
+// streamyard.jsh — StreamYard live-studio API client (secret-sauce generated)
+//
+// StreamYard's studio backend is same-origin cookie-authed REST at
+// https://streamyard.com/api/... SLICC's localhost-origin fetch can't carry
+// those cookies, so every call runs INSIDE the open studio tab via the
+// sliccy:browser bridge (page-context fetch, credentials: 'include').
+//
+// The broadcast id is the studio URL path segment (streamyard.com/<bid>),
+// auto-discovered from the open tab. Live viewer comments per connected
+// platform live at /destinations/<output.destinationId>/platform_comments.
+//
+// Discovered endpoints (all GET, cookie-authed, same-origin):
+//   /api/broadcasts/<bid>                                  broadcast + outputs[]
+//   /api/broadcasts/<bid>/destinations/<destId>/platform_comments
+//   /api/broadcasts/<bid>/starred_comments
+//   /api/broadcasts/<bid>/workspace | /team | /token
+// where destId = outputs[].destinationId (NOT outputs[].id).
+
+const browser = require('sliccy:browser');
+const exec = require('sliccy:exec'); // playwright-cli eval-file + webhook
+const fs = require('fs');
+
+const { positional, flags } = process.argv.parseFlags();
+const subcommand = positional[0] || 'info';
+
+function die(msg) { console.error(msg); process.exit(1); }
+function out(v) { console.log(typeof v === 'string' ? v : JSON.stringify(v, null, 2)); }
+
+let _tab = null, _bid = null;
+
+async function ensure() {
+  if (_tab) return;
+  _tab = await browser.findTab({ domain: 'streamyard.com' });
+  if (!_tab) die('No StreamYard tab found. Open your studio at https://streamyard.com/<id> and sign in, then retry.');
+  const path = await browser.eval(_tab, 'location.pathname');
+  const m = String(path).match(/\/([A-Za-z0-9]{6,})/);
+  if (!m) die('Could not determine the broadcast id from the studio URL (' + path + ').');
+  _bid = m[1];
+}
+
+// Page-context GET. Returns { status, ok, json }.
+//
+// NOTE: this runs the fetch in the studio tab's MAIN world via
+// `playwright-cli eval`, not the sliccy:browser `evalAsync` bridge. StreamYard's
+// same-origin API rejects requests issued from the bridge's isolated world
+// (observed: HTTP 400), but accepts main-world requests (HTTP 200) — the app's
+// own session/Referer context is what the backend validates. `playwright-cli
+// eval` awaits a returned Promise, so the async IIFE resolves correctly.
+async function api(path) {
+  await ensure();
+  const tid = (_tab && _tab.targetId) ? _tab.targetId : String(_tab);
+  const js = `(async () => { try { const r = await fetch(${JSON.stringify(path)}, { credentials: 'include', headers: { accept: 'application/json' } }); const t = await r.text(); let j=null; try{j=JSON.parse(t);}catch(e){j=t;} return JSON.stringify({ status: r.status, ok: r.ok, json: j }); } catch(e){ return JSON.stringify({ error: String(e) }); } })()`;
+  // Write the script to a VFS temp file and eval-file it — avoids shell-escaping
+  // the JS through exec (which corrupted the request URL and produced spurious
+  // 400s), and keeps the fetch in the tab's main world (StreamYard's API rejects
+  // the sliccy:browser isolated-world context).
+  const tmp = `/shared/.streamyard-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.js`;
+  await fs.writeFile(tmp, js);
+  const res = await exec(`playwright-cli eval-file ${tmp} --tab=${tid}`);
+  await fs.rm(tmp).catch(() => {});
+  if (res.exitCode !== 0) die('page eval failed: ' + (res.stderr || res.stdout));
+  let r;
+  const raw = (res.stdout || '').trim();
+  try { r = JSON.parse(raw); } catch (e) { try { r = JSON.parse(JSON.parse(raw)); } catch (e2) { die('Failed to parse StreamYard response: ' + raw.slice(0, 300)); } }
+  if (!r || r.error) die('StreamYard request failed: ' + (r && r.error ? r.error : 'empty'));
+  if (r.status === 401 || r.status === 403) die('StreamYard session expired (HTTP ' + r.status + '). Reload the studio tab and sign in, then retry.');
+  return r;
+}
+
+async function getBroadcast() {
+  await ensure(); // resolve _bid before building the path
+  const r = await api(`/api/broadcasts/${_bid}`);
+  if (!r.ok) die('Broadcast fetch failed: HTTP ' + r.status);
+  return r.json;
+}
+
+function outputRow(o) {
+  return {
+    id: o.id,
+    destinationId: o.destinationId,
+    platform: o.platform,
+    channel: o.platformUsername || o.platformLink || '',
+    title: o.title || '',
+    status: o.status,
+    plannedStartTime: o.plannedStartTime || null,
+    link: o.platformLink || '',
+  };
+}
+
+function normComment(c) {
+  // StreamYard comment shape (e.g. YouTube): author in `name`, body in a
+  // `contents[]` array of { type, content } segments, avatar in smallImageSrc.
+  let text = '';
+  if (Array.isArray(c.contents)) {
+    text = c.contents.map((seg) => (seg && (seg.content || seg.text || (seg.emoji ? (seg.alt || '') : ''))) || '').join('');
+  } else {
+    text = c.message || c.text || c.comment || '';
+  }
+  return {
+    id: c.id || c.commentId,
+    platform: c.platform,
+    author: c.name || c.authorName || c.author || (c.author && c.author.name) || 'unknown',
+    text: text,
+    at: c.createdAt || c.publishedAt || c.timestamp || null,
+    avatar: c.smallImageSrc || c.largeImageSrc || c.authorImageUrl || c.avatar || null,
+    isMember: !!c.isMember,
+    isModerator: !!c.isChatModerator,
+  };
+}
+
+async function collectComments() {
+  const b = await getBroadcast();
+  const outs = Array.isArray(b.outputs) ? b.outputs : [];
+  const seenDest = new Set();
+  const all = [];
+  for (const o of outs) {
+    const d = o.destinationId;
+    if (!d || seenDest.has(d)) continue;
+    seenDest.add(d);
+    const r = await api(`/api/broadcasts/${_bid}/destinations/${d}/platform_comments`);
+    if (!r.ok || !r.json) continue;
+    const arr = Array.isArray(r.json) ? r.json : (r.json.comments || r.json.data || []);
+    for (const c of arr) all.push({ ...normComment(c), platform: c.platform || o.platform });
+  }
+  all.sort((a, b2) => new Date(a.at || 0) - new Date(b2.at || 0));
+  return all;
+}
+
+function fmtDur(ms) {
+  if (!ms || ms < 0) return '—';
+  const s = Math.floor(ms / 1000), h = Math.floor(s / 3600), m = Math.floor((s % 3600) / 60);
+  return (h ? h + 'h ' : '') + m + 'm';
+}
+
+async function cmdInfo() {
+  const b = await getBroadcast();
+  const info = {
+    id: b.id,
+    title: b.title || b.studioName,
+    status: b.status,
+    host: b.hostDisplayName,
+    isLive: b.status === 'broadcasting' || b.status === 'live',
+    outputs: (b.outputs || []).map(outputRow),
+    lastStartedAt: b.lastStartedAt || null,
+    lastEpisodeDuration: fmtDur(b.lastEpisodeDurationInMs),
+    totalDuration: fmtDur(b.cumulativeDurationInMs),
+    shownComments: Array.isArray(b.shownCommentIds) ? b.shownCommentIds.length : 0,
+  };
+  if (flags.json) return out(info);
+  out(`${info.title}`);
+  out(`  status:   ${info.status}${info.isLive ? '  ● LIVE' : ''}`);
+  out(`  host:     ${info.host || '—'}`);
+  out(`  duration: this episode ${info.lastEpisodeDuration} · lifetime ${info.totalDuration}`);
+  if (info.outputs.length) {
+    out(`  destinations:`);
+    for (const o of info.outputs) {
+      out(`    ${o.platform.padEnd(9)} ${o.status.padEnd(11)} ${o.title || o.channel}${o.plannedStartTime ? '  @ ' + o.plannedStartTime : ''}`);
+      if (o.link) out(`      ${o.link}`);
+    }
+  }
+}
+
+async function cmdComments() {
+  const list = await collectComments();
+  if (flags.json) return out(list);
+  if (!list.length) { out('No platform comments yet (the broadcast may not be live, or no one has commented).'); return; }
+  out(`${list.length} comment(s):`);
+  for (const c of list) out(`  [${c.platform || '?'}] ${c.author}: ${c.text}`);
+}
+
+async function cmdStarred() {
+  await ensure(); // resolve _bid before building the path
+  const r = await api(`/api/broadcasts/${_bid}/starred_comments`);
+  const arr = (r.json && (r.json.starredComments || r.json.comments)) || [];
+  const list = arr.map(normComment);
+  if (flags.json) return out(list);
+  if (!list.length) { out('No starred comments.'); return; }
+  out(`${list.length} starred:`);
+  for (const c of list) out(`  ★ [${c.platform || '?'}] ${c.author}: ${c.text}`);
+}
+
+// Poll for new comments; print them (and optionally POST to a webhook / scoop).
+async function cmdWatch() {
+  const interval = Math.max(3, parseInt(flags.interval || '8', 10)) * 1000;
+  const scoop = flags.scoop || null;
+  let webhookUrl = flags.webhook || null;
+  if (scoop && !webhookUrl) {
+    const w = await exec(`webhook create --scoop ${scoop} --name streamyard-comments`);
+    const m = (w.stdout || '').match(/https?:\/\/\S+/);
+    if (m) webhookUrl = m[0];
+  }
+  const seen = new Set();
+  (await collectComments()).forEach(c => seen.add(c.id));
+  console.error(`[watch] broadcast ${_bid} — polling every ${interval / 1000}s${webhookUrl ? ' → webhook' : ''}. Ctrl-C to stop.`);
+  for (;;) {
+    await new Promise(r => setTimeout(r, interval));
+    let list = [];
+    try { list = await collectComments(); } catch (e) { continue; }
+    for (const c of list) {
+      if (seen.has(c.id)) continue;
+      seen.add(c.id);
+      out(`[${c.platform || '?'}] ${c.author}: ${c.text}`);
+      if (webhookUrl) {
+        const payload = JSON.stringify({ type: 'streamyard-comment', data: c });
+        await exec(`curl -s -X POST -H "Content-Type: application/json" -d ${JSON.stringify(payload)} ${JSON.stringify(webhookUrl)}`).catch(() => {});
+      }
+    }
+  }
+}
+
+async function cmdRaw() {
+  const path = positional[1];
+  if (!path) die('Usage: streamyard raw <api-path>   (e.g. /api/broadcasts/<id>/workspace)');
+  await ensure();
+  const full = path.startsWith('/') ? path : `/api/broadcasts/${_bid}/${path}`;
+  const r = await api(full);
+  out(r.json);
+}
+
+function help() {
+  out(`streamyard — StreamYard live-studio API client
+
+Usage: streamyard <command> [--json]
+
+Commands:
+  info                 Broadcast title, status, host, destinations, durations
+  comments             Live viewer comments across connected platforms
+  starred              Starred/featured comments
+  watch [--interval=8] [--scoop=<name>] [--webhook=<url>]
+                       Poll for new comments; print (and optionally POST to a
+                       webhook or a scoop's inbox) as they arrive
+  raw <api-path>       GET any /api/... path (escape hatch)
+
+Auth: runs inside your open StreamYard studio tab (cookie session). Open
+https://streamyard.com/<id> and sign in first. Broadcast id is auto-detected
+from the studio URL.`);
+}
+
+switch (subcommand) {
+  case 'info': await cmdInfo(); break;
+  case 'comments': await cmdComments(); break;
+  case 'starred': await cmdStarred(); break;
+  case 'watch': await cmdWatch(); break;
+  case 'raw': await cmdRaw(); break;
+  case 'help': case '--help': case '-h': help(); break;
+  default: console.error('Unknown command: ' + subcommand); help(); process.exit(1);
+}


### PR DESCRIPTION
## What

Adds a new **`streamyard`** skill: a read-only API client for a StreamYard live-streaming studio, reverse-engineered from a live session via the **secret-sauce** methodology.

## Capabilities

- `streamyard info` — broadcast title, status (with a LIVE indicator), host, connected destinations (platform, channel, scheduled time, watch link), and episode/lifetime durations.
- `streamyard comments` — live viewer comments across all connected platforms (YouTube/LinkedIn/…).
- `streamyard starred` — host-starred comments.
- `streamyard watch [--interval=8] [--scoop=<name>] [--webhook=<url>]` — poll for new comments and print them (optionally POST each to a webhook / a scoop).
- `streamyard raw <api-path>` — GET escape hatch.

All commands accept `--json`.

## Auth / how it works

StreamYard's studio backend is **same-origin cookie-authed REST** on `streamyard.com`. SLICC's localhost-origin `fetch` can't carry those cookies, so every call runs **inside the open studio tab's main world** via `playwright-cli eval-file`. The broadcast id is the studio URL path (`streamyard.com/<bid>`), auto-detected from the tab.

Discovered endpoints (see `references/endpoints.md`):
- `/api/broadcasts/<bid>` — broadcast + `outputs[]`
- `/api/broadcasts/<bid>/destinations/<output.destinationId>/platform_comments` — live comments (keyed by `outputs[].destinationId`, **not** the output `id`)
- `/api/broadcasts/<bid>/starred_comments`, `/workspace`, `/team`, `/token`, `/api/ws/auth`

## Notes / gotchas documented

- **Main-world only:** the API returns `400 "Schema validation failed"` for requests issued from the `sliccy:browser` isolated world; it accepts main-world (`playwright-cli eval`) requests. That's why this skill uses `eval-file` rather than the `browser.fetch`/`evalAsync` bridge.
- Comment shape (YouTube): author in `name`, body in a `contents[]` segment array, avatar in `smallImageSrc` — normalized in the client.
- Comments only appear while the broadcast is live on a platform with a comment feed.

## Safety

**Read-only.** Broadcast controls (go-live, banners, layout, on-screen comments) were intentionally **not** wired up, to avoid disrupting a live show.

## Validation

Built and verified live against a real, in-progress `us2`-region StreamYard studio (broadcast "What's new with SLICC - Thursday Frequency", live on YouTube): `info` (correct LIVE state + YouTube destination), `comments` (real viewer comments, correctly normalized), `starred`, and `raw`. A comment posted to the stream round-tripped back through `streamyard comments` within seconds.