### PR TITLE
feat(concur): German Travel Allowance itinerary + picklist/header fixes

### DIFF
--- a/skills/concur/SKILL.md
+++ b/skills/concur/SKILL.md
@@ -124,13 +124,18 @@ These hit the public-API surface at `www-us2.api.concursolutions.com/api/v3.0/*`
 | `concur set-payment <reportId> <expenseId> <CASH\|PCCD> [--comment="..."]` | Change an existing entry's payment type via `UpdateExistingExpenseEntry` (e.g. flip Corporate Card → Out of Pocket). `policyId` auto-resolves. |
 | `concur payment-types` | List the payment types available to the report owner (`GetPaymentTypes`). `CASH`="Out of Pocket", `PCCD`="Pending Card Transaction". |
 | `concur attach-receipt <reportId> <expenseId> <localPath>` | Upload a receipt image and attach it to a specific expense entry. Auto-converts HEIC/PNG → JPEG via ImageMagick (downscaled to 2048px max, quality 85). Pass `--no-convert` to skip conversion. (PDF attach needs ghostscript; attach a rendered image if unavailable.) |
+| `concur report-purpose <reportId> <listItemId>` | Set the report header's **Business Purpose** (`custom14`) via `UpdateReportHeader` and copy it down to every line (clears `NOBUSPUR`/`NOBUSLIN`/`BADHEADR`). Get the `listItemId` from `concur list-items <businessPurposeListId>`. |
+| `concur itinerary <reportId> <itinerary.json>` | Build & assign a **German Travel Allowance itinerary** (clears `GERTAB`/`NOITIN`) via the legacy Ext.Direct endpoint. `itinerary.json`: `{ "name":"...", "tacKey":"2043", "rows":[ {"departLocation":"Potsdam, GERMANY","departDate":"2026-06-29","departTime":"5:00 AM","arrivalLocation":"San Francisco, California","arrivalDate":"2026-06-29","arrivalTime":"2:00 PM"}, … ] }`. Location keys (`LnKey`) auto-resolve from the location strings; override per-row with `departLnKey`/`arrivalLnKey`. Note: meal expenses on a German-TA report must also be flagged `isExpensePartOfTravelAllowance:true` (via `new-expense --fields` or an entry update) or `GERTAB` persists. |
 | `concur submit <reportId> [--source=WEB] [--approver-validated]` | Two-step submit: runs server validation, then commits. Returns `{validation, commit}` statuses (both should be `COMPLETED`). Before submitting, run `concur exceptions <reportId>` and check `hasBlockingExceptions` — the server validation step catches hard blockers, but reviewing first avoids a wasted round-trip on reports that need edits. All mutation commands (`change-type`, `attach-receipt`, `itemize`, `submit`) also refuse to run against reports that are locked (already Approved/Submitted/Paid) and report the current status instead. |
+
+`concur itemize hotel`/`add` now auto-resolve the required `locationId` and `exchangeRate` from the parent entry's expense form (moved card charges carry a null `location` on the summary, which previously caused a generic `400`). `concur attach-receipt` accepts PDF receipts directly with `--no-convert` (Concur stores PDFs natively; no ghostscript rasterization needed).
 
 ### Escape hatches
 
 | Command | Description |
 |---|---|
 | `concur ops` | List all bundled GraphQL operations. |
+| `concur list-items <listId> [--search=text]` | Resolve a form picklist's items (id, code, value) — e.g. Business Purpose or Class of Service. Runs `GetFormListItems` on the **spend** surface with `{listInformation:{id,…}}` (not `cds`, and the key is `id`, not `listId`). |
 | `concur exceptions <reportId>` | Report status check: lists all validation exceptions (errors/warnings) grouped per entry, with `code`, `isBlocking`, and `message` (e.g. `ITEMREQ` "Itemizations are required", `RECEIPT_REQUIRED` "You must attach a receipt image"). Returns `hasBlockingExceptions` so you can tell if a report can be submitted. |
 | `concur graphql <opName> [<variables-json>] [spend\|cds]` | Run any captured operation verbatim. |
 | `concur tab` | Print the tab handle the skill is using for Concur requests. |

--- a/skills/concur/references/operations/UpdateReportHeader.graphql
+++ b/skills/concur/references/operations/UpdateReportHeader.graphql
@@ -1,0 +1,11 @@
+mutation UpdateReportHeader($userId: String!, $contextRole: ContextRoleType!, $reportId: String!, $fields: UpdateReportFieldsInput!) {
+  updateReport(
+    userId: $userId
+    contextRole: $contextRole
+    reportId: $reportId
+    fields: $fields
+  ) {
+    reportId
+    __typename
+  }
+}

--- a/skills/concur/scripts/concur.jsh
+++ b/skills/concur/scripts/concur.jsh
@@ -137,6 +137,97 @@ async function pageFetch(url, options = {}) {
   return resp.body;
 }
 
+// ----------------- Ext.Direct (legacy .NET router) helpers -----------------
+//
+// German Travel Allowance itineraries are NOT GraphQL — they go through the
+// legacy Ext.Direct proxy at /expense/expenseDotNet/Proxy/expenseRouter.ashx.
+// Body is form-encoded `data=<JSON array of {action,method,data}>&_=`. The
+// response is JavaScript-literal (unquoted keys), so we regex values out.
+// Must run via browser.fetch (page context) so cookies/session are attached.
+async function extDirect(action, method, dataArr) {
+  const tab = await ensureTab();
+  const url = `${HOST_WEB}/expense/expenseDotNet/Proxy/expenseRouter.ashx?requests=${encodeURIComponent(action + ':' + method)}`;
+  const body = 'data=' + encodeURIComponent(JSON.stringify([{ action, method, data: dataArr }])) + '&_=';
+  let resp;
+  try {
+    resp = await browser.fetch(tab, url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+        'X-Requested-With': 'XMLHttpRequest',
+        'X-Prototype-Version': '1.6.1',
+        'Accept': 'text/javascript, text/html, application/xml, text/xml, */*',
+      },
+      body,
+    });
+  } catch (e) {
+    console.error('Network error (ExtDirect):', e?.message || e);
+    process.exit(1);
+  }
+  if (!resp.ok) {
+    console.error(`ExtDirect HTTP ${resp.status}:`, (typeof resp.body === 'string' ? resp.body : JSON.stringify(resp.body)).slice(0, 2000));
+    process.exit(1);
+  }
+  return typeof resp.body === 'string' ? resp.body : JSON.stringify(resp.body);
+}
+
+// "5:00 AM" -> "5:00", "8:27 PM" -> "20:27"
+function to24(t) {
+  const m = String(t).trim().match(/^(\d{1,2}):(\d{2})\s*(AM|PM)?$/i);
+  if (!m) return t;
+  let h = parseInt(m[1], 10); const min = m[2]; const ap = (m[3] || '').toUpperCase();
+  if (ap === 'PM' && h !== 12) h += 12;
+  if (ap === 'AM' && h === 12) h = 0;
+  return `${h}:${min}`;
+}
+
+// Resolve a city string ("San Francisco, California") to its Travel-Allowance
+// location key (LnKey) via the Location.GetLocations Ext.Direct call.
+async function resolveLnKey(query) {
+  const raw = await extDirect('Location', 'GetLocations', [query, '', '']);
+  let recs = [];
+  try { recs = JSON.parse(raw)?.Location_GetLocations?.Records || []; }
+  catch (_) {
+    // JS-literal fallback: pull LnKey/LocText pairs
+    const re = /"?LnKey"?:(\d+)[^}]*?"?LocText"?:"([^"]+)"/g; let mm;
+    while ((mm = re.exec(raw))) recs.push({ LnKey: +mm[1], LocText: mm[2] });
+  }
+  if (!recs.length) throw new Error(`No TA location match for "${query}"`);
+  // Prefer exact LocText match, else first record.
+  const exact = recs.find(r => (r.LocText || '').toLowerCase() === query.toLowerCase());
+  const pick = exact || recs[0];
+  return { lnKey: pick.LnKey, locText: pick.LocText || query };
+}
+
+function buildItineraryXml({ name, tacKey, rptKey, itinKey, create, row }) {
+  const parts = [];
+  parts.push('<Itinerary>');
+  parts.push(`<Name>${name}</Name>`);
+  if (itinKey) parts.push(`<ItinKey>${itinKey}</ItinKey>`);
+  parts.push(`<TacKey>${tacKey}</TacKey>`);
+  if (itinKey) parts.push(`<TacName>German TA</TacName>`);
+  parts.push('<ShortDistanceTrip>N</ShortDistanceTrip>');
+  parts.push(`<RptKey>${rptKey}</RptKey>`);
+  if (create) parts.push('<CleanIfError>Y</CleanIfError>');
+  parts.push('<ItineraryRows><ItineraryRow>');
+  parts.push(`<DepartLnKey>${row.departLnKey}</DepartLnKey>`);
+  parts.push(`<DepartLocation>${row.departLocation}</DepartLocation>`);
+  parts.push('<DepartLocationCode></DepartLocationCode>');
+  parts.push(`<DepartDate>${row.departDate}</DepartDate>`);
+  parts.push(`<DepartTime>${row.departTime}</DepartTime>`);
+  parts.push(`<BorderDate>${row.departDate}</BorderDate>`);
+  parts.push(`<BorderTime>${row.departTime}</BorderTime>`);
+  parts.push(`<ArrivalLnKey>${row.arrivalLnKey}</ArrivalLnKey>`);
+  parts.push(`<ArrivalLocation>${row.arrivalLocation}</ArrivalLocation>`);
+  parts.push('<ArrivalLocationCode></ArrivalLocationCode>');
+  parts.push(`<ArrivalDate>${row.arrivalDate}</ArrivalDate>`);
+  parts.push(`<ArrivalTime>${row.arrivalTime}</ArrivalTime>`);
+  parts.push(`<DepartDateTime>${row.departDate} ${to24(row.departTime)}</DepartDateTime>`);
+  parts.push(`<ArrivalDateTime>${row.arrivalDate} ${to24(row.arrivalTime)}</ArrivalDateTime>`);
+  parts.push('</ItineraryRow></ItineraryRows></Itinerary>');
+  return parts.join('\n');
+}
+
 // ----------------- GraphQL helpers -----------------
 
 async function graphql(surface, body) {
@@ -255,6 +346,33 @@ async function getEntrySummary(reportId, expenseId) {
   };
 }
 
+// Resolve a parent entry's locationId + exchangeRate from its expense form.
+// Card charges moved onto a report frequently have a null `location` in the
+// entries list, but the expense FORM always carries the resolved location and
+// the home-currency exchange rate. Itemizations require both, so we pull them
+// here — this is what fixes the otherwise-generic 400 on SaveNewItemization.
+async function resolveEntryLocationAndRate(reportId, expenseId) {
+  const userId = await getUserId();
+  let form;
+  try {
+    form = await callOp('GetExistingExpenseForm', {
+      userId, contextRole: 'TRAVELER', reportId, expenseId,
+    });
+  } catch (_) { return {}; }
+  let locationId = null;
+  let exchangeRate = null;
+  const walk = (o) => {
+    if (!o || typeof o !== 'object') return;
+    if (!locationId && o.locationValue && o.locationValue.id) locationId = o.locationValue.id;
+    if (!exchangeRate && o.value != null && (o.operation === 'MULTIPLY' || o.operation === 'DIVIDE')) {
+      exchangeRate = { operation: o.operation, value: o.value };
+    }
+    for (const k in o) { const v = o[k]; if (v && typeof v === 'object') walk(v); }
+  };
+  walk(form);
+  return { locationId, exchangeRate };
+}
+
 // List itemization expense types available for an entry. Returns a
 // flat array of { id, code, name, parentName, itemizationType }.
 async function itemizeTypes(reportId, expenseId) {
@@ -370,9 +488,16 @@ async function itemizeAdd(reportId, parentExpenseId, typeId, amountStr, ...tail)
   const date = dateStr || entry?.transactionDate || new Date().toISOString().slice(0, 10);
   const policyId = opts.policy || entry?.policy?.id || entry?.policyId || ADOBE_INTL_POLICY.policyId;
 
+  // Auto-resolve locationId + exchangeRate from the parent entry's form
+  // (moved card charges usually lack them on the summary → SaveNewItemization 400s).
+  const overrides = {};
+  const resolved = await resolveEntryLocationAndRate(reportId, parentExpenseId);
+  if (resolved.locationId) overrides.locationId = resolved.locationId;
+  if (resolved.exchangeRate) overrides.exchangeRate = resolved.exchangeRate;
+
   const fields = buildItemizationFields(
     { parentExpenseId, typeId, date, amount, comment },
-    entry, currency,
+    entry, currency, overrides,
   );
 
   const result = await callOp('SaveNewItemization', {
@@ -483,6 +608,13 @@ async function itemizeHotel(reportId, expenseId, billJson) {
   const userId = await getUserId();
   const policyId = bill.policyId || ADOBE_INTL_POLICY.policyId;
   const overrides = bill.customFields || {};
+  // Auto-resolve locationId + exchangeRate from the parent entry's form when
+  // the entry summary lacks them (the common case for moved card charges).
+  if (!overrides.locationId || !overrides.exchangeRate) {
+    const resolved = await resolveEntryLocationAndRate(reportId, expenseId);
+    if (!overrides.locationId && resolved.locationId) overrides.locationId = resolved.locationId;
+    if (!overrides.exchangeRate && resolved.exchangeRate) overrides.exchangeRate = resolved.exchangeRate;
+  }
   const results = [];
   for (let i = 0; i < allLines.length; i++) {
     const l = allLines[i];
@@ -911,6 +1043,68 @@ const commands = {
     process.exit(1);
   },
 
+  // Build & assign a German Travel Allowance itinerary (Ext.Direct).
+  // Usage: concur itinerary <reportId> <itinerary.json>
+  //   { "name":"...", "tacKey":"2043",
+  //     "rows":[ {"departLocation":"Potsdam, GERMANY","departDate":"2026-06-29",
+  //               "departTime":"5:00 AM","arrivalLocation":"San Francisco, California",
+  //               "arrivalDate":"2026-06-29","arrivalTime":"2:00 PM"}, ... ] }
+  // LnKeys auto-resolve from the location strings via Location.GetLocations
+  // (override per-row with departLnKey / arrivalLnKey).
+  async itinerary(reportId, jsonPath) {
+    if (!reportId || !jsonPath) {
+      console.error('Usage: concur itinerary <reportId> <itinerary.json>');
+      process.exit(1);
+    }
+    await assertReportMutable(reportId, 'add a travel-allowance itinerary');
+    const spec = JSON.parse(await readFile(jsonPath));
+    const rows = Array.isArray(spec.rows) ? spec.rows : [];
+    if (!rows.length) throw new Error('itinerary.json needs a non-empty "rows" array');
+    const userId = await getUserId();
+    // Resolve the report's RptKey (the Ext.Direct APIs key on RptKey, not reportId).
+    const rk = await callOp('GetReportIdAndKey', { userId, contextRole: 'TRAVELER', reportId });
+    const rptKey = rk?.employee?.expenseReport?.rptKey;
+    if (!rptKey) throw new Error(`Could not resolve RptKey for report ${reportId}`);
+    const name = spec.name || rk?.employee?.expenseReport?.name || 'Trip';
+    const tacKey = spec.tacKey || '2043'; // German TA config
+
+    // Resolve LnKeys / canonical location text for every row.
+    const locCache = {};
+    async function loc(str, lnKey) {
+      if (lnKey) return { lnKey, locText: str };
+      if (locCache[str]) return locCache[str];
+      const r = await resolveLnKey(str);
+      locCache[str] = r;
+      return r;
+    }
+
+    let itinKey = null;
+    const results = [];
+    for (let i = 0; i < rows.length; i++) {
+      const r = rows[i];
+      const dep = await loc(r.departLocation, r.departLnKey);
+      const arr = await loc(r.arrivalLocation, r.arrivalLnKey);
+      const xml = buildItineraryXml({
+        name, tacKey, rptKey, itinKey, create: i === 0,
+        row: {
+          departLnKey: dep.lnKey, departLocation: dep.locText,
+          departDate: r.departDate, departTime: r.departTime,
+          arrivalLnKey: arr.lnKey, arrivalLocation: arr.locText,
+          arrivalDate: r.arrivalDate, arrivalTime: r.arrivalTime,
+        },
+      });
+      const raw = await extDirect('TravelAllowance', 'ValidateAndSaveItineraryRow', ['', xml, 'N']);
+      if (i === 0) {
+        const m = raw.match(/ItinKey:"?([^",}]+)"?/);
+        if (!m) throw new Error(`Itinerary create failed: ${raw.slice(0, 500)}`);
+        itinKey = m[1];
+      }
+      const status = (raw.match(/Status:"?([A-Z_]+)"?/) || [])[1] || 'UNKNOWN';
+      results.push({ row: i + 1, from: dep.locText, to: arr.locText, status });
+    }
+    return { reportId, rptKey, itinKey, rows: results };
+  },
+
   async submit(reportId, ...args) {
     if (!reportId) { console.error('Usage: concur submit <reportId> [--source=WEB] [--approver-validated]'); process.exit(1); }
     const opts = parseFlags(args, { source: 'WEB', 'approver-validated': '' });
@@ -1007,6 +1201,39 @@ const commands = {
     const r = await exec(`ls ${OPS_DIR}`);
     const list = r.stdout.split('\n').filter(Boolean).map(s => s.replace(/\.graphql$/, ''));
     return { count: list.length, operations: list };
+  },
+
+  // Resolve a form picklist's items (e.g. Business Purpose, Class of Service).
+  // GetFormListItems runs on the SPEND surface with {listInformation:{id,...}}
+  // — NOT the cds surface, and the key is `id` (not `listId`).
+  // Usage: concur list-items <listId> [--search=text]
+  async ['list-items'](listId, ...args) {
+    if (!listId) { console.error('Usage: concur list-items <listId> [--search=text]'); process.exit(1); }
+    const opts = parseFlags(args, { search: '' });
+    const r = await callOp('GetFormListItems', {
+      listInformation: { id: listId, isExternal: null },
+      includeTotalPages: true, sessionId: null,
+    }, 'spend');
+    const items = (r?.CDS_spend?.list?.items || []).map((i) => ({ id: i.id, code: i.code, value: i.value }));
+    const q = String(opts.search || '').toLowerCase();
+    return q ? items.filter((i) => (i.value || '').toLowerCase().includes(q)) : items;
+  },
+
+  // Set a report header's Business Purpose (custom14) and copy it down to all
+  // lines. Pass the list-item id from `concur list-items <businessPurposeListId>`.
+  // Usage: concur report-purpose <reportId> <listItemId>
+  async ['report-purpose'](reportId, listItemId) {
+    if (!reportId || !listItemId) {
+      console.error('Usage: concur report-purpose <reportId> <listItemId>');
+      console.error('  (get the id from `concur list-items <businessPurposeListId>`)');
+      process.exit(1);
+    }
+    await assertReportMutable(reportId, 'set the report business purpose');
+    const userId = await getUserId();
+    return callOp('UpdateReportHeader', {
+      userId, contextRole: 'TRAVELER', reportId,
+      fields: { custom14: { value: listItemId }, reportSource: 'WEB', copyDownRequested: true },
+    });
   },
 
   // Report status + all validation exceptions (error/warning messages) for a

--- a/skills/concur/scripts/concur.jsh
+++ b/skills/concur/scripts/concur.jsh
@@ -122,10 +122,14 @@ async function pageFetch(url, options = {}) {
   try {
     resp = await browser.fetch(tab, url, { method, headers, body });
   } catch (e) {
+    // `soft` callers (best-effort enrichment lookups) get null instead of a
+    // hard exit so they can fall back rather than aborting the whole command.
+    if (options.soft) return null;
     console.error('Network error:', e?.message || e);
     process.exit(1);
   }
   if (!resp.ok) {
+    if (options.soft) return null;
     if (resp.status === 401 || resp.status === 403) {
       console.error(`Auth failed (${resp.status}). Open ${HOST_WEB} in your browser, log in, and retry.`);
     } else {
@@ -199,38 +203,51 @@ async function resolveLnKey(query) {
   return { lnKey: pick.LnKey, locText: pick.LocText || query };
 }
 
+// Escape XML text content — report names ("Sales & Marketing") and location
+// strings can contain &, <, >, quotes that would otherwise produce malformed
+// XML in the Ext.Direct itinerary payload.
+function xmlEscape(v) {
+  return String(v == null ? '' : v)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
 function buildItineraryXml({ name, tacKey, rptKey, itinKey, create, row }) {
+  const x = xmlEscape;
   const parts = [];
   parts.push('<Itinerary>');
-  parts.push(`<Name>${name}</Name>`);
-  if (itinKey) parts.push(`<ItinKey>${itinKey}</ItinKey>`);
-  parts.push(`<TacKey>${tacKey}</TacKey>`);
+  parts.push(`<Name>${x(name)}</Name>`);
+  if (itinKey) parts.push(`<ItinKey>${x(itinKey)}</ItinKey>`);
+  parts.push(`<TacKey>${x(tacKey)}</TacKey>`);
   if (itinKey) parts.push(`<TacName>German TA</TacName>`);
   parts.push('<ShortDistanceTrip>N</ShortDistanceTrip>');
-  parts.push(`<RptKey>${rptKey}</RptKey>`);
+  parts.push(`<RptKey>${x(rptKey)}</RptKey>`);
   if (create) parts.push('<CleanIfError>Y</CleanIfError>');
   parts.push('<ItineraryRows><ItineraryRow>');
-  parts.push(`<DepartLnKey>${row.departLnKey}</DepartLnKey>`);
-  parts.push(`<DepartLocation>${row.departLocation}</DepartLocation>`);
+  parts.push(`<DepartLnKey>${x(row.departLnKey)}</DepartLnKey>`);
+  parts.push(`<DepartLocation>${x(row.departLocation)}</DepartLocation>`);
   parts.push('<DepartLocationCode></DepartLocationCode>');
-  parts.push(`<DepartDate>${row.departDate}</DepartDate>`);
-  parts.push(`<DepartTime>${row.departTime}</DepartTime>`);
-  parts.push(`<BorderDate>${row.departDate}</BorderDate>`);
-  parts.push(`<BorderTime>${row.departTime}</BorderTime>`);
-  parts.push(`<ArrivalLnKey>${row.arrivalLnKey}</ArrivalLnKey>`);
-  parts.push(`<ArrivalLocation>${row.arrivalLocation}</ArrivalLocation>`);
+  parts.push(`<DepartDate>${x(row.departDate)}</DepartDate>`);
+  parts.push(`<DepartTime>${x(row.departTime)}</DepartTime>`);
+  parts.push(`<BorderDate>${x(row.departDate)}</BorderDate>`);
+  parts.push(`<BorderTime>${x(row.departTime)}</BorderTime>`);
+  parts.push(`<ArrivalLnKey>${x(row.arrivalLnKey)}</ArrivalLnKey>`);
+  parts.push(`<ArrivalLocation>${x(row.arrivalLocation)}</ArrivalLocation>`);
   parts.push('<ArrivalLocationCode></ArrivalLocationCode>');
-  parts.push(`<ArrivalDate>${row.arrivalDate}</ArrivalDate>`);
-  parts.push(`<ArrivalTime>${row.arrivalTime}</ArrivalTime>`);
-  parts.push(`<DepartDateTime>${row.departDate} ${to24(row.departTime)}</DepartDateTime>`);
-  parts.push(`<ArrivalDateTime>${row.arrivalDate} ${to24(row.arrivalTime)}</ArrivalDateTime>`);
+  parts.push(`<ArrivalDate>${x(row.arrivalDate)}</ArrivalDate>`);
+  parts.push(`<ArrivalTime>${x(row.arrivalTime)}</ArrivalTime>`);
+  parts.push(`<DepartDateTime>${x(row.departDate)} ${x(to24(row.departTime))}</DepartDateTime>`);
+  parts.push(`<ArrivalDateTime>${x(row.arrivalDate)} ${x(to24(row.arrivalTime))}</ArrivalDateTime>`);
   parts.push('</ItineraryRow></ItineraryRows></Itinerary>');
   return parts.join('\n');
 }
 
 // ----------------- GraphQL helpers -----------------
 
-async function graphql(surface, body) {
+async function graphql(surface, body, opts = {}) {
   const url = surface === 'cds'
     ? `${HOST_API}/cds/graphql`
     : `${HOST_API}/spend-graphql/graphql`;
@@ -238,11 +255,15 @@ async function graphql(surface, body) {
   const result = await pageFetch(url, {
     method: 'POST',
     body,
+    soft: opts.soft,
     headers: {
       'concur-correlationId': correlationId,
       'concur-correlationid': correlationId,
     },
   });
+  // `soft`: a null body (HTTP error swallowed above) or GraphQL errors resolve
+  // to null instead of exiting, so best-effort callers can fall back.
+  if (opts.soft && (result == null || result.errors)) return null;
   if (result?.errors) {
     console.error('GraphQL errors:', JSON.stringify(result.errors, null, 2));
     process.exit(1);
@@ -250,9 +271,9 @@ async function graphql(surface, body) {
   return result?.data ?? result;
 }
 
-async function callOp(opName, variables = {}, surface = 'spend') {
+async function callOp(opName, variables = {}, surface = 'spend', opts = {}) {
   const query = await loadOp(opName);
-  return graphql(surface, { operationName: opName, query, variables });
+  return graphql(surface, { operationName: opName, query, variables }, opts);
 }
 
 // Resolve a report's policyId (needed by create/update expense mutations).
@@ -353,12 +374,13 @@ async function getEntrySummary(reportId, expenseId) {
 // here — this is what fixes the otherwise-generic 400 on SaveNewItemization.
 async function resolveEntryLocationAndRate(reportId, expenseId) {
   const userId = await getUserId();
-  let form;
-  try {
-    form = await callOp('GetExistingExpenseForm', {
-      userId, contextRole: 'TRAVELER', reportId, expenseId,
-    });
-  } catch (_) { return {}; }
+  // Best-effort: use the soft path so an HTTP/GraphQL error on this lookup
+  // returns null (→ {}) and the caller falls back to overrides/parent data
+  // instead of the whole `itemize` command exiting.
+  const form = await callOp('GetExistingExpenseForm', {
+    userId, contextRole: 'TRAVELER', reportId, expenseId,
+  }, 'spend', { soft: true });
+  if (!form) return {};
   let locationId = null;
   let exchangeRate = null;
   const walk = (o) => {


### PR DESCRIPTION
## Summary
Adds the reverse-engineered, previously-missing pieces needed to file a German expense report end-to-end via the CLI, and fixes two operations that failed on Adobe's live tenant. All deterministic logic is in code; markdown covers only usage.

### New commands
- **`concur itinerary <reportId> <itinerary.json>`** — builds & assigns a **German Travel Allowance itinerary** (clears `GERTAB`/`NOITIN`). Travel Allowance is *not* GraphQL; it goes through the legacy Ext.Direct proxy (`expenseRouter.ashx`, `ValidateAndSaveItineraryRow`, XML `<Itinerary>` payload). LnKeys auto-resolve from location strings via `Location.GetLocations`; RptKey resolves via `GetReportIdAndKey`. Runs through `browser.fetch` (page context) so cookies/session attach — a raw injected `fetch`/XHR gets a 200-empty response.
- **`concur list-items <listId> [--search=text]`** — resolve a form picklist (Business Purpose, Class of Service, …).
- **`concur report-purpose <reportId> <listItemId>`** — set header Business Purpose (`custom14`) via the new `UpdateReportHeader` op, with copy-down to all lines.

### Fixes
- **`itemize` 400 → fixed:** `SaveNewItemization` requires `locationId` + `exchangeRate`. Moved card charges carry a null `location` on the entry summary, so the skill omitted `locationId` and every itemization 400'd. `itemize hotel`/`add` now auto-resolve both from the parent entry's expense form (`GetExistingExpenseForm` → `locationValue.id` + `exchangeRate`).
- **`GetFormListItems` → fixed:** must run on the **spend** surface with `{listInformation:{id,…}}` — the previous shape used the `cds` surface and a `listId` key, which failed live schema validation. New `list-items` command uses the correct shape.
- Added the **`UpdateReportHeader`** GraphQL operation (was missing entirely).

### Docs
- SKILL.md: new commands, the German-TA meal caveat (`isExpensePartOfTravelAllowance:true`), the itemize auto-resolution note, and that `attach-receipt --no-convert` accepts PDFs natively.

## Validation
Filed two real Adobe expense reports end-to-end (Basel + San Francisco trips): moved card charges, itemized both hotels, built both TA itineraries programmatically, set business purpose + class of service, attached all receipts, and submitted — both reached "Pending Audit Review" with zero blocking exceptions.

Note: `itemize`/`GetFormListItems`/`UpdateReportHeader` were validated against Adobe's live `us2` tenant; the Ext.Direct itinerary path was decoded from a recorded UI session and replayed successfully on a second report.