### PR TITLE
fix(outlook): validate saved token freshness before reuse

### DIFF
--- a/skills/outlook/scripts/outlook.jsh
+++ b/skills/outlook/scripts/outlook.jsh
@@ -317,10 +317,14 @@ async function getToken() {
   const browserToken = await extractTokenFromBrowser();
   if (browserToken) return browserToken;
 
-  // 2. Fallback to saved token file
+  // 2. Fallback to saved token file — only if it is still fresh. A stale
+  // on-disk token would otherwise be returned and cause confusing downstream
+  // API failures (401s / empty-body parse errors) instead of the actionable
+  // "open Outlook" guidance below. Mirrors the revalidation already applied to
+  // network-captured tokens (see isFreshBearerCandidate).
   try {
     const saved = (await fs.readFile(TOKEN_PATH)).trim();
-    if (saved) return saved;
+    if (saved && isFreshBearerCandidate(saved)) return saved;
   } catch { /* no file */ }
 
   die(


### PR DESCRIPTION
## Bug

`getToken()` in `skills/outlook/scripts/outlook.jsh` revalidates network-captured tokens with `isFreshBearerCandidate()` (well-formed JWT, `aud` targets `outlook.office.com`, `exp` beyond the safety margin), but the saved-token-file fallback returned the on-disk token from `/shared/.outlook-token` with **no** freshness check.

## Impact

A stale/expired on-disk token was handed back and used, producing opaque downstream failures — 401s or empty-body JSON parse errors ("Unexpected end of input") — instead of the clear, actionable "Could not extract Outlook token. Open Outlook..." guidance the function already contains. This was hit in a real Outlook session where the on-disk token had expired earlier that day: `outlook mail` failed with an opaque parse error rather than prompting re-auth.

## Fix

Gate the saved-file token behind the existing `isFreshBearerCandidate()` helper, mirroring the revalidation already applied to captured/cached tokens. When the saved token is stale, `getToken()` now falls through to the existing re-auth guidance instead of returning an unusable token.

Single-block change; no other files or skills touched.