### PR TITLE
feat(github) : Add GitHub Projects (v2) support to `gh.jsh`

### DIFF
--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -5,11 +5,13 @@ description: >
   Use this skill for any GitHub task: listing or viewing pull requests, merging PRs,
   posting comments, checking out branches, viewing issues, inspecting workflow runs,
   listing releases, searching PRs, managing Actions variables, creating branches,
-  pushing file content, archiving repos, or calling any GitHub API endpoint directly.
+  pushing file content, archiving repos, managing org-owned Projects (v2) and their
+  standalone draft items, or calling any GitHub API endpoint directly.
   Trigger on requests like "list open PRs", "check CI status", "merge this PR",
   "what issues are open", "show the latest release", "post a comment on PR #42",
   "set a repo variable", "archive this repo", "create a branch", "push this file",
-  or any task involving a GitHub repository.
+  "list my GitHub projects", "add a draft item to the project", "capture this request
+  in the project board", or any task involving a GitHub repository or organization Project.
 allowed_tools:
   - bash
 ---
@@ -51,6 +53,7 @@ The default token covers most operations. Request additional scopes when needed,
 | `workflow` | Pushing/modifying `.github/workflows/` files |
 | `delete_repo` | Deleting repositories |
 | `admin:org` | Managing organization settings |
+| `project` | Reading or writing org-owned Projects (v2) — required for all `project` subcommands |
 
 ```bash
 git config github.token "$(oauth-token github --scope workflow)"
@@ -232,6 +235,23 @@ gh.jsh vars list
 gh.jsh vars set MY_VAR "hello world"
 ```
 Creates or updates the variable (PATCH if exists, POST if new).
+
+---
+
+### Projects (org-owned, v2)
+
+Requires the `project` scope — see Scope escalation above. Projects v2 items are org-scoped, not repo-scoped: pass an org login and project number, never `owner/repo`.
+
+```bash
+gh.jsh project list myorg                          # list org's projects, with number/state/url
+gh.jsh project list-items myorg 2                  # list items in project #2
+gh.jsh project add-draft myorg 2 "Some request"    # create a standalone draft item, no repo needed
+gh.jsh project add-draft myorg 2 "Some request" "Longer body text describing it"
+gh.jsh project set-title myorg 2 215884384 "New title"   # rename an existing item
+```
+`add-draft` creates a **draft issue** — an item that lives only inside the project, with no linked repository or real issue, until someone chooses to convert it later (via GitHub's UI; `gh.jsh` does not currently support conversion). This is the standalone-capture mechanism for tracking requests before deciding whether they warrant becoming real repo work — see [GitHub's REST API docs for draft Project items](https://docs.github.com/en/rest/projects/drafts) for the underlying contract.
+
+`set-title` renames an existing item (draft or linked issue/PR). Project item field updates are field-ID-based, not a direct `{title: ...}` body — `set-title` looks up the item's own title field ID for you, so you only pass the item ID and the new title. `add-draft`'s own output prints the new item's ID for exactly this purpose.
 
 ---
 

--- a/skills/github/scripts/gh.jsh
+++ b/skills/github/scripts/gh.jsh
@@ -206,6 +206,7 @@ const WRITE_OPS = {
   vars:          ['set'],
   release:       ['create','upload','delete'],
   notifications: ['read'],
+  project:       ['add-draft', 'set-title'],
 };
 
 function isMutating(cmd, sub) {
@@ -830,6 +831,115 @@ async function issueEdit(args) {
     console.log(sym('success') + ' Edited issue ' + color.cyan('#' + num) + ': ' + res.title);
     console.log(color.gray('URL:') + '     ' + res.html_url);
   } catch (e) { fail('issue edit', e); }
+}
+
+// ─── project (org-owned Projects v2) ─────────────────────────────────────────
+// Projects v2 items are org-scoped, not repo-scoped — there is no owner/repo
+// argument here, only an org login and a project number. REST support for
+// Projects v2 (including standalone draft issues with no linked repo) is
+// documented at https://docs.github.com/en/rest/projects — no GraphQL needed.
+
+function validateOrg(val) {
+  if (!val || !/^[a-zA-Z0-9._-]+$/.test(val)) {
+    cli.die(`Invalid org: expected a plain org login (got: ${JSON.stringify(val)})`);
+  }
+  return val;
+}
+
+async function projectList(args) {
+  const usage = 'usage: gh project list <org>';
+  if (!args[0]) cli.die('project list: org required\n' + usage);
+  const org = validateOrg(args[0]);
+  let projects;
+  try { projects = await api.get(`/orgs/${org}/projectsV2`); }
+  catch (e) { fail('project list', e); }
+
+  if (!projects.length) { console.log(color.gray('No projects.')); return; }
+
+  const rows = projects.map(p => [
+    color.cyan('#' + p.number),
+    fmt.trunc(p.title, 52),
+    p.state === 'open' ? color.green('open') : color.red(p.state),
+    color.gray(`https://github.com/orgs/${org}/projects/${p.number}`),
+  ]);
+  console.log(fmt.table(rows, [6, 54, 10]));
+}
+
+async function projectListItems(args) {
+  const usage = 'usage: gh project list-items <org> <project_number>';
+  if (!args[0]) cli.die('project list-items: org required\n' + usage);
+  if (!args[1]) cli.die('project list-items: project number required\n' + usage);
+  const org = validateOrg(args[0]);
+  const num = validateNum(args[1], 'project number');
+  let items;
+  try { items = await api.get(`/orgs/${org}/projectsV2/${num}/items`); }
+  catch (e) { fail('project list-items', e); }
+
+  if (!items.length) { console.log(color.gray('No items.')); return; }
+
+  const rows = items.map(it => {
+    const title = it.content?.title || '(untitled)';
+    const kind = it.content_type || '(unknown)';
+    return [
+      color.cyan(String(it.id)),
+      fmt.trunc(title, 50),
+      color.gray(kind),
+    ];
+  });
+  console.log(fmt.table(rows, [10, 52]));
+}
+
+async function projectAddDraft(args) {
+  const usage = 'usage: gh project add-draft <org> <project_number> <title> [body]';
+  if (!args[0]) cli.die('project add-draft: org required\n' + usage);
+  if (!args[1]) cli.die('project add-draft: project number required\n' + usage);
+  if (!args[2]) cli.die('project add-draft: title required\n' + usage);
+  const org = validateOrg(args[0]);
+  const num = validateNum(args[1], 'project number');
+  const title = args[2];
+  const body = args[3];
+
+  const payload = { title };
+  if (body !== undefined) payload.body = body;
+
+  try {
+    const res = await api.post(`/orgs/${org}/projectsV2/${num}/drafts`, { body: payload });
+    const item = res.value || res;
+    console.log(sym('success') + ' Created draft item ' + color.cyan(String(item.id)) + ' in ' + org + ' project #' + num);
+    if (item.content && item.content.title) console.log(color.gray('Title:') + '   ' + item.content.title);
+  } catch (e) { fail('project add-draft', e); }
+}
+
+// ─── project set-title ────────────────────────────────────────────────────────
+// Project item field updates are field-ID-based (PATCH .../items/{item_id} with
+// {"fields":[{"id":<field_id>,"value":<new_value>}]}), not a direct {title:...}
+// body — this looks up the item's own "Title" field ID first so the caller only
+// ever has to think in terms of item_id + new title.
+
+async function projectSetTitle(args) {
+  const usage = 'usage: gh project set-title <org> <project_number> <item_id> <new_title>';
+  if (!args[0]) cli.die('project set-title: org required\n' + usage);
+  if (!args[1]) cli.die('project set-title: project number required\n' + usage);
+  if (!args[2]) cli.die('project set-title: item id required\n' + usage);
+  if (args[3] === undefined) cli.die('project set-title: new title required\n' + usage);
+  const org = validateOrg(args[0]);
+  const num = validateNum(args[1], 'project number');
+  const itemId = validateNum(args[2], 'item id');
+  const newTitle = args[3];
+
+  let item;
+  try { item = await api.get(`/orgs/${org}/projectsV2/${num}/items/${itemId}`); }
+  catch (e) { fail('project set-title', e); }
+
+  const titleField = (item.fields || []).find(f => f.data_type === 'title');
+  if (!titleField) cli.die('project set-title: could not find a title field on item ' + itemId);
+
+  try {
+    await api.patch(`/orgs/${org}/projectsV2/${num}/items/${itemId}`, {
+      body: { fields: [{ id: titleField.id, value: newTitle }] },
+    });
+    console.log(sym('success') + ' Updated item ' + color.cyan(String(itemId)) + ' title to: ' + newTitle);
+  } catch (e) { fail('project set-title', e); }
 }
 
 // ─── repo view ───────────────────────────────────────────────────────────────
@@ -1472,6 +1582,10 @@ ${color.bold('COMMANDS')}
   ${color.cyan('search prs')}    <query> [repo]               Search PRs by keyword
   ${color.cyan('vars list')}     [repo]                       List Actions variables
   ${color.cyan('vars set')}      <name> <value> [repo]        Set an Actions variable
+  ${color.cyan('project list')}       <org>                    List org-owned Projects (v2)
+  ${color.cyan('project list-items')} <org> <project_number>    List items in a project
+  ${color.cyan('project add-draft')}  <org> <project_number> <title> [body]  Create a standalone draft item (no repo needed)
+  ${color.cyan('project set-title')}  <org> <project_number> <item_id> <new_title>  Rename a project item
   ${color.cyan('repo archive')}  [repo]                       Archive a repository
   ${color.cyan('branch create')} <name> [--from=<ref>] [repo]  Create a branch
   ${color.cyan('branch delete')} <name> [repo]                 Delete a branch
@@ -1516,6 +1630,7 @@ const dispatch = {
   search:  { prs:  () => searchPrs(rest) },
   vars:    { list: () => varsList(rest),    set:  () => varsSet(rest) },
   notifications: { list: () => notificationsList(rest), read: () => notificationsRead(rest) },
+  project: { list: () => projectList(rest), 'list-items': () => projectListItems(rest), 'add-draft': () => projectAddDraft(rest), 'set-title': () => projectSetTitle(rest) },
 };
 
 if (!dispatch[cmd]) cli.die("unknown command: '" + cmd + "'. Run gh --help for usage.");


### PR DESCRIPTION
### Summary

Extends the `gh.jsh` CLI to support org-owned GitHub Projects (v2). The existing CLI only covered repo-scoped Issues/PRs and had no way to interact with Projects at all.

### What's new

Four new `project` subcommands, all REST-backed (no GraphQL needed — confirmed against GitHub's REST API docs for Projects v2):

- `gh.jsh project list <org>` — list an org's Projects (number, title, state, URL)
- `gh.jsh project list-items <org> <project_number>` — list items in a project
- `gh.jsh project add-draft <org> <project_number> <title> [body]` — create a **standalone draft issue**, with no linked repository or real issue, until someone chooses to convert it later. This is the key capability for capturing items before deciding whether they warrant becoming real repo work.
- `gh.jsh project set-title <org> <project_number> <item_id> <new_title>` — rename an existing item. Project item field updates are field-ID-based (`PATCH .../items/{item_id}` with a `fields` array), not a direct `{title: ...}` body; this command looks up the item's own title field ID automatically so the caller only deals with `item_id` + new title.

### Also included

- New `project` entry in the OAuth scope-escalation table (`SKILL.md`) — Projects v2 requires the `project` scope, which is not part of the CLI's documented default scopes (`repo, read:org`).
- `project add-draft` and `project set-title` registered in `WRITE_OPS` for AI-attribution routing, consistent with how other mutating subcommands (`pr create`, `issue create`, etc.) are handled.
- Help text and Command Reference section updated to document all four subcommands with usage and examples.

### Verification

All four commands were tested against a real org and a live Project, not just unit-style checks:

- `list` correctly returned the org's real projects.
- `add-draft` created a real draft item with a full title and body — confirmed via direct API inspection that the resulting item has `content_type: "DraftIssue"` and no linked repo.
- `set-title` correctly renamed that item, confirmed via `list-items` before/after.
- Error paths (missing org, missing project number, invalid project number, 404 on a nonexistent org/project) all return clean, `fail()`-formatted errors rather than crashing.

### Not included

Deliberately, by request: delete/archive commands for project items — out of scope for this change.