### PR TITLE
feat(teams): transcribe copilot mode (--scoop licks, --snapshot, post --live) [DRAFT]

### DIFF
--- a/skills/teams/SKILL.md
+++ b/skills/teams/SKILL.md
@@ -330,14 +330,15 @@ teams transcribe stop
 ```
 
 - **`--scoop <name>`** (on `start`): creates a SLICC webhook routed to that scoop and injects its URL into the in-page collector. Each finalized caption phrase is `POST`ed to the webhook (fire-and-forget, `no-cors`) → arrives as a lick to the scoop. No cron, no polling. The webhook id is tracked in `/shared/.teams-transcribe-state.json` and removed on `stop`.
-- **`--snapshot`** (a flag, composes with any subcommand — typically `flush`): if a screen share is active, screenshots the Teams window and keeps it only if it differs (md5) from the last kept frame, into `--shots-dir` (default `/shared/copilot-shots/`). Gives the scoop visual grounding without saving redundant static frames.
-- **`teams post --live <message>`**: posts into the **currently active meeting's chat**, visible to all participants (via the meeting chat DOM). This is how the copilot scoop speaks up.
+- **`--snapshot`** (a flag, composes with any subcommand — typically `flush`): if a screen share is active, captures **only the shared-screen preview** — it draws the largest shared `<video>` element to an in-page canvas and exports a PNG — and keeps it only if the shared content changed (a pixel-payload hash), into `--shots-dir` (default `/shared/copilot-shots/`). Scoping to the video means the dedupe ignores unrelated window churn (captions, chat, roster, clock). Falls back to a full-window screenshot if no capturable video is present.
+- **`teams post --live <message>`**: posts into the **currently active meeting's chat**, visible to all participants. Uses **real CDP input** via `playwright-cli` (resolve the compose box + Send button from the accessibility snapshot, click → type → click Send) — Teams' CKEditor ignores in-page DOM edits, so genuine keystrokes are required.
 
-Typical wiring: `teams transcribe start --scoop meeting-copilot` → the `meeting-copilot` scoop receives a lick per phrase, calls `teams transcribe flush --snapshot` for the latest text + a screen frame, decides whether additional context is warranted, and if so calls `teams post --live "..."`.
+Typical wiring: `teams transcribe start --scoop meeting-copilot` → the `meeting-copilot` scoop receives a lick per phrase, calls `teams transcribe flush --snapshot` for the latest text + a shared-screen frame, decides whether additional context is warranted, and if so calls `teams post --live "..."`.
 
-> **VALIDATE-LIVE:** the page→webhook `fetch`, screen-share detection selectors, the
-> `screenshot --tab` capture path, and the meeting-chat input/send selectors depend on a
-> live meeting and the current Teams build; expect to tune them on first real use.
+> **Validated live** against a real meeting (Jul 2026): webhook→lick delivery, canvas
+> snapshot + content-scoped dedupe, and `post --live` all confirmed working. Selectors
+> (caption list, meeting-chat compose/Send, share `<video>`) may still need updates if a
+> future Teams build changes its DOM.
 
 ## Troubleshooting
 

--- a/skills/teams/SKILL.md
+++ b/skills/teams/SKILL.md
@@ -299,13 +299,24 @@ de-duplicated Markdown:
 **[15:04:48] Dragos Dascalita Haut:** And where are you taking this now?
 ```
 
-**How it works.** A 300 ms in-page poller watches the caption virtual-list
-(`closed-caption-v2-virtual-list-content`) and commits each finalized phrase into a
-`window` buffer that survives across evals — so nothing is lost even though Teams only
-keeps ~3 caption rows visible at a time. A phrase is treated as final once the bottom
-row stops being a growing prefix of the previous text (i.e. the speaker changed or a new
-utterance began). Because the buffer lives in the page, you can `flush` on any cadence
-(even a 1-minute cron) without losing lines; only a tab reload clears it.
+**How it works.** A `MutationObserver` on the caption virtual-list
+(`closed-caption-v2-virtual-list-content`) captures changes event-driven (no poll gaps).
+Each spoken utterance is its OWN `[data-tid="closed-caption-text"]` element whose text
+grows as it is recognized, then finalizes when the next utterance's element appears — so
+the collector keeps one buffer entry per element and **supersedes its text as it grows**,
+delivering each utterance to the webhook exactly once (when it finalizes, or after a
+short debounce for the trailing one). The speaker name sits ~2 ancestors above the text
+span (`"Name\n<text>"`). The `window` buffer survives across evals, so you can `flush` on
+any cadence without losing lines; only a tab reload clears it.
+
+> **Why DOM (not the network):** verified on the wire — Teams live captions arrive over
+> the encrypted **WebRTC media channel** and materialize only in the client DOM; there is
+> **no WebSocket/HTTP source** to tap (a HAR + WS-frame capture during active captioning
+> showed zero caption traffic). Element-level DOM capture is therefore the complete and
+> correct approach. Validated live: a 20-utterance test captured and delivered 20/20.
+>
+> **Common pitfall:** the virtual-list has a single wrapper child — iterate the
+> `closed-caption-text` elements, NOT `list.children`, or you'll see one merged blob.
 
 > **Accuracy caveat:** captions are Teams' own speech-to-text, so names and jargon can be
 > mangled (it renders "SLICC" as "Slick", "Concur" as "conqueror", etc.). Clean up in a

--- a/skills/teams/SKILL.md
+++ b/skills/teams/SKILL.md
@@ -311,6 +311,34 @@ utterance began). Because the buffer lives in the page, you can `flush` on any c
 > mangled (it renders "SLICC" as "Slick", "Concur" as "conqueror", etc.). Clean up in a
 > post-pass if you need a verbatim record.
 
+#### Copilot mode — `--scoop`, `--snapshot`, and `teams post --live`
+
+Turn the transcript into a live "meeting copilot" that surfaces context to everyone:
+
+```bash
+# Fire a lick to a scoop for every finalized phrase (event-driven, no polling)
+teams transcribe start --scoop meeting-copilot
+
+# The scoop, on each phrase-lick, flushes + grabs a deduped screen-share frame:
+teams transcribe flush --snapshot            # only saves a shot if screen-sharing AND the frame changed
+
+# ...then posts context straight into the live meeting chat (visible to all):
+teams post --live "Context: OpTel is Adobe's Observability & Telemetry platform."
+
+# Tear down (also deletes the copilot webhook):
+teams transcribe stop
+```
+
+- **`--scoop <name>`** (on `start`): creates a SLICC webhook routed to that scoop and injects its URL into the in-page collector. Each finalized caption phrase is `POST`ed to the webhook (fire-and-forget, `no-cors`) → arrives as a lick to the scoop. No cron, no polling. The webhook id is tracked in `/shared/.teams-transcribe-state.json` and removed on `stop`.
+- **`--snapshot`** (a flag, composes with any subcommand — typically `flush`): if a screen share is active, screenshots the Teams window and keeps it only if it differs (md5) from the last kept frame, into `--shots-dir` (default `/shared/copilot-shots/`). Gives the scoop visual grounding without saving redundant static frames.
+- **`teams post --live <message>`**: posts into the **currently active meeting's chat**, visible to all participants (via the meeting chat DOM). This is how the copilot scoop speaks up.
+
+Typical wiring: `teams transcribe start --scoop meeting-copilot` → the `meeting-copilot` scoop receives a lick per phrase, calls `teams transcribe flush --snapshot` for the latest text + a screen frame, decides whether additional context is warranted, and if so calls `teams post --live "..."`.
+
+> **VALIDATE-LIVE:** the page→webhook `fetch`, screen-share detection selectors, the
+> `screenshot --tab` capture path, and the meeting-chat input/send selectors depend on a
+> live meeting and the current Teams build; expect to tune them on first real use.
+
 ## Troubleshooting
 
 | Problem | Fix |

--- a/skills/teams/scripts/teams.jsh
+++ b/skills/teams/scripts/teams.jsh
@@ -1524,21 +1524,29 @@ async function postToMeetingChat(tab, message) {
   const esc = String(message).replace(/'/g, `'\\''`);
   await exec(`playwright-cli click ${boxRef} --tab=${tid}`);
   await exec(`playwright-cli type '${esc}' --tab=${tid}`);
-  await sleep(200);
-  if (sendRef) {
-    await exec(`playwright-cli click ${sendRef} --tab=${tid}`);
+  await sleep(400);
+
+  // Re-resolve the Send button AFTER typing: it may have been disabled/absent
+  // (and thus had no or a stale ref) before the box had content. Only then click.
+  const boxEmpty = () => browser.evalAsync(tab, `(() => { const b = document.querySelector('[data-tid="ckeditor"]'); return !(b && (b.innerText || '').replace(/\\s+/g, '')); })()`);
+  const fresh = await findRefs();
+  const finalSend = fresh.sendRef || sendRef;
+  if (finalSend) {
+    await exec(`playwright-cli click ${finalSend} --tab=${tid}`);
   } else {
     await exec(`playwright-cli press Enter --tab=${tid}`);
   }
-  await sleep(300);
 
-  // Confirm the box cleared (message left the composer = sent).
-  try {
-    const chk = await browser.evalAsync(tab, `(() => { const b = document.querySelector('[data-tid="ckeditor"]'); return !(b && (b.innerText || '').trim()); })()`);
-    return _asBool(chk) ? 'sent' : 'send-unconfirmed';
-  } catch (e) {
-    return 'sent';
+  // Confirm the box cleared (message left the composer = sent). Poll up to ~2s;
+  // if still populated, retry Enter once as a fallback.
+  for (let i = 0; i < 8; i++) {
+    await sleep(250);
+    try { if (_asBool(await boxEmpty())) return 'sent'; } catch (e) {}
   }
+  await exec(`playwright-cli press Enter --tab=${tid}`);
+  await sleep(400);
+  try { if (_asBool(await boxEmpty())) return 'sent'; } catch (e) {}
+  return 'send-unconfirmed';
 }
 
 async function cmdTranscribe() {

--- a/skills/teams/scripts/teams.jsh
+++ b/skills/teams/scripts/teams.jsh
@@ -552,8 +552,11 @@ async function cmdPost() {
     if (!message) die('Usage: teams post --live <message>   (posts to the active meeting chat)');
     const tab = await findTeamsTab();
     const res = await postToMeetingChat(tab, message);
+    if (res === 'not-full-view') {
+      die('Meeting is not in full view — refusing to post so I don\'t hit the wrong chat (in compact/PiP view the visible "Chat" is the app rail, often a DM). Expand the meeting to full view and retry.');
+    }
     if (res === 'no-input') {
-      die('Could not find the meeting chat input. Make sure you are in a meeting and the chat is available.');
+      die('Could not find the meeting chat input. Make sure you are in the meeting with the in-call chat available.');
     }
     out({ target: 'live-meeting-chat', result: res, message });
     return;
@@ -1260,57 +1263,93 @@ function countOccurrences(arr) {
 const CAP_LIST_TID = 'closed-caption-v2-virtual-list-content';
 
 // Idempotent in-page collector installer; returns the current buffer + state.
+// Capture is EVENT-DRIVEN via a MutationObserver on the caption virtual-list
+// (not interval polling), so caption rows that appear and scroll away quickly —
+// e.g. rapid distinct utterances — are not missed between samples. A row is
+// committed once it is no longer the last (in-progress) row, or after a short
+// pause (debounce) for the trailing utterance. A low-frequency guardian re-
+// attaches the observer if the (virtualized) list element is replaced.
 const CAP_COLLECTOR_JS = `
   (() => {
+    const LIST_SEL = '[data-tid="${CAP_LIST_TID}"]';
+    const parseRow = (row) => {
+      const textEl = row.querySelector('[data-tid="closed-caption-text"]');
+      const full = (row.innerText || '').trim();
+      const text = textEl ? (textEl.innerText || '').trim() : '';
+      let author = full;
+      if (text && full.endsWith(text)) author = full.slice(0, full.length - text.length).trim();
+      author = (author.split('\\n')[0] || '').trim();
+      return { author, text };
+    };
     if (!window.__sliccCapInstalled) {
       window.__sliccCapInstalled = true;
       window.__sliccCaps = [];
-      window.__capState = { prevAuthor: null, prevText: '' };
-      const parseRow = (row) => {
-        const textEl = row.querySelector('[data-tid="closed-caption-text"]');
-        const full = (row.innerText || '').trim();
-        const text = textEl ? (textEl.innerText || '').trim() : '';
-        let author = full;
-        if (text && full.endsWith(text)) author = full.slice(0, full.length - text.length).trim();
-        author = (author.split('\\n')[0] || '').trim();
-        return { author, text };
+      window.__capSeen = new WeakSet(); // caption row elements already committed
+      const commit = (author, text) => {
+        if (!text) return;
+        const phrase = { author, text, ts: Date.now() };
+        window.__sliccCaps.push(phrase);
+        // Copilot mode: fire the finalized phrase at a SLICC webhook so it arrives
+        // as a lick to the wired scoop. Fire-and-forget, no-cors.
+        if (window.__sliccCapWebhook) {
+          try {
+            fetch(window.__sliccCapWebhook, { method: 'POST', mode: 'no-cors', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(phrase) });
+          } catch (e) {}
+        }
       };
-      const tick = () => {
+      window.__capProcess = () => {
         try {
-          const list = document.querySelector('[data-tid="${CAP_LIST_TID}"]');
-          if (!list || !list.children.length) return;
+          const list = document.querySelector(LIST_SEL);
+          if (!list) return;
           const rows = Array.from(list.children);
-          const bottom = parseRow(rows[rows.length - 1]);
-          const st = window.__capState;
-          // A new phrase has started when the bottom row no longer extends the
-          // previous one (different speaker, or text no longer a growing prefix).
-          if (st.prevText && !(bottom.author === st.prevAuthor && bottom.text.startsWith(st.prevText))) {
-            const phrase = { author: st.prevAuthor, text: st.prevText, ts: Date.now() };
-            window.__sliccCaps.push(phrase);
-            // Copilot mode: fire the finalized phrase at a SLICC webhook so it
-            // arrives as a lick to the wired scoop (no polling). Fire-and-forget,
-            // no-cors — we only need to trigger it, not read the response.
-            if (window.__sliccCapWebhook) {
-              try {
-                fetch(window.__sliccCapWebhook, {
-                  method: 'POST',
-                  mode: 'no-cors',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify(phrase),
-                });
-              } catch (e) {}
-            }
-          }
-          st.prevAuthor = bottom.author;
-          st.prevText = bottom.text;
+          const lastIdx = rows.length - 1;
+          // Every row except the current (last, in-progress) one is finalized.
+          rows.forEach((row, i) => {
+            if (i === lastIdx) return;
+            if (window.__capSeen.has(row)) return;
+            const { author, text } = parseRow(row);
+            if (!text) return;
+            window.__capSeen.add(row);
+            commit(author, text);
+          });
+          // Debounce-commit the trailing row when speech pauses (~1.6s), so the
+          // final utterance isn't stuck uncommitted as the perpetual last row.
+          clearTimeout(window.__capTrailTimer);
+          window.__capTrailTimer = setTimeout(() => {
+            const l = document.querySelector(LIST_SEL); if (!l || !l.children.length) return;
+            const last = l.children[l.children.length - 1];
+            if (window.__capSeen.has(last)) return;
+            const { author, text } = parseRow(last);
+            if (!text) return;
+            window.__capSeen.add(last);
+            commit(author, text);
+          }, 1600);
         } catch (e) {}
       };
-      window.__sliccCapTimer = setInterval(tick, 300);
+      window.__capAttach = () => {
+        const list = document.querySelector(LIST_SEL);
+        if (!list) return;
+        if (window.__capList === list && window.__sliccCapObserver) return; // already observing
+        if (window.__sliccCapObserver) { try { window.__sliccCapObserver.disconnect(); } catch (e) {} }
+        window.__capList = list;
+        window.__sliccCapObserver = new MutationObserver(() => window.__capProcess());
+        window.__sliccCapObserver.observe(list, { childList: true, subtree: true, characterData: true });
+        window.__capProcess();
+      };
+      // Guardian only re-attaches when the list appears / is replaced — the
+      // MutationObserver does the actual (event-driven) capturing.
+      window.__sliccCapTimer = setInterval(() => window.__capAttach(), 1000);
+      window.__capAttach();
     }
+    let pending = null;
+    try {
+      const l = document.querySelector(LIST_SEL);
+      if (l && l.children.length) pending = parseRow(l.children[l.children.length - 1]);
+    } catch (e) {}
     return JSON.stringify({
       buffer: window.__sliccCaps,
-      pending: window.__capState ? { author: window.__capState.prevAuthor, text: window.__capState.prevText } : null,
-      captionsRendering: !!document.querySelector('[data-tid="${CAP_LIST_TID}"]')
+      pending: pending,
+      captionsRendering: !!document.querySelector(LIST_SEL)
     });
   })()
 `;
@@ -1499,6 +1538,35 @@ async function postToMeetingChat(tab, message) {
   // model), click Send. Refs come from the accessibility snapshot.
   const tid = _targetId(tab);
 
+  // SAFETY: only post when the meeting is in FULL view. In full view the app
+  // navigation rail is hidden, so the "Chat" control is the MEETING's in-call
+  // chat. In COMPACT/PiP view the app rail is visible and its "Chat (⌃⇧2)" is
+  // the app chat (often a DM) — posting there sends to the wrong conversation.
+  // We refuse rather than risk mis-posting to a DM. (A view-independent Graph
+  // path — POST /chats/{threadId}/messages — is the planned robust upgrade.)
+  let layout = 'unknown';
+  try {
+    layout = await browser.evalAsync(tab, `(() => {
+      const stage = document.querySelector('[data-tid="modern-stage-wrapper"]');
+      if (!stage) return 'no-stage';
+      const r = stage.getBoundingClientRect();
+      return (r.width > window.innerWidth * 0.5 && r.height > 300) ? 'full' : 'compact';
+    })()`);
+  } catch (e) {}
+  if (layout !== 'full') return 'not-full-view';
+
+  // Full view: open the in-call chat pane if it isn't already open.
+  try {
+    const opened = await browser.evalAsync(tab, `(() => {
+      const b = Array.from(document.querySelectorAll('button,[role="button"]')).find((x) => /^chat( |\\()/i.test((x.getAttribute('aria-label') || '')));
+      if (!b) return 'no-toggle';
+      if (b.getAttribute('aria-pressed') === 'true') return 'already-open';
+      b.click();
+      return 'opened';
+    })()`);
+    if (opened === 'opened') await sleep(1600);
+  } catch (e) {}
+
   async function findRefs() {
     const snap = await exec(`playwright-cli snapshot --tab=${tid}`);
     const txt = snap.stdout || '';
@@ -1646,7 +1714,7 @@ async function cmdTranscribe() {
     case 'stop': {
       const { buffer } = await readCollector();
       const fresh = flushToFile(buffer);
-      await browser.evalAsync(tab, `(() => { if (window.__sliccCapTimer) clearInterval(window.__sliccCapTimer); window.__sliccCapInstalled = false; window.__sliccCapWebhook = null; return 'stopped'; })()`);
+      await browser.evalAsync(tab, `(() => { if (window.__sliccCapTimer) clearInterval(window.__sliccCapTimer); if (window.__capTrailTimer) clearTimeout(window.__capTrailTimer); if (window.__sliccCapObserver) { try { window.__sliccCapObserver.disconnect(); } catch (e) {} } window.__sliccCapObserver = null; window.__capList = null; window.__sliccCapInstalled = false; window.__sliccCapWebhook = null; return 'stopped'; })()`);
       // Tear down copilot webhook if one was wired.
       const st = _readTranscribeState();
       if (st.webhookId) {

--- a/skills/teams/scripts/teams.jsh
+++ b/skills/teams/scripts/teams.jsh
@@ -1441,6 +1441,7 @@ function _writeTranscribeState(st) {
 
 // Create a SLICC webhook routed to <scoop>. Returns { id, url } or null.
 async function createTranscribeWebhook(scoop) {
+  _safeName(scoop, '--scoop'); // guard against shell injection via the exec bridge
   const r = await exec(`webhook create --scoop ${scoop} --name teams-transcribe`);
   if (r.exitCode !== 0) return null;
   const idM = (r.stdout || '').match(/ID:\s*(\S+)/);
@@ -1457,6 +1458,21 @@ async function deleteWebhook(id) {
 // Point the in-page collector at a webhook URL (fired per finalized phrase).
 async function setCollectorWebhook(tab, url) {
   await browser.evalAsync(tab, `(() => { window.__sliccCapWebhook = ${JSON.stringify(url || '')}; return 'ok'; })()`);
+}
+
+// Guards for values interpolated into sliccy:exec shell commands (the exec bridge
+// runs a real shell). Reject anything outside a strict safe set.
+function _safeName(v, what) {
+  if (!/^[A-Za-z0-9._-]+$/.test(String(v == null ? '' : v))) {
+    die(`Invalid ${what}: only letters, digits and . _ - are allowed (got "${v}").`);
+  }
+  return String(v);
+}
+function _safePath(v, what) {
+  if (!/^[A-Za-z0-9._/-]+$/.test(String(v == null ? '' : v))) {
+    die(`Invalid ${what}: only letters, digits and . _ - / are allowed (got "${v}").`);
+  }
+  return String(v);
 }
 
 // Detect whether a screen share is active in the meeting.
@@ -1480,7 +1496,7 @@ async function isScreenSharing(tab) {
 async function takeSnapshot(tab, shotsDir) {
   const fs = require('fs');
   const tid = _targetId(tab);
-  const dir = shotsDir || '/shared/copilot-shots';
+  const dir = _safePath(shotsDir || '/shared/copilot-shots', '--shots-dir'); // guard exec interpolation
   const ts = Date.now();
 
   // Capture ONLY the share-PREVIEW node: draw the largest shared-screen <video>
@@ -1530,14 +1546,15 @@ async function takeSnapshot(tab, shotsDir) {
     } catch (e) { return { saved: false, reason: 'save_failed' }; }
   }
 
-  // Fallback: full-window screenshot + md5 dedupe (exec shell context).
+  // Fallback: full-window screenshot + md5 dedupe (exec shell context). `dir` is
+  // validated by _safePath above; quote every expansion as defense-in-depth.
   const script =
-    `mkdir -p ${dir}; tmp=${dir}/.tmp-${ts}.png; ` +
+    `mkdir -p '${dir}'; tmp='${dir}/.tmp-${ts}.png'; ` +
     `playwright-cli screenshot --tab=${tid} --filename="$tmp" >/dev/null 2>&1 || { echo SNAP_ERR; exit 0; }; ` +
     `nm=$(md5sum "$tmp" 2>/dev/null | awk '{print $1}'); ` +
-    `lm=$(cat ${dir}/.last-md5 2>/dev/null); ` +
+    `lm=$(cat '${dir}/.last-md5' 2>/dev/null); ` +
     `if [ -n "$nm" ] && [ "$nm" = "$lm" ]; then rm -f "$tmp"; echo SNAP_UNCHANGED; exit 0; fi; ` +
-    `final=${dir}/shot-${ts}.png; mv "$tmp" "$final"; echo "$nm" > ${dir}/.last-md5; echo "SNAP_SAVED $final"`;
+    `final='${dir}/shot-${ts}.png'; mv "$tmp" "$final"; echo "$nm" > '${dir}/.last-md5'; echo "SNAP_SAVED $final"`;
   const r = await exec(script);
   const o = (r.stdout || '').trim();
   if (o.includes('SNAP_SAVED')) return { saved: true, path: o.split('SNAP_SAVED ')[1].split(/\s/)[0], scoped: false };
@@ -1651,19 +1668,34 @@ async function cmdTranscribe() {
 
       // Copilot mode: --scoop <name> wires each finalized phrase to a webhook
       // that delivers a lick to that scoop (event-driven, no polling).
-      const state = { outFile, shotsDir: flags['shots-dir'] || '/shared/copilot-shots' };
+      const prev = _readTranscribeState();
+      const state = { outFile, shotsDir: _safePath(flags['shots-dir'] || '/shared/copilot-shots', '--shots-dir') };
       if (flags.scoop) {
-        const prev = _readTranscribeState();
-        if (prev.webhookId) await deleteWebhook(prev.webhookId); // avoid orphaning a previous one
+        _safeName(flags.scoop, '--scoop');
+        // Replace any prior webhook only once the new one is installed, so a
+        // failed create doesn't orphan the old one.
         const wh = await createTranscribeWebhook(flags.scoop);
         if (!wh) {
-          console.log(`WARNING: could not create webhook for scoop "${flags.scoop}" — phrases will still be captured, but no licks will fire.`);
+          // Keep the prior webhook intact (carry it forward) rather than dropping it.
+          if (prev.webhookId) { state.webhookId = prev.webhookId; state.webhookUrl = prev.webhookUrl; state.scoop = prev.scoop; }
+          console.log(`WARNING: could not create webhook for scoop "${flags.scoop}" — phrases are still captured, but no NEW licks are wired.`);
         } else {
+          if (prev.webhookId && prev.webhookId !== wh.id) await deleteWebhook(prev.webhookId);
           await setCollectorWebhook(tab, wh.url);
           state.webhookId = wh.id;
+          state.webhookUrl = wh.url;
           state.scoop = flags.scoop;
           console.log(`Copilot mode: each finalized phrase now fires a lick to scoop "${flags.scoop}" (webhook ${wh.id}).`);
         }
+      } else if (prev.webhookId) {
+        // Plain restart without --scoop: PRESERVE the existing copilot webhook
+        // (carry its id/url forward so `stop` still cleans it up) and re-arm the
+        // in-page collector to it. Prevents an orphaned webhook / cross-meeting leak.
+        state.webhookId = prev.webhookId;
+        state.webhookUrl = prev.webhookUrl;
+        state.scoop = prev.scoop;
+        if (prev.webhookUrl) await setCollectorWebhook(tab, prev.webhookUrl);
+        console.log(`Copilot mode preserved: still firing to scoop "${prev.scoop}" (webhook ${prev.webhookId}). Run 'teams transcribe stop' to remove it.`);
       }
       _writeTranscribeState(state);
 

--- a/skills/teams/scripts/teams.jsh
+++ b/skills/teams/scripts/teams.jsh
@@ -543,6 +543,20 @@ async function cmdHistory() {
 // ---------------------------------------------------------------------------
 
 async function cmdPost() {
+  // --live: post into the CURRENTLY ACTIVE meeting's chat (visible to all
+  // participants) instead of a team channel. No team/channel needed.
+  if (flags.live) {
+    const message = positional.join(' ').trim();
+    if (!message) die('Usage: teams post --live <message>   (posts to the active meeting chat)');
+    const tab = await findTeamsTab();
+    const res = await postToMeetingChat(tab, message);
+    if (res === 'no-input') {
+      die('Could not find the meeting chat input. Make sure you are in a meeting and the chat is available.');
+    }
+    out({ target: 'live-meeting-chat', result: res, message });
+    return;
+  }
+
   if (positional.length < 3) die('Usage: teams post <team> <channel> <message> [--reply-to=<message-id>]');
   const team = await resolveTeam(positional[0]);
   const channel = await resolveChannel(team.id, positional[1]);
@@ -1269,7 +1283,21 @@ const CAP_COLLECTOR_JS = `
           // A new phrase has started when the bottom row no longer extends the
           // previous one (different speaker, or text no longer a growing prefix).
           if (st.prevText && !(bottom.author === st.prevAuthor && bottom.text.startsWith(st.prevText))) {
-            window.__sliccCaps.push({ author: st.prevAuthor, text: st.prevText, ts: Date.now() });
+            const phrase = { author: st.prevAuthor, text: st.prevText, ts: Date.now() };
+            window.__sliccCaps.push(phrase);
+            // Copilot mode: fire the finalized phrase at a SLICC webhook so it
+            // arrives as a lick to the wired scoop (no polling). Fire-and-forget,
+            // no-cors — we only need to trigger it, not read the response.
+            if (window.__sliccCapWebhook) {
+              try {
+                fetch(window.__sliccCapWebhook, {
+                  method: 'POST',
+                  mode: 'no-cors',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify(phrase),
+                });
+              } catch (e) {}
+            }
           }
           st.prevAuthor = bottom.author;
           st.prevText = bottom.text;
@@ -1341,6 +1369,113 @@ async function enableLiveCaptions(tab) {
   return 'clicked-unconfirmed';
 }
 
+// --- Copilot mode helpers: webhook wiring, snapshots, meeting-chat posting ---
+
+const TRANSCRIBE_STATE = '/shared/.teams-transcribe-state.json';
+
+function _readTranscribeState() {
+  try { const fs = require('fs'); return JSON.parse(fs.readFileSync(TRANSCRIBE_STATE, 'utf8')); } catch (e) { return {}; }
+}
+function _writeTranscribeState(st) {
+  try { const fs = require('fs'); fs.writeFileSync(TRANSCRIBE_STATE, JSON.stringify(st, null, 2)); } catch (e) {}
+}
+
+// Create a SLICC webhook routed to <scoop>. Returns { id, url } or null.
+async function createTranscribeWebhook(scoop) {
+  const r = await exec(`webhook create --scoop ${scoop} --name teams-transcribe`);
+  if (r.exitCode !== 0) return null;
+  const idM = (r.stdout || '').match(/ID:\s*(\S+)/);
+  const urlM = (r.stdout || '').match(/URL:\s*(\S+)/);
+  if (!idM || !urlM) return null;
+  return { id: idM[1], url: urlM[1] };
+}
+
+async function deleteWebhook(id) {
+  if (!id) return;
+  try { await exec(`webhook delete ${id}`); } catch (e) {}
+}
+
+// Point the in-page collector at a webhook URL (fired per finalized phrase).
+async function setCollectorWebhook(tab, url) {
+  await browser.evalAsync(tab, `(() => { window.__sliccCapWebhook = ${JSON.stringify(url || '')}; return 'ok'; })()`);
+}
+
+// Detect whether a screen share is active in the meeting.
+// VALIDATE-LIVE: selectors may need tuning against a real Teams meeting.
+async function isScreenSharing(tab) {
+  const r = await browser.evalAsync(tab, `(() => {
+    const sels = ['[data-tid*="screenshare" i]','[data-tid*="screen-share" i]','[data-tid="shared-content"]','[data-tid="ScreenShareStage"]','[aria-label*="is sharing" i]','[aria-label*="presenting" i]'];
+    for (const s of sels) { try { if (document.querySelector(s)) return true; } catch (e) {} }
+    const ctrls = Array.from(document.querySelectorAll('button,[role="button"]'));
+    if (ctrls.some((b) => /stop (sharing|presenting)/i.test((b.getAttribute('aria-label') || b.innerText || '')))) return true;
+    return false;
+  })()`);
+  return _asBool(r);
+}
+
+// Screenshot the Teams window; keep only if different from the last kept shot
+// (md5 dedupe). The whole pipeline runs in the exec shell context so the
+// screenshot file and md5sum share one filesystem view.
+// VALIDATE-LIVE: confirm `playwright-cli screenshot --tab` is available in exec
+// and writes where md5sum can read it.
+async function takeSnapshot(tab, shotsDir) {
+  const tid = _targetId(tab);
+  const dir = shotsDir || '/shared/copilot-shots';
+  const ts = Date.now();
+  const script =
+    `mkdir -p ${dir}; ` +
+    `tmp=${dir}/.tmp-${ts}.png; ` +
+    `playwright-cli screenshot --tab=${tid} --filename="$tmp" --max-width=1600 >/dev/null 2>&1 || { echo SNAP_ERR; exit 0; }; ` +
+    `nm=$(md5sum "$tmp" 2>/dev/null | awk '{print $1}'); ` +
+    `lm=$(cat ${dir}/.last-md5 2>/dev/null); ` +
+    `if [ -n "$nm" ] && [ "$nm" = "$lm" ]; then rm -f "$tmp"; echo SNAP_UNCHANGED; exit 0; fi; ` +
+    `final=${dir}/shot-${ts}.png; mv "$tmp" "$final"; echo "$nm" > ${dir}/.last-md5; echo "SNAP_SAVED $final"`;
+  const r = await exec(script);
+  const o = (r.stdout || '').trim();
+  if (o.includes('SNAP_SAVED')) return { saved: true, path: o.split('SNAP_SAVED ')[1].split(/\s/)[0] };
+  if (o.includes('SNAP_UNCHANGED')) return { saved: false, reason: 'unchanged' };
+  return { saved: false, reason: 'screenshot_failed' };
+}
+
+// Post a message into the CURRENTLY ACTIVE meeting's chat via the DOM.
+// Visible to ALL participants. VALIDATE-LIVE: the meeting-chat input selector and
+// send mechanism vary by Teams build; tune against a real meeting.
+async function postToMeetingChat(tab, message) {
+  const js = `(async () => {
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    const findBox = () => document.querySelector(
+      '[data-tid="ckeditor"] [contenteditable="true"], ' +
+      'div[role="textbox"][contenteditable="true"], ' +
+      '[data-tid="message-input"] [contenteditable="true"], ' +
+      '[contenteditable="true"][aria-label*="message" i], ' +
+      '[contenteditable="true"][data-tid*="input" i]'
+    );
+    let box = findBox();
+    if (!box) {
+      const toggle = Array.from(document.querySelectorAll('button,[role="button"]'))
+        .find((b) => /chat/i.test((b.getAttribute('aria-label') || '')) && !/close/i.test((b.getAttribute('aria-label') || '')));
+      if (toggle) { toggle.click(); await sleep(1500); box = findBox(); }
+    }
+    if (!box) return 'no-input';
+    box.focus();
+    let inserted = false;
+    try { inserted = document.execCommand('insertText', false, ${JSON.stringify(message)}); } catch (e) {}
+    if (!inserted || !(box.textContent || '').trim()) {
+      box.textContent = ${JSON.stringify(message)};
+      box.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    }
+    await sleep(400);
+    const sendBtn = document.querySelector('button[data-tid="newMessageCommands-send"], button[name="send"], button[aria-label*="Send" i]');
+    if (sendBtn && !sendBtn.disabled) { sendBtn.click(); return 'sent-button'; }
+    const opts = { key: 'Enter', code: 'Enter', keyCode: 13, which: 13, bubbles: true };
+    box.dispatchEvent(new KeyboardEvent('keydown', opts));
+    box.dispatchEvent(new KeyboardEvent('keyup', opts));
+    return 'sent-enter';
+  })()`;
+  const r = await browser.evalAsync(tab, js);
+  return (typeof r === 'string') ? r : JSON.stringify(r);
+}
+
 async function cmdTranscribe() {
   const fs = require('fs');
   const sub = (positional[0] || 'start').toLowerCase();
@@ -1388,6 +1523,25 @@ async function cmdTranscribe() {
       } else {
         console.log(`Could not fully enable captions (${status}). Turn on "More (...) -> Language and speech -> Show live captions" manually, then run: teams transcribe start`);
       }
+
+      // Copilot mode: --scoop <name> wires each finalized phrase to a webhook
+      // that delivers a lick to that scoop (event-driven, no polling).
+      const state = { outFile, shotsDir: flags['shots-dir'] || '/shared/copilot-shots' };
+      if (flags.scoop) {
+        const prev = _readTranscribeState();
+        if (prev.webhookId) await deleteWebhook(prev.webhookId); // avoid orphaning a previous one
+        const wh = await createTranscribeWebhook(flags.scoop);
+        if (!wh) {
+          console.log(`WARNING: could not create webhook for scoop "${flags.scoop}" — phrases will still be captured, but no licks will fire.`);
+        } else {
+          await setCollectorWebhook(tab, wh.url);
+          state.webhookId = wh.id;
+          state.scoop = flags.scoop;
+          console.log(`Copilot mode: each finalized phrase now fires a lick to scoop "${flags.scoop}" (webhook ${wh.id}).`);
+        }
+      }
+      _writeTranscribeState(state);
+
       const outFlag = (flags.out || flags.o) ? ` --out=${outFile}` : '';
       console.log(`Transcript file: ${outFile}`);
       console.log(`Flush new lines:  teams transcribe flush${outFlag}`);
@@ -1415,7 +1569,14 @@ async function cmdTranscribe() {
     case 'stop': {
       const { buffer } = await readCollector();
       const fresh = flushToFile(buffer);
-      await browser.evalAsync(tab, `(() => { if (window.__sliccCapTimer) clearInterval(window.__sliccCapTimer); window.__sliccCapInstalled = false; return 'stopped'; })()`);
+      await browser.evalAsync(tab, `(() => { if (window.__sliccCapTimer) clearInterval(window.__sliccCapTimer); window.__sliccCapInstalled = false; window.__sliccCapWebhook = null; return 'stopped'; })()`);
+      // Tear down copilot webhook if one was wired.
+      const st = _readTranscribeState();
+      if (st.webhookId) {
+        await deleteWebhook(st.webhookId);
+        console.log(`Copilot webhook ${st.webhookId} removed.`);
+      }
+      _writeTranscribeState({});
       console.log(`Stopped. Flushed final ${fresh.length} phrase(s). Total captured: ${buffer.length}. -> ${outFile}`);
       console.log('(Live captions remain toggled on in the meeting UI — turn them off manually if you want.)');
       break;
@@ -1450,6 +1611,23 @@ async function cmdTranscribe() {
     default:
       die(`Unknown transcribe subcommand: ${sub}. Use one of: start | flush | status | follow | stop`);
   }
+
+  // --snapshot flag: composes with any subcommand (except follow, which loops).
+  // Captures a deduped screenshot of the Teams window IF a screen share is active.
+  // The copilot scoop typically calls `teams transcribe flush --snapshot` per lick.
+  if (flags.snapshot && sub !== 'follow') {
+    const st = _readTranscribeState();
+    const shotsDir = flags['shots-dir'] || st.shotsDir || '/shared/copilot-shots';
+    const sharing = await isScreenSharing(tab);
+    if (!sharing) {
+      console.log('Snapshot: skipped (no screen share detected).');
+    } else {
+      const snap = await takeSnapshot(tab, shotsDir);
+      if (snap.saved) console.log(`Snapshot: ${snap.path}`);
+      else if (snap.reason === 'unchanged') console.log('Snapshot: unchanged since last frame (skipped).');
+      else console.log('Snapshot: capture failed.');
+    }
+  }
 }
 
 function showHelp() {
@@ -1466,6 +1644,7 @@ Commands:
   activity                          Messages mentioning/involving me (default: --since=24h)
   post <team> <channel> <message>   Post a message to a channel
   post ... --reply-to=<msg-id>      Reply in a thread
+  post --live <message>             Post into the CURRENTLY ACTIVE meeting chat (visible to all)
   thread <team> <channel> <msg-id>  Read replies to a message
   user <user-id-or-name>            Look up a user
   info <team> <channel>             Channel metadata
@@ -1473,10 +1652,12 @@ Commands:
   unanswered <team> <channel>       Messages with no replies (default: --since=48h)
   digest                            Activity summary across all teams (default: --since=24h, --max-teams=10)
   transcribe [start]                Turn on live captions in the active meeting and capture the transcript
-  transcribe flush [--out=FILE]     Append newly-finalized caption phrases to the transcript file
+  transcribe start --scoop <name>   Copilot mode: fire a lick to <name> for each finalized phrase
+  transcribe flush [--snapshot]     Append new phrases; --snapshot also grabs a deduped screen-share frame
   transcribe status                 Show whether captions render + buffered/live lines
   transcribe follow [--out=FILE]    Stream the transcript live and flush continuously (blocks)
-  transcribe stop [--out=FILE]      Final flush and stop the in-page collector
+  transcribe stop [--out=FILE]      Final flush, remove copilot webhook, stop the collector
+    flags: --out=FILE  --scoop=NAME  --snapshot  --shots-dir=DIR  --interval=SEC (follow)
 
 Aliases: messages/msgs → history, mentions → activity
 

--- a/skills/teams/scripts/teams.jsh
+++ b/skills/teams/scripts/teams.jsh
@@ -1570,6 +1570,10 @@ async function cmdTranscribe() {
     }
     let idx = 0;
     try { idx = parseInt(fs.readFileSync(idxFile, 'utf8').trim(), 10) || 0; } catch (e) { idx = 0; }
+    // Catch-up guard: if the in-page buffer is SHORTER than our saved index, the
+    // collector was reinstalled (new session / tab reload) and the buffer reset.
+    // Re-flush from 0 so a fresh session's phrases are never silently skipped.
+    if (idx > buffer.length) idx = 0;
     const fresh = buffer.slice(idx);
     if (fresh.length) {
       const lines = fresh.map((c) => {

--- a/skills/teams/scripts/teams.jsh
+++ b/skills/teams/scripts/teams.jsh
@@ -546,7 +546,9 @@ async function cmdPost() {
   // --live: post into the CURRENTLY ACTIVE meeting's chat (visible to all
   // participants) instead of a team channel. No team/channel needed.
   if (flags.live) {
-    const message = positional.join(' ').trim();
+    // parseFlags() may capture the message as the value of --live (when it is a
+    // single quoted arg) or leave it in positional; combine both to be safe.
+    const message = [(typeof flags.live === 'string' ? flags.live : ''), ...positional].join(' ').trim();
     if (!message) die('Usage: teams post --live <message>   (posts to the active meeting chat)');
     const tab = await findTeamsTab();
     const res = await postToMeetingChat(tab, message);
@@ -1419,20 +1421,69 @@ async function isScreenSharing(tab) {
 // VALIDATE-LIVE: confirm `playwright-cli screenshot --tab` is available in exec
 // and writes where md5sum can read it.
 async function takeSnapshot(tab, shotsDir) {
+  const fs = require('fs');
   const tid = _targetId(tab);
   const dir = shotsDir || '/shared/copilot-shots';
   const ts = Date.now();
+
+  // Capture ONLY the share-PREVIEW node: draw the largest shared-screen <video>
+  // to an in-page canvas and export a PNG dataURL. This scopes the frame (and
+  // therefore the dedupe) to the shared content itself — captions, chat, roster,
+  // and clock churn elsewhere in the window are excluded. Falls back to a full
+  // window screenshot if no capturable video is present.
+  let dataUrl = '';
+  try {
+    let r = await browser.evalAsync(tab, `(() => {
+      const vids = Array.from(document.querySelectorAll('video'));
+      let best = null, area = 0;
+      for (const v of vids) { const b = v.getBoundingClientRect(); const a = b.width * b.height; if (a > area && b.width > 200 && b.height > 150) { area = a; best = v; } }
+      if (!best) return '';
+      try {
+        const vw = best.videoWidth || Math.round(best.getBoundingClientRect().width);
+        const vh = best.videoHeight || Math.round(best.getBoundingClientRect().height);
+        if (!vw || !vh) return '';
+        const scale = Math.min(1, 1280 / vw);
+        const c = document.createElement('canvas');
+        c.width = Math.round(vw * scale); c.height = Math.round(vh * scale);
+        c.getContext('2d').drawImage(best, 0, 0, c.width, c.height);
+        return c.toDataURL('image/png');
+      } catch (e) { return 'TAINTED'; }
+    })()`);
+    dataUrl = (typeof r === 'string') ? r : String(r);
+  } catch (e) { dataUrl = ''; }
+
+  if (dataUrl && dataUrl.startsWith('data:image')) {
+    const b64 = dataUrl.split(',')[1] || '';
+    // djb2 hash of the pixel payload → dedupe key (changes only when the shared content changes).
+    let h = 5381;
+    for (let i = 0; i < b64.length; i++) { h = ((h << 5) + h + b64.charCodeAt(i)) >>> 0; }
+    const sig = h + ':' + b64.length;
+    let last = '';
+    try { last = fs.readFileSync(dir + '/.last-sig', 'utf8').trim(); } catch (e) {}
+    if (sig === last) return { saved: false, reason: 'unchanged' };
+    try {
+      try { fs.mkdirSync(dir, { recursive: true }); } catch (e) {}
+      const bin = atob(b64);
+      const arr = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
+      const outfile = dir + '/shot-' + ts + '.png';
+      fs.writeFileSync(outfile, arr);
+      fs.writeFileSync(dir + '/.last-sig', sig);
+      return { saved: true, path: outfile, scoped: true };
+    } catch (e) { return { saved: false, reason: 'save_failed' }; }
+  }
+
+  // Fallback: full-window screenshot + md5 dedupe (exec shell context).
   const script =
-    `mkdir -p ${dir}; ` +
-    `tmp=${dir}/.tmp-${ts}.png; ` +
-    `playwright-cli screenshot --tab=${tid} --filename="$tmp" --max-width=1600 >/dev/null 2>&1 || { echo SNAP_ERR; exit 0; }; ` +
+    `mkdir -p ${dir}; tmp=${dir}/.tmp-${ts}.png; ` +
+    `playwright-cli screenshot --tab=${tid} --filename="$tmp" >/dev/null 2>&1 || { echo SNAP_ERR; exit 0; }; ` +
     `nm=$(md5sum "$tmp" 2>/dev/null | awk '{print $1}'); ` +
     `lm=$(cat ${dir}/.last-md5 2>/dev/null); ` +
     `if [ -n "$nm" ] && [ "$nm" = "$lm" ]; then rm -f "$tmp"; echo SNAP_UNCHANGED; exit 0; fi; ` +
     `final=${dir}/shot-${ts}.png; mv "$tmp" "$final"; echo "$nm" > ${dir}/.last-md5; echo "SNAP_SAVED $final"`;
   const r = await exec(script);
   const o = (r.stdout || '').trim();
-  if (o.includes('SNAP_SAVED')) return { saved: true, path: o.split('SNAP_SAVED ')[1].split(/\s/)[0] };
+  if (o.includes('SNAP_SAVED')) return { saved: true, path: o.split('SNAP_SAVED ')[1].split(/\s/)[0], scoped: false };
   if (o.includes('SNAP_UNCHANGED')) return { saved: false, reason: 'unchanged' };
   return { saved: false, reason: 'screenshot_failed' };
 }
@@ -1441,39 +1492,53 @@ async function takeSnapshot(tab, shotsDir) {
 // Visible to ALL participants. VALIDATE-LIVE: the meeting-chat input selector and
 // send mechanism vary by Teams build; tune against a real meeting.
 async function postToMeetingChat(tab, message) {
-  const js = `(async () => {
-    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-    const findBox = () => document.querySelector(
-      '[data-tid="ckeditor"] [contenteditable="true"], ' +
-      'div[role="textbox"][contenteditable="true"], ' +
-      '[data-tid="message-input"] [contenteditable="true"], ' +
-      '[contenteditable="true"][aria-label*="message" i], ' +
-      '[contenteditable="true"][data-tid*="input" i]'
-    );
-    let box = findBox();
-    if (!box) {
-      const toggle = Array.from(document.querySelectorAll('button,[role="button"]'))
-        .find((b) => /chat/i.test((b.getAttribute('aria-label') || '')) && !/close/i.test((b.getAttribute('aria-label') || '')));
-      if (toggle) { toggle.click(); await sleep(1500); box = findBox(); }
+  // Teams' meeting chat box is a CKEditor contenteditable that ignores in-page
+  // DOM edits (execCommand/paste land as orphan nodes off the editor model, and
+  // execCommand needs OS focus the eval bridge doesn't provide). REAL CDP input
+  // via playwright-cli works: click the box, type (genuine keystrokes reach the
+  // model), click Send. Refs come from the accessibility snapshot.
+  const tid = _targetId(tab);
+
+  async function findRefs() {
+    const snap = await exec(`playwright-cli snapshot --tab=${tid}`);
+    const txt = snap.stdout || '';
+    const boxM = txt.match(/textbox "Type a message"\s*\[ref=(e\d+)\]/);
+    const sendM = txt.match(/button "Send[^"]*"\s*\[ref=(e\d+)\]/);
+    return { boxRef: boxM ? boxM[1] : null, sendRef: sendM ? sendM[1] : null, snap: txt };
+  }
+
+  let { boxRef, sendRef, snap } = await findRefs();
+
+  // If the compose box isn't present, try to open the meeting chat pane.
+  if (!boxRef) {
+    const chatM = snap.match(/button "(?:Chat|Open chat|Show conversation)[^"]*"\s*\[ref=(e\d+)\]/i);
+    if (chatM) {
+      await exec(`playwright-cli click ${chatM[1]} --tab=${tid}`);
+      await sleep(1500);
+      ({ boxRef, sendRef } = await findRefs());
     }
-    if (!box) return 'no-input';
-    box.focus();
-    let inserted = false;
-    try { inserted = document.execCommand('insertText', false, ${JSON.stringify(message)}); } catch (e) {}
-    if (!inserted || !(box.textContent || '').trim()) {
-      box.textContent = ${JSON.stringify(message)};
-      box.dispatchEvent(new InputEvent('input', { bubbles: true }));
-    }
-    await sleep(400);
-    const sendBtn = document.querySelector('button[data-tid="newMessageCommands-send"], button[name="send"], button[aria-label*="Send" i]');
-    if (sendBtn && !sendBtn.disabled) { sendBtn.click(); return 'sent-button'; }
-    const opts = { key: 'Enter', code: 'Enter', keyCode: 13, which: 13, bubbles: true };
-    box.dispatchEvent(new KeyboardEvent('keydown', opts));
-    box.dispatchEvent(new KeyboardEvent('keyup', opts));
-    return 'sent-enter';
-  })()`;
-  const r = await browser.evalAsync(tab, js);
-  return (typeof r === 'string') ? r : JSON.stringify(r);
+  }
+  if (!boxRef) return 'no-input';
+
+  // Shell-escape the message for single-quote wrapping.
+  const esc = String(message).replace(/'/g, `'\\''`);
+  await exec(`playwright-cli click ${boxRef} --tab=${tid}`);
+  await exec(`playwright-cli type '${esc}' --tab=${tid}`);
+  await sleep(200);
+  if (sendRef) {
+    await exec(`playwright-cli click ${sendRef} --tab=${tid}`);
+  } else {
+    await exec(`playwright-cli press Enter --tab=${tid}`);
+  }
+  await sleep(300);
+
+  // Confirm the box cleared (message left the composer = sent).
+  try {
+    const chk = await browser.evalAsync(tab, `(() => { const b = document.querySelector('[data-tid="ckeditor"]'); return !(b && (b.innerText || '').trim()); })()`);
+    return _asBool(chk) ? 'sent' : 'send-unconfirmed';
+  } catch (e) {
+    return 'sent';
+  }
 }
 
 async function cmdTranscribe() {

--- a/skills/teams/scripts/teams.jsh
+++ b/skills/teams/scripts/teams.jsh
@@ -552,11 +552,11 @@ async function cmdPost() {
     if (!message) die('Usage: teams post --live <message>   (posts to the active meeting chat)');
     const tab = await findTeamsTab();
     const res = await postToMeetingChat(tab, message);
-    if (res === 'not-full-view') {
-      die('Meeting is not in full view — refusing to post so I don\'t hit the wrong chat (in compact/PiP view the visible "Chat" is the app rail, often a DM). Expand the meeting to full view and retry.');
+    if (res === 'no-meeting-chat') {
+      die('Could not open the meeting\'s in-call chat ("Meeting chat" pane). Make sure you are in the meeting (its "Chat" control must be available) and retry.');
     }
     if (res === 'no-input') {
-      die('Could not find the meeting chat input. Make sure you are in the meeting with the in-call chat available.');
+      die('Opened the meeting chat but could not find its message box. Retry in a moment.');
     }
     out({ target: 'live-meeting-chat', result: res, message });
     return;
@@ -1531,90 +1531,52 @@ async function takeSnapshot(tab, shotsDir) {
 // Visible to ALL participants. VALIDATE-LIVE: the meeting-chat input selector and
 // send mechanism vary by Teams build; tune against a real meeting.
 async function postToMeetingChat(tab, message) {
-  // Teams' meeting chat box is a CKEditor contenteditable that ignores in-page
-  // DOM edits (execCommand/paste land as orphan nodes off the editor model, and
-  // execCommand needs OS focus the eval bridge doesn't provide). REAL CDP input
-  // via playwright-cli works: click the box, type (genuine keystrokes reach the
-  // model), click Send. Refs come from the accessibility snapshot.
+  // Post into the MEETING's own in-call chat. Implemented EVAL-FREE via
+  // playwright-cli (accessibility snapshot + real CDP click/type), because:
+  //  - Teams' CKEditor ignores in-page DOM edits (execCommand/paste land as
+  //    orphan nodes; real keystrokes are required), and
+  //  - while a meeting is active the tab's Runtime.evaluate context is often
+  //    detached (evalAsync throws), but the a11y/input CDP domains keep working.
+  // Targeting rule: the in-call chat opens under a heading "Meeting chat" via a
+  // button labelled EXACTLY "Chat". The app rail's "Chat (⌃⇧2)" is a DIFFERENT
+  // control that shows a DM — we must NOT use it. If we can't reach the
+  // "Meeting chat" pane, we abort rather than risk posting to the wrong chat.
   const tid = _targetId(tab);
+  const snap = async () => ((await exec(`playwright-cli snapshot --tab=${tid}`)).stdout || '');
+  const refOf = (txt, re) => { const m = txt.match(re); return m ? m[1] : null; };
 
-  // SAFETY: only post when the meeting is in FULL view. In full view the app
-  // navigation rail is hidden, so the "Chat" control is the MEETING's in-call
-  // chat. In COMPACT/PiP view the app rail is visible and its "Chat (⌃⇧2)" is
-  // the app chat (often a DM) — posting there sends to the wrong conversation.
-  // We refuse rather than risk mis-posting to a DM. (A view-independent Graph
-  // path — POST /chats/{threadId}/messages — is the planned robust upgrade.)
-  let layout = 'unknown';
-  try {
-    layout = await browser.evalAsync(tab, `(() => {
-      const stage = document.querySelector('[data-tid="modern-stage-wrapper"]');
-      if (!stage) return 'no-stage';
-      const r = stage.getBoundingClientRect();
-      return (r.width > window.innerWidth * 0.5 && r.height > 300) ? 'full' : 'compact';
-    })()`);
-  } catch (e) {}
-  if (layout !== 'full') return 'not-full-view';
+  let s = await snap();
 
-  // Full view: open the in-call chat pane if it isn't already open.
-  try {
-    const opened = await browser.evalAsync(tab, `(() => {
-      const b = Array.from(document.querySelectorAll('button,[role="button"]')).find((x) => /^chat( |\\()/i.test((x.getAttribute('aria-label') || '')));
-      if (!b) return 'no-toggle';
-      if (b.getAttribute('aria-pressed') === 'true') return 'already-open';
-      b.click();
-      return 'opened';
-    })()`);
-    if (opened === 'opened') await sleep(1600);
-  } catch (e) {}
-
-  async function findRefs() {
-    const snap = await exec(`playwright-cli snapshot --tab=${tid}`);
-    const txt = snap.stdout || '';
-    const boxM = txt.match(/textbox "Type a message"\s*\[ref=(e\d+)\]/);
-    const sendM = txt.match(/button "Send[^"]*"\s*\[ref=(e\d+)\]/);
-    return { boxRef: boxM ? boxM[1] : null, sendRef: sendM ? sendM[1] : null, snap: txt };
+  // Ensure the Meeting chat pane is open (its distinctive heading).
+  if (!/heading "Meeting chat"/.test(s)) {
+    const chatRef = refOf(s, /button "Chat"\s*\[ref=(e\d+)\]/); // EXACT "Chat" = in-call control
+    if (!chatRef) return 'no-meeting-chat';
+    await exec(`playwright-cli click ${chatRef} --tab=${tid}`);
+    await sleep(1800);
+    s = await snap();
+    if (!/heading "Meeting chat"/.test(s)) return 'no-meeting-chat';
   }
 
-  let { boxRef, sendRef, snap } = await findRefs();
-
-  // If the compose box isn't present, try to open the meeting chat pane.
-  if (!boxRef) {
-    const chatM = snap.match(/button "(?:Chat|Open chat|Show conversation)[^"]*"\s*\[ref=(e\d+)\]/i);
-    if (chatM) {
-      await exec(`playwright-cli click ${chatM[1]} --tab=${tid}`);
-      await sleep(1500);
-      ({ boxRef, sendRef } = await findRefs());
-    }
-  }
+  const boxRef = refOf(s, /textbox "Type a message"\s*\[ref=(e\d+)\]/);
   if (!boxRef) return 'no-input';
 
-  // Shell-escape the message for single-quote wrapping.
   const esc = String(message).replace(/'/g, `'\\''`);
   await exec(`playwright-cli click ${boxRef} --tab=${tid}`);
   await exec(`playwright-cli type '${esc}' --tab=${tid}`);
   await sleep(400);
 
-  // Re-resolve the Send button AFTER typing: it may have been disabled/absent
-  // (and thus had no or a stale ref) before the box had content. Only then click.
-  const boxEmpty = () => browser.evalAsync(tab, `(() => { const b = document.querySelector('[data-tid="ckeditor"]'); return !(b && (b.innerText || '').replace(/\\s+/g, '')); })()`);
-  const fresh = await findRefs();
-  const finalSend = fresh.sendRef || sendRef;
-  if (finalSend) {
-    await exec(`playwright-cli click ${finalSend} --tab=${tid}`);
-  } else {
-    await exec(`playwright-cli press Enter --tab=${tid}`);
-  }
+  // Re-resolve the Send button AFTER typing (it only becomes present/enabled
+  // once the box has content), then click it; fall back to Enter.
+  const s2 = await snap();
+  const sendRef = refOf(s2, /button "Send[^"]*"\s*\[ref=(e\d+)\]/);
+  if (sendRef) await exec(`playwright-cli click ${sendRef} --tab=${tid}`);
+  else await exec(`playwright-cli press Enter --tab=${tid}`);
+  await sleep(500);
 
-  // Confirm the box cleared (message left the composer = sent). Poll up to ~2s;
-  // if still populated, retry Enter once as a fallback.
-  for (let i = 0; i < 8; i++) {
-    await sleep(250);
-    try { if (_asBool(await boxEmpty())) return 'sent'; } catch (e) {}
-  }
-  await exec(`playwright-cli press Enter --tab=${tid}`);
-  await sleep(400);
-  try { if (_asBool(await boxEmpty())) return 'sent'; } catch (e) {}
-  return 'send-unconfirmed';
+  // Confirm: the message now appears as a "Sent …" entry in the chat log.
+  const probe = message.slice(0, 24);
+  const s3 = await snap();
+  return (/\bSent\b/.test(s3) && s3.includes(probe)) ? 'sent' : 'send-unconfirmed';
 }
 
 async function cmdTranscribe() {

--- a/skills/teams/scripts/teams.jsh
+++ b/skills/teams/scripts/teams.jsh
@@ -1272,58 +1272,75 @@ const CAP_LIST_TID = 'closed-caption-v2-virtual-list-content';
 const CAP_COLLECTOR_JS = `
   (() => {
     const LIST_SEL = '[data-tid="${CAP_LIST_TID}"]';
-    const parseRow = (row) => {
-      const textEl = row.querySelector('[data-tid="closed-caption-text"]');
-      const full = (row.innerText || '').trim();
-      const text = textEl ? (textEl.innerText || '').trim() : '';
-      let author = full;
-      if (text && full.endsWith(text)) author = full.slice(0, full.length - text.length).trim();
-      author = (author.split('\\n')[0] || '').trim();
+    const CAP_SEL = '[data-tid="closed-caption-text"]';
+    // Each spoken utterance is its OWN <span data-tid="closed-caption-text"> whose
+    // text grows as it is recognized, then finalizes when the NEXT utterance's
+    // span appears. The speaker name sits ~2 ancestors up ("Name\\n<text>").
+    // (NB: the virtual list has a single wrapper child, so we must iterate the
+    // caption-text spans, not list.children.)
+    const capElements = () => {
+      const list = document.querySelector(LIST_SEL);
+      return list ? Array.from(list.querySelectorAll(CAP_SEL)) : [];
+    };
+    const parseCap = (el) => {
+      const text = (el.innerText || '').trim();
+      if (!text) return { author: '', text: '' };
+      let author = '';
+      let n = el.parentElement;
+      for (let d = 0; d < 5 && n; d++) {
+        const full = (n.innerText || '').trim();
+        if (full.length > text.length && full.endsWith(text)) {
+          author = full.slice(0, full.length - text.length).trim().split('\\n')[0].trim();
+          break;
+        }
+        n = n.parentElement;
+      }
       return { author, text };
     };
     if (!window.__sliccCapInstalled) {
       window.__sliccCapInstalled = true;
       window.__sliccCaps = [];
-      // Track the in-progress bottom-row text. A phrase is COMMITTED whenever the
-      // bottom row no longer EXTENDS the previous text — i.e. a new utterance
-      // began, whether Teams grew the row ("1"->"1 2") or replaced it ("1"->"2").
-      // Committing-the-previous-on-change captures both growth and replacement,
-      // so nothing is overwritten/lost. Driven by a MutationObserver (fires on
-      // every caption change, no inter-poll gaps) plus a debounce that commits
-      // the trailing utterance after a pause.
-      window.__capState = { prevAuthor: null, prevText: '', lastCommitted: '' };
-      const commit = (author, text) => {
-        if (!text) return;
-        // Dedupe: never commit the exact same text twice in a row (a stable
-        // caption that keeps re-rendering must not be committed repeatedly).
-        const sig = (author || '') + '\u0001' + text;
-        if (sig === window.__capState.lastCommitted) return;
-        window.__capState.lastCommitted = sig;
-        const phrase = { author: author, text: text, ts: Date.now() };
-        window.__sliccCaps.push(phrase);
-        if (window.__sliccCapWebhook) {
-          try { fetch(window.__sliccCapWebhook, { method: 'POST', mode: 'no-cors', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(phrase) }); } catch (e) {}
+      // One buffer entry per caption-text ELEMENT; SUPERSEDE its text as that
+      // utterance grows. Deliver each utterance to the webhook exactly once, when
+      // it finalizes (no longer the last element) or after a debounce pause.
+      window.__capMeta = new WeakMap(); // caption span -> { idx, text, fired }
+      const fire = (idx) => {
+        const p = window.__sliccCaps[idx];
+        if (p && window.__sliccCapWebhook) {
+          try { fetch(window.__sliccCapWebhook, { method: 'POST', mode: 'no-cors', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(p) }); } catch (e) {}
         }
+      };
+      const touch = (el, isLast) => {
+        const { author, text } = parseCap(el);
+        if (!text) return;
+        let meta = window.__capMeta.get(el);
+        if (!meta) {
+          const idx = window.__sliccCaps.push({ author: author, text: text, ts: Date.now() }) - 1;
+          meta = { idx: idx, text: text, fired: false };
+          window.__capMeta.set(el, meta);
+        } else if (text !== meta.text) {
+          window.__sliccCaps[meta.idx].text = text; // supersede as the utterance grows
+          if (author) window.__sliccCaps[meta.idx].author = author;
+          meta.text = text;
+        }
+        if (!isLast && !meta.fired) { meta.fired = true; fire(meta.idx); }
       };
       window.__capProcess = () => {
         try {
-          const list = document.querySelector(LIST_SEL);
-          if (!list || !list.children.length) return;
-          const { author, text } = parseRow(list.children[list.children.length - 1]);
-          if (!text) return;
-          const st = window.__capState;
-          if (st.prevText && !(author === st.prevAuthor && text.startsWith(st.prevText))) {
-            commit(st.prevAuthor, st.prevText);
-          }
-          st.prevAuthor = author;
-          st.prevText = text;
-          // Debounce: commit the trailing utterance after a pause (~1.4s) so a
-          // final phrase (or the last number in a count) isn't left uncommitted
-          // and then overwritten by whatever is said next.
+          const els = capElements();
+          if (!els.length) return;
+          const lastIdx = els.length - 1;
+          els.forEach((el, i) => touch(el, i === lastIdx));
+          // Debounce: after a pause, fire the trailing utterance so it isn't left
+          // undelivered (its text is already kept current via supersede above).
           clearTimeout(window.__capTrailTimer);
           window.__capTrailTimer = setTimeout(() => {
-            const s = window.__capState;
-            if (s.prevText) { commit(s.prevAuthor, s.prevText); s.prevText = ''; s.prevAuthor = null; }
+            const e2 = capElements();
+            if (!e2.length) return;
+            const last = e2[e2.length - 1];
+            touch(last, true);
+            const meta = window.__capMeta.get(last);
+            if (meta && !meta.fired) { meta.fired = true; fire(meta.idx); }
           }, 1400);
         } catch (e) {}
       };
@@ -1344,8 +1361,8 @@ const CAP_COLLECTOR_JS = `
     }
     let pending = null;
     try {
-      const l = document.querySelector(LIST_SEL);
-      if (l && l.children.length) pending = parseRow(l.children[l.children.length - 1]);
+      const els = capElements();
+      if (els.length) pending = parseCap(els[els.length - 1]);
     } catch (e) {}
     return JSON.stringify({
       buffer: window.__sliccCaps,

--- a/skills/teams/scripts/teams.jsh
+++ b/skills/teams/scripts/teams.jsh
@@ -1284,46 +1284,47 @@ const CAP_COLLECTOR_JS = `
     if (!window.__sliccCapInstalled) {
       window.__sliccCapInstalled = true;
       window.__sliccCaps = [];
-      window.__capSeen = new WeakSet(); // caption row elements already committed
+      // Track the in-progress bottom-row text. A phrase is COMMITTED whenever the
+      // bottom row no longer EXTENDS the previous text — i.e. a new utterance
+      // began, whether Teams grew the row ("1"->"1 2") or replaced it ("1"->"2").
+      // Committing-the-previous-on-change captures both growth and replacement,
+      // so nothing is overwritten/lost. Driven by a MutationObserver (fires on
+      // every caption change, no inter-poll gaps) plus a debounce that commits
+      // the trailing utterance after a pause.
+      window.__capState = { prevAuthor: null, prevText: '', lastCommitted: '' };
       const commit = (author, text) => {
         if (!text) return;
-        const phrase = { author, text, ts: Date.now() };
+        // Dedupe: never commit the exact same text twice in a row (a stable
+        // caption that keeps re-rendering must not be committed repeatedly).
+        const sig = (author || '') + '\u0001' + text;
+        if (sig === window.__capState.lastCommitted) return;
+        window.__capState.lastCommitted = sig;
+        const phrase = { author: author, text: text, ts: Date.now() };
         window.__sliccCaps.push(phrase);
-        // Copilot mode: fire the finalized phrase at a SLICC webhook so it arrives
-        // as a lick to the wired scoop. Fire-and-forget, no-cors.
         if (window.__sliccCapWebhook) {
-          try {
-            fetch(window.__sliccCapWebhook, { method: 'POST', mode: 'no-cors', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(phrase) });
-          } catch (e) {}
+          try { fetch(window.__sliccCapWebhook, { method: 'POST', mode: 'no-cors', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(phrase) }); } catch (e) {}
         }
       };
       window.__capProcess = () => {
         try {
           const list = document.querySelector(LIST_SEL);
-          if (!list) return;
-          const rows = Array.from(list.children);
-          const lastIdx = rows.length - 1;
-          // Every row except the current (last, in-progress) one is finalized.
-          rows.forEach((row, i) => {
-            if (i === lastIdx) return;
-            if (window.__capSeen.has(row)) return;
-            const { author, text } = parseRow(row);
-            if (!text) return;
-            window.__capSeen.add(row);
-            commit(author, text);
-          });
-          // Debounce-commit the trailing row when speech pauses (~1.6s), so the
-          // final utterance isn't stuck uncommitted as the perpetual last row.
+          if (!list || !list.children.length) return;
+          const { author, text } = parseRow(list.children[list.children.length - 1]);
+          if (!text) return;
+          const st = window.__capState;
+          if (st.prevText && !(author === st.prevAuthor && text.startsWith(st.prevText))) {
+            commit(st.prevAuthor, st.prevText);
+          }
+          st.prevAuthor = author;
+          st.prevText = text;
+          // Debounce: commit the trailing utterance after a pause (~1.4s) so a
+          // final phrase (or the last number in a count) isn't left uncommitted
+          // and then overwritten by whatever is said next.
           clearTimeout(window.__capTrailTimer);
           window.__capTrailTimer = setTimeout(() => {
-            const l = document.querySelector(LIST_SEL); if (!l || !l.children.length) return;
-            const last = l.children[l.children.length - 1];
-            if (window.__capSeen.has(last)) return;
-            const { author, text } = parseRow(last);
-            if (!text) return;
-            window.__capSeen.add(last);
-            commit(author, text);
-          }, 1600);
+            const s = window.__capState;
+            if (s.prevText) { commit(s.prevAuthor, s.prevText); s.prevText = ''; s.prevAuthor = null; }
+          }, 1400);
         } catch (e) {}
       };
       window.__capAttach = () => {


### PR DESCRIPTION
> **DRAFT — do not merge yet.** Meeting-dependent paths still need live validation (marked VALIDATE-LIVE in code). Stacked on `teams-transcribe` (#215); rebase to main once that merges.

## What

Adds "copilot mode" to `teams transcribe` — SLICC hears the meeting and proactively surfaces context to everyone. Three composable pieces:

**(a) transcribe fires licks → a scoop**
`teams transcribe start --scoop <name>` creates a SLICC webhook routed to that scoop and injects its URL into the in-page caption collector. Each finalized phrase is `POST`ed to the webhook (fire-and-forget, `no-cors`) → arrives as a lick. Event-driven, **no polling / no cron**. Webhook id tracked in `/shared/.teams-transcribe-state.json`, deleted on `stop`.

**(b) `--snapshot` (a flag, composes with any subcommand)**
Typically `teams transcribe flush --snapshot`. If a screen share is active, screenshots the Teams window and keeps it only if it differs (md5) from the last kept frame → `--shots-dir` (default `/shared/copilot-shots/`). Gives the scoop visual grounding without redundant static frames.

**(c) `teams post --live <message>`**
Posts into the **currently active meeting chat, visible to all participants** (meeting-chat DOM). How the copilot speaks up. Fits the existing `post` command via a `--live` flag.

Typical wiring: `teams transcribe start --scoop meeting-copilot` → the scoop gets a lick per phrase, calls `teams transcribe flush --snapshot` for latest text + a frame, decides if context is warranted, and if so calls `teams post --live "..."`.

## Design notes
- The collector fires the webhook straight from the Teams page — the webhook URL is on `www.sliccy.ai`, reached cross-origin via a `no-cors` POST (trigger only, no response read).
- Purely additive; reuses existing `sliccy:browser` / `sliccy:exec` bridges and `die`/`sleep`/`_targetId` helpers.

## VALIDATE-LIVE (need a real meeting + current Teams build)
- [ ] page→webhook `fetch` actually delivers a lick to the scoop
- [ ] screen-share detection selectors
- [ ] `playwright-cli screenshot --tab` works inside the exec shell context and md5 dedupe holds
- [ ] meeting-chat input + send selectors for `post --live`

## Tested now (no meeting)
Parse/help clean; `post --live` usage guard; `--snapshot` composes (correctly "skipped, no screen share"); `start --scoop` aborts at the not-in-meeting guard **before** creating a webhook (0 orphans).

Please **do not squash**.