### PR TITLE
chore(strava): use runtime process.argv.parseFlags(), drop the local copy

### DIFF
--- a/skills/strava/scripts/strava.jsh
+++ b/skills/strava/scripts/strava.jsh
@@ -25,54 +25,6 @@ REQUIRES
   strava.com open and logged in in your browser
 `.trim();
 
-// ── argument parsing ───────────────────────────────────────────────────────
-// Local replacement for the retired process.argv.parseFlags(): parses
-// `--flag=val`, `--flag val`, `-x` (boolean), positional args, and a `--`
-// passthrough boundary. Shape matches the old parseFlags() output.
-
-function parseFlags(argv) {
-  const positional = [];
-  const flags = {};
-  const passthrough = [];
-  let inPassthrough = false;
-
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    if (inPassthrough) {
-      passthrough.push(arg);
-      continue;
-    }
-    if (arg === '--') {
-      inPassthrough = true;
-      continue;
-    }
-    if (arg.startsWith('--')) {
-      const eq = arg.indexOf('=');
-      if (eq !== -1) {
-        flags[arg.slice(2, eq)] = arg.slice(eq + 1);
-      } else {
-        const key = arg.slice(2);
-        const next = argv[i + 1];
-        // A following token that looks like a negative number (e.g. `-5`)
-        // is a value, not a new flag — only treat `-`-prefixed tokens as
-        // flags when they aren't purely numeric.
-        if (next !== undefined && (!next.startsWith('-') || /^-\d+(\.\d+)?$/.test(next))) {
-          flags[key] = next;
-          i++;
-        } else {
-          flags[key] = true;
-        }
-      }
-    } else if (arg.startsWith('-') && arg.length > 1) {
-      flags[arg.slice(1)] = true;
-    } else {
-      positional.push(arg);
-    }
-  }
-
-  return { positional, flags, subcommand: positional[0], passthrough };
-}
-
 // ── helpers ────────────────────────────────────────────────────────────────
 
 function stripHtml(s) {
@@ -315,7 +267,11 @@ async function cmdNotifications(tab, flags) {
 // ── main ───────────────────────────────────────────────────────────────────
 
 async function main() {
-  const { positional, flags, subcommand } = parseFlags(process.argv.slice(2));
+  // Runtime helper — parses --flag=val, --flag val, -x shorts, repeated
+  // flags (promoted to array), and a `--` passthrough boundary. Same shape
+  // as the local copy this replaced; `subcommand` is bareword-only, so keep
+  // the positional[0] fallback.
+  const { positional, flags, subcommand } = process.argv.parseFlags();
   const cmd = subcommand || positional[0];
 
   if (flags.help || flags.h || cmd === '--help' || cmd === 'help' || !cmd) {


### PR DESCRIPTION
## Summary

Removes strava.jsh's 46-line local `parseFlags()` and its fossil comment ("the retired process.argv.parseFlags()") in favor of the runtime helper, which is present and current (slicc `js-realm-helpers.ts:34` / attached at `:92`, documented in `jsh-runtime-extensions.md`). Part of the fossil cleanup identified while writing the repo CLAUDE.md (#218); the comment dates from the bare-globals migration window when the helper genuinely looked gone.

## Behavioral deltas (all no-ops for this CLI)

| Difference | Why it doesn't matter here |
|---|---|
| Runtime treats `--flag -5` as flag+flag, local treated `-5` as value | No strava flag accepts negatives; `--limit` is clamped to ≥ 1 |
| Runtime bundles multi-char shorts (`-ab` → `a`,`b`); local set `flags.ab` | Only `-h`/`-l` documented, both single-char |
| Runtime promotes repeated flags to an array | `parseInt` on the array picks the first value |
| Runtime `subcommand` is bareword-only (`/^[a-z][\w-]*$/i`) | `main()` already falls back to `positional[0]` |

## Verification

- Parity check of the runtime parser semantics against the removed copy for every documented invocation shape (`me`, `feed --limit 5`, `feed -l 5 --following`, `activity <id>`, `--json`, `--help`).
- Not live-verified against a strava.com session in this PR — the dispatch surface is unchanged and the parsed shape is identical for all documented flags; happy to run the live pass if wanted before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LuEhZuA9v2PsdXuiDVvrS