### PR TITLE
chore(fluffyjaws): correct the false parseFlags claim, keep the local parser

### DIFF
--- a/skills/fluffyjaws/scripts/fj.jsh
+++ b/skills/fluffyjaws/scripts/fj.jsh
@@ -275,10 +275,11 @@ async function api(method, path, body) {
 }
 
 // ---------- arg parsing ----------
-// process.argv.parseFlags() does not exist in the jsh runtime — kept the
-// script's own parseArgs(), which already handled the boolean-flag/value
-// distinction this CLI needs (and which parseFlags() doesn't model, since it
-// has no notion of a fixed boolean-flag allowlist).
+// Deliberately NOT process.argv.parseFlags(): the runtime helper exists, but
+// it has no notion of a fixed boolean-flag allowlist — it would consume the
+// token after a boolean flag as its value (e.g. `--raw <question>` eats the
+// question). The local parseArgs() keeps the boolean-flag/value distinction
+// this CLI needs via BOOLEAN_FLAGS below.
 
 const BOOLEAN_FLAGS = new Set([
   'no-search', 'no-canvas', 'raw', 'json', 'help',


### PR DESCRIPTION
## Summary

Comment-only fix in `fj.jsh`, part of the fossil sweep from the CLAUDE.md work (#218). The arg-parsing comment claimed `process.argv.parseFlags()` "does not exist in the jsh runtime" — it does (slicc `js-realm-helpers.ts:34,92`); it was only briefly unavailable during the bare-globals migration window.

Unlike strava (#219) and github (#220), the local parser here is **deliberately kept**: `parseArgs()` has a `BOOLEAN_FLAGS` allowlist the runtime helper doesn't model — the runtime parser would consume the token after a boolean flag as its value (e.g. `--raw <question>` eats the question). The comment now states that rationale without the false runtime claim.

## Verification

- Comment-only diff; `parseArgs()` and `BOOLEAN_FLAGS` untouched, zero behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LuEhZuA9v2PsdXuiDVvrS