### PR TITLE
ci: Biome lint for .jsh skills + shell-injection hardening (supersedes #222)

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -1,0 +1,31 @@
+name: Lint (Biome)
+
+# Lints the repo's .jsh/.bsh skill scripts with Biome. Biome's CLI ignores the
+# .jsh/.bsh extensions in file mode, so tools/lint-jsh.sh mirrors each script to
+# a temporary .js file and lints those against biome.json. Complements the
+# Tessl skill-lint workflows, which validate skill *content* rather than JS.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  biome:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Biome
+        run: npm install
+
+      - name: Lint .jsh/.bsh skills
+        run: npm run lint:jsh

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .yolo/
 skills/concur/.session.json
 skills/oryx/.config
+node_modules/

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+  "files": {
+    "includes": [
+      "**/*.js",
+      "**/*.mjs",
+      "**/*.cjs",
+      "**/*.json",
+      "**/*.jsonc",
+      "!**/node_modules/**"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100,
+    "lineEnding": "lf"
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always",
+      "trailingCommas": "es5",
+      "arrowParentheses": "always"
+    },
+    "globals": [
+      "exec",
+      "fs",
+      "fetch",
+      "process",
+      "console",
+      "require",
+      "module",
+      "URLSearchParams",
+      "TextEncoder",
+      "TextDecoder",
+      "Buffer",
+      "setTimeout",
+      "clearTimeout",
+      "setInterval",
+      "clearInterval",
+      "btoa",
+      "atob",
+      "crypto",
+      "browser",
+      "structuredClone"
+    ]
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noInnerDeclarations": "off"
+      },
+      "style": {
+        "useTemplate": "off",
+        "useNodejsImportProtocol": "off"
+      },
+      "complexity": {
+        "useOptionalChain": "off",
+        "useArrowFunction": "off",
+        "useLiteralKeys": "off"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "skills-repo",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Root tooling for the skills repo (Biome lint/format, aligned with SLICC).",
+  "license": "Apache-2.0",
+  "scripts": {
+    "format": "biome format --write",
+    "lint:jsh": "bash tools/lint-jsh.sh",
+    "check": "biome check"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.4.16"
+  }
+}

--- a/skills/concur/scripts/concur.jsh
+++ b/skills/concur/scripts/concur.jsh
@@ -7,6 +7,12 @@
 
 const exec = require('sliccy:exec');
 const browser = require('sliccy:browser');
+// Single POSIX-shell-quote a value for safe interpolation into an exec()
+// command line (exec runs through the jsh shell bridge).
+function escapeShellArg(value) {
+  return "'" + String(value).replace(/'/g, "'\\''") + "'";
+}
+
 
 const HOME_URL   = 'https://us2.concursolutions.com/home';
 const HOST_WEB   = 'https://us2.concursolutions.com';
@@ -61,7 +67,7 @@ async function getUserId() {
 }
 
 async function readFile(p) {
-  const r = await exec(`cat "${p}"`);
+  const r = await exec(`cat ${escapeShellArg(p)}`);
   if (r.exitCode !== 0) throw new Error(`read failed: ${p}`);
   return r.stdout;
 }
@@ -74,11 +80,11 @@ async function writeFile(p, s) {
   // can still see it if the caller later moves it under /shared.
   const tmp = `/shared/.concur-write-${Date.now()}.tmp`;
   if (s.length < 600_000) {
-    await exec(`cat > "${tmp}" <<'____CONCUR_EOF____'\n${s}\n____CONCUR_EOF____`);
+    await exec(`cat > ${escapeShellArg(tmp)} <<'____CONCUR_EOF____'\n${s}\n____CONCUR_EOF____`);
   } else {
     // Chunk-stream via base64 so the shell never sees the raw payload as argv.
     const chunkSize = 400_000; // ~400 KB raw → ~540 KB base64 per chunk
-    await exec(`: > "${tmp}"`);
+    await exec(`: > ${escapeShellArg(tmp)}`);
     // Build the base64 string in small sub-chunks to avoid spreading a huge
     // typed-array into String.fromCharCode (which hits arg-limit / is slow).
     const encoder = new TextEncoder();
@@ -92,11 +98,11 @@ async function writeFile(p, s) {
       }
       const b64 = btoa(bin);
       // Single arg of ~540 KB is safe (well below 1 MB cap).
-      const r = await exec(`printf %s '${b64}' | base64 -d >> "${tmp}"`);
+      const r = await exec(`printf %s ${escapeShellArg(b64)} | base64 -d >> ${escapeShellArg(tmp)}`);
       if (r.exitCode !== 0) throw new Error(`writeFile chunk failed at offset ${i}: ${r.stderr}`);
     }
   }
-  await exec(`mkdir -p "$(dirname "${p}")" && mv "${tmp}" "${p}"`);
+  await exec(`mkdir -p "$(dirname ${escapeShellArg(p)})" && mv ${escapeShellArg(tmp)} ${escapeShellArg(p)}`);
 }
 
 async function loadOp(name) {
@@ -194,7 +200,7 @@ async function resolveLnKey(query) {
   catch (_) {
     // JS-literal fallback: pull LnKey/LocText pairs
     const re = /"?LnKey"?:(\d+)[^}]*?"?LocText"?:"([^"]+)"/g; let mm;
-    while ((mm = re.exec(raw))) recs.push({ LnKey: +mm[1], LocText: mm[2] });
+    for (mm = re.exec(raw); mm; mm = re.exec(raw)) recs.push({ LnKey: +mm[1], LocText: mm[2] });
   }
   if (!recs.length) throw new Error(`No TA location match for "${query}"`);
   // Prefer exact LocText match, else first record.
@@ -935,7 +941,7 @@ const commands = {
     await assertReportMutable(reportId, 'attach receipts');
 
     // Stat the file
-    const stat = await exec(`test -f "${localPath}" && stat -c %s "${localPath}" 2>/dev/null || stat -f %z "${localPath}"`);
+    const stat = await exec(`test -f ${escapeShellArg(localPath)} && stat -c %s ${escapeShellArg(localPath)} 2>/dev/null || stat -f %z ${escapeShellArg(localPath)}`);
     if (stat.exitCode !== 0) { console.error('File not found:', localPath); process.exit(1); }
     const inputBytes = parseInt((stat.stdout || '').trim(), 10) || 0;
 
@@ -950,7 +956,7 @@ const commands = {
       jpgPath = `/shared/.concur-receipt-${Date.now()}.jpg`;
       const dim = needShrink ? '1800x1800>' : '2048x2048>';
       const q   = needShrink ? '75' : '85';
-      const conv = await exec(`magick "${localPath}" -resize '${dim}' -quality ${q} "${jpgPath}"`);
+      const conv = await exec(`magick ${escapeShellArg(localPath)} -resize ${escapeShellArg(dim)} -quality ${escapeShellArg(q)} ${escapeShellArg(jpgPath)}`);
       if (conv.exitCode !== 0) {
         console.error('magick conversion failed:', conv.stderr);
         process.exit(1);
@@ -958,7 +964,7 @@ const commands = {
     }
 
     // Base64 the JPEG to embed as a literal in the evalAsync upload function
-    const b64r = await exec(`base64 < "${jpgPath}" | tr -d '\\n'`);
+    const b64r = await exec(`base64 < ${escapeShellArg(jpgPath)} | tr -d '\\n'`);
     if (b64r.exitCode !== 0) { console.error('base64 failed'); process.exit(1); }
     const b64 = b64r.stdout.trim();
 
@@ -992,11 +998,11 @@ const commands = {
     } catch (e) {
       // Clean up the converted/shrunk temp JPEG before bailing so an upload
       // failure never leaves receipt copies behind in /shared.
-      if (jpgPath !== localPath) await exec(`rm -f "${jpgPath}"`);
+      if (jpgPath !== localPath) await exec(`rm -f ${escapeShellArg(jpgPath)}`);
       console.error('upload failed:', e?.message || e);
       process.exit(1);
     }
-    if (jpgPath !== localPath) await exec(`rm -f "${jpgPath}"`);
+    if (jpgPath !== localPath) await exec(`rm -f ${escapeShellArg(jpgPath)}`);
     if (wrap.status >= 400) {
       console.error(`Upload HTTP ${wrap.status}:`, wrap.body);
       process.exit(1);
@@ -1220,7 +1226,7 @@ const commands = {
   },
 
   async ops() {
-    const r = await exec(`ls ${OPS_DIR}`);
+    const r = await exec(`ls ${escapeShellArg(OPS_DIR)}`);
     const list = r.stdout.split('\n').filter(Boolean).map(s => s.replace(/\.graphql$/, ''));
     return { count: list.length, operations: list };
   },
@@ -1288,8 +1294,10 @@ const commands = {
           if (!seen.has(key)) {
             seen.add(key);
             const rec = { code: o.exceptionCode, isBlocking: !!o.isBlocking, message: o.message };
-            if (o.expenseId) (exById[o.expenseId] = exById[o.expenseId] || []).push(rec);
-            else headerEx.push(rec);
+            if (o.expenseId) {
+              if (!exById[o.expenseId]) exById[o.expenseId] = [];
+              exById[o.expenseId].push(rec);
+            } else headerEx.push(rec);
           }
         }
         for (const k in o) walk(o[k]);

--- a/skills/github/scripts/gh.jsh
+++ b/skills/github/scripts/gh.jsh
@@ -108,6 +108,13 @@ const cli = require('sliccy:cli');
 const fmt = require('sliccy:fmt');
 const color = require('sliccy:color'); // renamed from bare `c` global
 const http = require('sliccy:http');
+
+// Single POSIX-shell-quote a value for safe interpolation into an exec()
+// command line (exec runs through the jsh shell bridge).
+function escapeShellArg(value) {
+  return "'" + String(value).replace(/'/g, "'\\''") + "'";
+}
+
 const exec = require('sliccy:exec');
 const time = require('sliccy:time'); // only used by `monday`
 const fs = require('fs'); // plain node-ish builtin, not a sliccy: module
@@ -316,7 +323,7 @@ async function inferRepo() {
   const top = await exec('git rev-parse --show-toplevel 2>/dev/null');
   if (top.exitCode !== 0 || !top.stdout.trim()) return null;
   const toplevel = top.stdout.trim();
-  const r = await exec(`git -C "${toplevel}" config --get remote.origin.url 2>/dev/null`);
+  const r = await exec(`git -C ${escapeShellArg(toplevel)} config --get remote.origin.url 2>/dev/null`);
   if (r.exitCode !== 0 || !r.stdout.trim()) return null;
   const match = r.stdout.trim().match(/github\.com[:/]([^/\s]+\/[^/\s.]+)/);
   return match ? match[1].replace(/\.git$/, '') : null;
@@ -627,7 +634,7 @@ async function prWatch(args) {
   } catch (e) {
     // Best-effort cleanup of the SLICC-side webhook if the GitHub-side
     // registration failed, so we don't leave an orphaned watcher behind.
-    try { await exec(`webhook delete ${webhookId}`); } catch {}
+    try { await exec(`webhook delete ${escapeShellArg(webhookId)}`); } catch {}
     fail('pr watch', e);
   }
 
@@ -667,7 +674,7 @@ async function prUnwatch(args) {
     catch (e) { cli.warn('pr unwatch: could not remove GitHub-side hook ' + ghHookId + ': ' + (e.body?.message || e.message)); }
   }
 
-  try { await exec(`webhook delete ${webhookId}`); }
+  try { await exec(`webhook delete ${escapeShellArg(webhookId)}`); }
   catch (e) { cli.die('pr unwatch: failed to delete SLICC webhook ' + webhookId + ': ' + e.message); }
 
   console.log(sym('success') + ' Stopped watching PR ' + color.cyan('#' + num) + ' in ' + repo);

--- a/skills/jira/jira.jsh
+++ b/skills/jira/jira.jsh
@@ -105,7 +105,7 @@ async function get(key) {
   if (f.labels?.length) out.push(`  Labels:      ${f.labels.join(', ')}`);
   out.push('', '  Description:');
   if (f.description) {
-    stripWiki(f.description).split('\n').forEach(l => out.push(`    ${l}`));
+    stripWiki(f.description).split('\n').forEach(l => { out.push(`    ${l}`); });
   } else {
     out.push(`    ${c.dim('(none)')}`);
   }
@@ -131,7 +131,7 @@ async function comments(key) {
   console.log(`Comments on ${c.bold(key)} (${items.length}):\n`);
   items.forEach(comment => {
     console.log(`  ${c.dim('[' + fmtDate(comment.created) + ']')} ${c.bold(comment.author?.displayName || 'Unknown')}:`);
-    stripWiki(comment.body).split('\n').slice(0, 20).forEach(l => console.log(`    ${l}`));
+    stripWiki(comment.body).split('\n').slice(0, 20).forEach(l => { console.log(`    ${l}`); });
     console.log('');
   });
 }
@@ -144,7 +144,7 @@ async function components(project) {
   if (!items.length) { console.log(`No components defined for ${project}.`); return; }
   console.log(`Components for ${c.bold(project)} (${items.length}):\n`);
   items.sort((a, b) => a.name.localeCompare(b.name))
-       .forEach(item => console.log(`  ${item.name}${item.description ? c.dim(' — ' + item.description) : ''}`));
+       .forEach(item => { console.log(`  ${item.name}${item.description ? c.dim(' — ' + item.description) : ''}`); });
 }
 
 async function types(project) {
@@ -162,7 +162,7 @@ async function types(project) {
   if (!items.length) { console.log(`No issue types found for ${project}.`); return; }
   console.log(`Issue types for ${c.bold(project)} (${items.length}):\n`);
   items.sort((a, b) => a.name.localeCompare(b.name))
-       .forEach(item => console.log(`  ${item.name}${item.description ? c.dim(' — ' + item.description) : ''}`));
+       .forEach(item => { console.log(`  ${item.name}${item.description ? c.dim(' — ' + item.description) : ''}`); });
 }
 
 async function labels(project) {
@@ -189,12 +189,12 @@ async function labels(project) {
   console.log(`Labels for ${c.bold(project)}:\n`);
   if (projectLabels.size) {
     console.log(c.bold(`  Used in this project (${projectLabels.size}):`));
-    [...projectLabels].sort().forEach(l => console.log(`    ${l}`));
+    [...projectLabels].sort().forEach(l => { console.log(`    ${l}`); });
   }
   const instanceOnly = allLabels.filter(l => !projectLabels.has(l));
   if (instanceOnly.length) {
     console.log(c.dim(`\n  Instance-wide (${instanceOnly.length}):`));
-    instanceOnly.forEach(l => console.log(c.dim(`    ${l}`)));
+    instanceOnly.forEach(l => { console.log(c.dim(`    ${l}`)); });
   }
 }
 
@@ -353,13 +353,13 @@ async function create(flags) {
         console.log('Available components for this project:\n');
         if (suggestions.length) {
           console.log(c.bold('  Likely matches (based on issue content):'));
-          suggestions.forEach((s, i) => console.log(`    ${c.cyan(String(i + 1))}. ${s.name}`));
+          suggestions.forEach((s, i) => { console.log(`    ${c.cyan(String(i + 1))}. ${s.name}`); });
           if (others.length) {
             console.log(c.dim('\n  Other components:'));
-            others.forEach((s, i) => console.log(c.dim(`    ${i + suggestions.length + 1}. ${s.name}`)));
+            others.forEach((s, i) => { console.log(c.dim(`    ${i + suggestions.length + 1}. ${s.name}`)); });
           }
         } else {
-          names.forEach((name, i) => console.log(`    ${c.cyan(String(i + 1))}. ${name}`));
+          names.forEach((name, i) => { console.log(`    ${c.cyan(String(i + 1))}. ${name}`); });
         }
 
         const allOrdered = [...suggestions.map(s => s.name), ...others.map(s => s.name)];
@@ -371,7 +371,7 @@ async function create(flags) {
         // Generic allowed-values prompt for other required fields
         const values = fieldMeta.allowedValues.map(v => v.name ?? v.value ?? v.id);
         console.error(c.yellow(`\nRequired: ${req.name}`));
-        values.forEach((v, i) => console.error(`  ${c.cyan(String(i + 1))}. ${v}`));
+        values.forEach((v, i) => { console.error(`  ${c.cyan(String(i + 1))}. ${v}`); });
         console.error(`\nRe-run with: --field-${req.id} "<value>"`);
         process.exit(1);
 
@@ -440,13 +440,13 @@ async function create(flags) {
       console.log('Labels in use in this project:\n');
       if (suggestions.length) {
         console.log(c.bold('  Likely matches:'));
-        suggestions.forEach((s, i) => console.log(`    ${c.cyan(String(i + 1))}. ${s.name}${s.inProject ? c.dim(' (used in project)') : ''}`));
+        suggestions.forEach((s, i) => { console.log(`    ${c.cyan(String(i + 1))}. ${s.name}${s.inProject ? c.dim(' (used in project)') : ''}`); });
         if (others.length) {
           console.log(c.dim('\n  Other labels:'));
-          others.forEach((s, i) => console.log(c.dim(`    ${i + suggestions.length + 1}. ${s.name}${s.inProject ? ' (used in project)' : ''}`)));
+          others.forEach((s, i) => { console.log(c.dim(`    ${i + suggestions.length + 1}. ${s.name}${s.inProject ? ' (used in project)' : ''}`)); });
         }
       } else {
-        scored.forEach((s, i) => console.log(`    ${c.cyan(String(i + 1))}. ${s.name}${s.inProject ? c.dim(' (used in project)') : ''}`));
+        scored.forEach((s, i) => { console.log(`    ${c.cyan(String(i + 1))}. ${s.name}${s.inProject ? c.dim(' (used in project)') : ''}`); });
       }
 
       console.log(c.dim('\nRe-run with --labels "<name>,<name>" to set labels, or --no-labels to skip.'));

--- a/skills/llm-wiki/wiki.jsh
+++ b/skills/llm-wiki/wiki.jsh
@@ -57,7 +57,7 @@ async function find(name) {
 function wl(c) {
   const r = /\[\[([^\]]+)\]\]/g, ls = [];
   let m;
-  while ((m = r.exec(c)) !== null) {
+  for (m = r.exec(c); m !== null; m = r.exec(c)) {
     const target = m[1].split('|', 1)[0].trim();
     if (target) ls.push(target);
   }

--- a/skills/monday/scripts/monday.jsh
+++ b/skills/monday/scripts/monday.jsh
@@ -15,6 +15,12 @@
 const exec = require('sliccy:exec');
 const fs = require('fs');
 
+// Single POSIX-shell-quote a value for safe interpolation into an exec()
+// command line (exec runs through the jsh shell bridge).
+function escapeShellArg(value) {
+  return "'" + String(value).replace(/'/g, "'\\''") + "'";
+}
+
 // ─── Argument Parsing ────────────────────────────────────────────────────────
 
 const args = process.argv.slice(2); // argv[0]=node, argv[1]=script path, argv[2+]=actual args
@@ -89,7 +95,7 @@ const KNOWN_COMMANDS = ['gh', 'slack', 'teams', 'outlook', 'gmail', 'servicenow'
  */
 async function discoverCommands() {
   const checks = KNOWN_COMMANDS.map(async (cmd) => {
-    const r = await exec(`which ${cmd} 2>/dev/null`);
+    const r = await exec(`which ${escapeShellArg(cmd)} 2>/dev/null`);
     return r.exitCode === 0 ? cmd : null;
   });
   const results = await Promise.all(checks);
@@ -239,7 +245,7 @@ async function rateItem(item) {
   const result = await exec(fullCmd);
 
   // Clean up temp file
-  await exec(`rm -f ${tmpFile}`);
+  await exec(`rm -f ${escapeShellArg(tmpFile)}`);
 
   if (result.exitCode !== 0) {
     console.error(`[monday] WARNING: rating agent failed for item ${item.id}`);

--- a/skills/navan/scripts/navan.jsh
+++ b/skills/navan/scripts/navan.jsh
@@ -251,8 +251,8 @@ async function cmdTrip(args) {
       const f = { bookingId: it.bookingId, bookingUuid: it.bookingUuid, confirmationNumber: it.confirmationNumber, status: it.bookingStatus, price: it.totalPrice, name: it.tripName, legs: [] };
       const dseg = it.departureFlight && it.departureFlight.flight && it.departureFlight.flight.flightSegments || [];
       const rseg = it.returnFlight && it.returnFlight.flight && it.returnFlight.flight.flightSegments || [];
-      dseg.forEach(s => f.legs.push({ dir: 'outbound', ...pickSeg(s) }));
-      rseg.forEach(s => f.legs.push({ dir: 'return', ...pickSeg(s) }));
+      dseg.forEach(s => { f.legs.push({ dir: 'outbound', ...pickSeg(s) }); });
+      rseg.forEach(s => { f.legs.push({ dir: 'return', ...pickSeg(s) }); });
       flights.push(f);
     }
     if (it.hotelRoom || it.hotel) {
@@ -581,7 +581,7 @@ async function cmdBook(args) {
   if (!confirm) {
     console.log('=== BOOKING PREVIEW (not booked) ===');
     console.log(type.toUpperCase() + ' contract ' + contractId);
-    sum.lines.forEach(l => console.log(l));
+    sum.lines.forEach(l => { console.log(l); });
     console.log('  TOTAL: ' + money(sum.total));
     if (c.requiresApproval) console.log('  NOTE: this booking requires approval.');
     console.log('');

--- a/skills/oryx/scripts/oryx.jsh
+++ b/skills/oryx/scripts/oryx.jsh
@@ -60,6 +60,12 @@
 // page-context bridge (tab discovery + localStorage reads).
 const { exec } = require('sliccy:exec');
 const browser = require('sliccy:browser');
+// Single POSIX-shell-quote a value for safe interpolation into an exec()
+// command line (exec runs through the jsh shell bridge).
+function escapeShellArg(value) {
+  return "'" + String(value).replace(/'/g, "'\\''") + "'";
+}
+
 
 const CONFIG_FILE = '/workspace/skills/oryx/.config';
 const ENDPOINT    = 'https://oryx.zsa.io/graphql';
@@ -96,7 +102,7 @@ for (let i = 1; i < rawArgs.length; i++) {
 
 async function loadConfig() {
   try {
-    const r = await exec(`cat ${CONFIG_FILE}`);
+    const r = await exec(`cat ${escapeShellArg(CONFIG_FILE)}`);
     if (r.exitCode === 0 && r.stdout.trim()) return JSON.parse(r.stdout.trim());
   } catch (_) {}
   return {};

--- a/skills/pptx/scripts/pptx-lib.jsh
+++ b/skills/pptx/scripts/pptx-lib.jsh
@@ -3,6 +3,12 @@
 // No dependencies — pure XML + custom ZIP builder
 // ZIP format: https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
 
+// Single POSIX-shell-quote a value for safe interpolation into an exec()
+// command line (exec runs through the jsh shell bridge).
+function escapeShellArg(value) {
+  return "'" + String(value).replace(/'/g, "'\\''") + "'";
+}
+
 // ============================================================
 // ZIP BUILDER (STORE method, binary-safe)
 // ============================================================
@@ -420,9 +426,9 @@ var assemblePptxWithImages = function(slideXmls, images, meta) {
 var writePptx = async function(zipData, outputPath) {
   const b64 = toB64Safe(zipData);
   await fs.writeFile('/tmp/_pptx_export.b64', b64);
-  await exec(`cat /tmp/_pptx_export.b64 | base64 -d > "${outputPath}"`);
+  await exec(`cat /tmp/_pptx_export.b64 | base64 -d > ${escapeShellArg(outputPath)}`);
   await exec('rm -f /tmp/_pptx_export.b64');
-  const verify = await exec(`wc -c "${outputPath}"`);
+  const verify = await exec(`wc -c ${escapeShellArg(outputPath)}`);
   return (verify.stdout || '').trim();
 }
 

--- a/skills/pptx2pdf/scripts/pptx2pdf-lib.jsh
+++ b/skills/pptx2pdf/scripts/pptx2pdf-lib.jsh
@@ -173,7 +173,7 @@ var loadFonts = async function(pdfDoc, lib, typeface, zip) {
     if (urls) {
       try {
         await registerFontkit(pdfDoc);
-        var variants = await Promise.all(urls.map(fetchFontBytes));
+        const variants = await Promise.all(urls.map(fetchFontBytes));
         console.log('Embedded font: ' + typeface);
         return {
           regular:    await pdfDoc.embedFont(variants[0], { subset: true }),

--- a/skills/slack/scripts/slack.jsh
+++ b/skills/slack/scripts/slack.jsh
@@ -8,6 +8,13 @@ const SLACK_DOMAIN = 'app.slack.com';
 // them via the sliccy: virtual-module scheme. `fs` is the VFS bridge.
 const { exec } = require('sliccy:exec');
 const fs = require('fs');
+
+// Single POSIX-shell-quote a value for safe interpolation into an exec()
+// command line (exec runs through the jsh shell bridge).
+function escapeShellArg(value) {
+  return "'" + String(value).replace(/'/g, "'\\''") + "'";
+}
+
 const browser = require('sliccy:browser');
 
 // --- Tab management ---
@@ -687,7 +694,7 @@ const commands = {
       }
       // Clean up old webhook
       if (existing.webhookId) {
-        await exec(`webhook delete ${existing.webhookId}`).catch(() => {});
+        await exec(`webhook delete ${escapeShellArg(existing.webhookId)}`).catch(() => {});
       }
     } catch (e) {
       if (e && e.name === 'NodeExitError') throw e;
@@ -712,7 +719,7 @@ const commands = {
     // pre-migration file) -- the watch feature has never actually worked
     // end-to-end -- fixed here since this PR is the designated
     // security/correctness review pass for this file.
-    const whResult = await exec(`webhook create --scoop ${scoop}`);
+    const whResult = await exec(`webhook create --scoop ${escapeShellArg(scoop)}`);
     if (whResult.exitCode !== 0) {
       console.error('Failed to create webhook:', whResult.stderr);
       process.exit(1);
@@ -746,7 +753,7 @@ const commands = {
       sub = await subscribeWatch(tab, state);
     } catch (e) {
       // Roll back: delete the webhook on subscription failure
-      await exec(`webhook delete ${webhook.id}`).catch(() => {});
+      await exec(`webhook delete ${escapeShellArg(webhook.id)}`).catch(() => {});
       console.error('Failed to register WebSocket observer — watch rolled back:', e.message || e);
       process.exit(1);
     }
@@ -787,7 +794,7 @@ const commands = {
     // closeable handle only at creation time, so a later invocation cannot
     // close a prior subscription by id).
     if (state.webhookId) {
-      await exec(`webhook delete ${state.webhookId}`).catch(() => {});
+      await exec(`webhook delete ${escapeShellArg(state.webhookId)}`).catch(() => {});
     }
 
     // Remove state file

--- a/skills/teams/scripts/teams.jsh
+++ b/skills/teams/scripts/teams.jsh
@@ -18,6 +18,12 @@
 
 const browser = require('sliccy:browser');
 const exec = require('sliccy:exec'); // only for the one-time CDP request-buffer seed (see AUTH note)
+// Single POSIX-shell-quote a value for safe interpolation into an exec()
+// command line (exec runs through the jsh shell bridge).
+function escapeShellArg(value) {
+  return "'" + String(value).replace(/'/g, "'\\''") + "'";
+}
+
 
 const TEAMS_DOMAIN_PRIMARY = 'teams.microsoft.com';
 const TEAMS_DOMAIN_SECONDARY = 'teams.live.com';
@@ -213,7 +219,7 @@ function _formField(body, name) {
 // disk) where it is decoded and stored in a page global.
 async function seedFromBuffer(tab) {
   const tid = _targetId(tab);
-  const r = await exec(`playwright-cli requests --filter="oauth2/v2.0/token" --tab=${tid}`);
+  const r = await exec(`playwright-cli requests --filter="oauth2/v2.0/token" --tab=${escapeShellArg(tid)}`);
   if (r.exitCode !== 0) return false;
   const lines = r.stdout
     .split('\n')
@@ -224,7 +230,7 @@ async function seedFromBuffer(tab) {
   const authMatch = last.match(/https:\/\/[^/]+\/[0-9a-fA-F-]{36}/);
   const authority = authMatch ? authMatch[0] : null;
   if (!authority || !/^\d+$/.test(idx)) return false;
-  const b = await exec(`playwright-cli request-body ${idx} --tab=${tid}`);
+  const b = await exec(`playwright-cli request-body ${escapeShellArg(idx)} --tab=${escapeShellArg(tid)}`);
   if (b.exitCode !== 0) return false;
   const rt = _formField(b.stdout, 'refresh_token');
   const cid = _formField(b.stdout, 'client_id');
@@ -1442,7 +1448,7 @@ function _writeTranscribeState(st) {
 // Create a SLICC webhook routed to <scoop>. Returns { id, url } or null.
 async function createTranscribeWebhook(scoop) {
   _safeName(scoop, '--scoop'); // guard against shell injection via the exec bridge
-  const r = await exec(`webhook create --scoop ${scoop} --name teams-transcribe`);
+  const r = await exec(`webhook create --scoop ${escapeShellArg(scoop)} --name teams-transcribe`);
   if (r.exitCode !== 0) return null;
   const idM = (r.stdout || '').match(/ID:\s*(\S+)/);
   const urlM = (r.stdout || '').match(/URL:\s*(\S+)/);
@@ -1452,7 +1458,7 @@ async function createTranscribeWebhook(scoop) {
 
 async function deleteWebhook(id) {
   if (!id) return;
-  try { await exec(`webhook delete ${id}`); } catch (e) {}
+  try { await exec(`webhook delete ${escapeShellArg(id)}`); } catch (e) {}
 }
 
 // Point the in-page collector at a webhook URL (fired per finalized phrase).
@@ -1550,7 +1556,7 @@ async function takeSnapshot(tab, shotsDir) {
   // validated by _safePath above; quote every expansion as defense-in-depth.
   const script =
     `mkdir -p '${dir}'; tmp='${dir}/.tmp-${ts}.png'; ` +
-    `playwright-cli screenshot --tab=${tid} --filename="$tmp" >/dev/null 2>&1 || { echo SNAP_ERR; exit 0; }; ` +
+    `playwright-cli screenshot --tab=${escapeShellArg(tid)} --filename="$tmp" >/dev/null 2>&1 || { echo SNAP_ERR; exit 0; }; ` +
     `nm=$(md5sum "$tmp" 2>/dev/null | awk '{print $1}'); ` +
     `lm=$(cat '${dir}/.last-md5' 2>/dev/null); ` +
     `if [ -n "$nm" ] && [ "$nm" = "$lm" ]; then rm -f "$tmp"; echo SNAP_UNCHANGED; exit 0; fi; ` +
@@ -1577,7 +1583,7 @@ async function postToMeetingChat(tab, message) {
   // control that shows a DM — we must NOT use it. If we can't reach the
   // "Meeting chat" pane, we abort rather than risk posting to the wrong chat.
   const tid = _targetId(tab);
-  const snap = async () => ((await exec(`playwright-cli snapshot --tab=${tid}`)).stdout || '');
+  const snap = async () => ((await exec(`playwright-cli snapshot --tab=${escapeShellArg(tid)}`)).stdout || '');
   const refOf = (txt, re) => { const m = txt.match(re); return m ? m[1] : null; };
 
   let s = await snap();
@@ -1586,7 +1592,7 @@ async function postToMeetingChat(tab, message) {
   if (!/heading "Meeting chat"/.test(s)) {
     const chatRef = refOf(s, /button "Chat"\s*\[ref=(e\d+)\]/); // EXACT "Chat" = in-call control
     if (!chatRef) return 'no-meeting-chat';
-    await exec(`playwright-cli click ${chatRef} --tab=${tid}`);
+    await exec(`playwright-cli click ${escapeShellArg(chatRef)} --tab=${escapeShellArg(tid)}`);
     await sleep(1800);
     s = await snap();
     if (!/heading "Meeting chat"/.test(s)) return 'no-meeting-chat';
@@ -1596,16 +1602,16 @@ async function postToMeetingChat(tab, message) {
   if (!boxRef) return 'no-input';
 
   const esc = String(message).replace(/'/g, `'\\''`);
-  await exec(`playwright-cli click ${boxRef} --tab=${tid}`);
-  await exec(`playwright-cli type '${esc}' --tab=${tid}`);
+  await exec(`playwright-cli click ${escapeShellArg(boxRef)} --tab=${escapeShellArg(tid)}`);
+  await exec(`playwright-cli type '${esc}' --tab=${escapeShellArg(tid)}`);
   await sleep(400);
 
   // Re-resolve the Send button AFTER typing (it only becomes present/enabled
   // once the box has content), then click it; fall back to Enter.
   const s2 = await snap();
   const sendRef = refOf(s2, /button "Send[^"]*"\s*\[ref=(e\d+)\]/);
-  if (sendRef) await exec(`playwright-cli click ${sendRef} --tab=${tid}`);
-  else await exec(`playwright-cli press Enter --tab=${tid}`);
+  if (sendRef) await exec(`playwright-cli click ${escapeShellArg(sendRef)} --tab=${escapeShellArg(tid)}`);
+  else await exec(`playwright-cli press Enter --tab=${escapeShellArg(tid)}`);
   await sleep(500);
 
   // Confirm: the message now appears as a "Sent …" entry in the chat log.

--- a/tools/lint-jsh.sh
+++ b/tools/lint-jsh.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Lint the repo's `.jsh` / `.bsh` skill scripts with Biome.
+#
+# Biome's CLI recognises files by extension: in file mode it silently ignores
+# `.jsh`/`.bsh`, and in stdin mode it emits no diagnostics. So we mirror each
+# script to a temporary `.js` file and lint those with the repo's biome.json
+# (passed via --config-path). The SLICC biome shim already treats `.jsh`/`.bsh`
+# as JavaScript; once the Biome CLI does too, this reduces to `biome check .`.
+#
+# Exit code is Biome's: non-zero if any error-level diagnostic is found.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+biome="${BIOME:-npx --no-install @biomejs/biome}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+count=0
+while IFS= read -r f; do
+  # mirror path with '/' -> '@' so temp names round-trip back to real paths
+  key="$(printf '%s' "$f" | tr '/' '@')"
+  key="${key%.*}.js"
+  cp "$f" "$tmp/$key"
+  count=$((count + 1))
+done < <(git ls-files '*.jsh' '*.bsh')
+
+if [ "$count" -eq 0 ]; then
+  echo "lint-jsh: no .jsh/.bsh files found"
+  exit 0
+fi
+
+# Lint the mirrors with this repo's config; rewrite temp names back to real paths.
+out="$($biome lint --config-path "$repo_root" "$tmp" 2>&1)"
+code=$?
+printf '%s\n' "$out" | sed -E "s#${tmp}/##g; s#([A-Za-z0-9._@-]+)\.js#\1#g; s#@#/#g"
+
+if [ "$code" -eq 0 ]; then
+  echo "lint-jsh: $count .jsh/.bsh file(s) clean (no error-level diagnostics)"
+fi
+exit "$code"


### PR DESCRIPTION
Supersedes #222 (eslint-plugin-jsh-skills), which is now closed. SLICC standardizes on **Biome**, so the skills repo lints with Biome too — and this hardens the shell-injection sites the earlier audit surfaced.

## Biome (curated ruleset)

`biome.json` enables `recommended` minus the rules that are either idiomatic in `.jsh` command scripts or pure churn on legacy code:
- `noInnerDeclarations` off — functions-in-blocks is the norm here (this alone was **224 of 244** legacy "errors").
- `useTemplate`, `useOptionalChain`, `useArrowFunction`, `useLiteralKeys`, `useNodejsImportProtocol` off — high-volume style/complexity suggestions.

Result: a **green, meaningful gate** (0 errors) instead of a wall of red, with the high-signal correctness rules kept on. Warnings/infos stay visible but non-blocking; the formatter matches SLICC but is not enforced retroactively.

### The `.jsh` wrinkle

Biome's CLI recognises files by extension: it **ignores `.jsh`/`.bsh` in file mode** and emits **no diagnostics in stdin mode**. So `tools/lint-jsh.sh` mirrors each script to a temp `.js` and lints those against `biome.json` via `--config-path`. The SLICC biome shim already treats `.jsh`/`.bsh` as JS; **once the Biome CLI does too (separate slicc PR), this reduces to `biome check .`** and the mirror hack goes away.

CI: `.github/workflows/biome.yml` runs `npm run lint:jsh` on push/PR to `main`.

### Lint-error fixes (the 20 the curated ruleset keeps)

- `useIterableCallbackReturn` × 16 — `forEach` callbacks returning a value (jira, navan) → brace-wrapped.
- `noAssignInExpressions` × 3 — regex-`exec` while-loops → `for`-loops (concur, llm-wiki); one assignment split out of an expression (concur).
- `noRedeclare` × 1 — duplicate `var variants` → block-scoped `const` (pptx2pdf).

## Security hardening — shell-quote every `exec()` interpolation

`exec()` runs through the jsh shell bridge, so unvalidated interpolation is a shell-injection risk. Added a POSIX single-quoting `escapeShellArg()` helper to the 7 skills that build `exec()` commands and routed every unsafe interpolation through it (concur, teams, github, monday, oryx, pptx, slack — ~50 sites).

Left as-is because already safe: sites that already do correct inline single-quote escaping (oryx `curl`/`wc`, teams `message`), and concur's quoted-heredoc body (literal, no expansion).

> This directly addresses the Codex review on #222 ("stop treating `JSON.stringify` as a shell sanitizer") — the fix uses real POSIX shell quoting, not `JSON.stringify`.

## Verification

- Biome (2.4.16): **error count 0 across all 31 `.jsh`** (was 244).
- `node --check` clean on every edited file.

## Follow-ups (not here)

- Separate **slicc PR**: make the Biome shim treat `.jsh`/`.bsh` natively so CI can drop the temp-`.js` mirror.
- Bump Biome to match slicc's pinned 2.5.4 once verified in CI (pinned to the verified 2.4.16 for now).
- Promote more rules from warn → the gate as the skills get cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
