### PR TITLE
feat(gcloud): Google Cloud skill via gcloud CLI OAuth intercept

### DIFF
--- a/skills/gcloud/SKILL.md
+++ b/skills/gcloud/SKILL.md
@@ -66,6 +66,16 @@ Override per-call with `--project <id>` (or `-p`).
 | `gcloud dns records list <zone> [--name N] [--type T]` | List record sets in a zone |
 | `gcloud dns records add <zone> <name> <type> <data>... [--ttl 300] --confirm` | Add/replace a record set |
 | `gcloud dns records remove <zone> <name> <type> --confirm` | Delete a record set |
+| `gcloud dns logging status <zone>` | Show whether query logging is enabled for a zone |
+| `gcloud dns logging enable <zone> --confirm` | Enable Cloud DNS query logging on a zone |
+| `gcloud dns logging disable <zone> --confirm` | Disable query logging on a zone |
+| `gcloud billing accounts list` | Billing accounts you can access |
+| `gcloud billing accounts describe <ACCOUNT_ID>` | Details for one billing account |
+| `gcloud billing accounts get-iam-policy <ACCOUNT_ID>` | IAM bindings on a billing account |
+| `gcloud billing projects list <ACCOUNT_ID>` | Projects linked to a billing account |
+| `gcloud billing projects describe <PROJECT_ID>` | A project's billing link + enabled state |
+| `gcloud billing projects link <PROJECT_ID> --billing-account <ACCOUNT_ID> --confirm` | Link a project to a billing account |
+| `gcloud billing projects unlink <PROJECT_ID> --confirm` | Remove a project's billing link |
 | `gcloud api [METHOD] <full-url> [--data <json>]` | Authenticated raw call to any Google API |
 
 All commands accept `--json` for raw output, and `--project <id>` to override
@@ -105,6 +115,49 @@ targets under `routingPolicy`. `records list` surfaces these — e.g. a weighted
 CNAME prints each item's weight and target (weight `0` is flagged as inactive) —
 so a routed record no longer renders as a blank line. Use `--json` for the raw
 `routingPolicy` structure.
+
+**Query logging.** `gcloud dns logging status <zone>` reports whether a managed
+zone records DNS queries (via the zone's `cloudLoggingConfig.enableLogging`
+flag). `enable`/`disable` toggle it and, like every mutation, require
+`--confirm` — without it they print a preview only. Enabling logging is not
+free: DNS query logs bill through Cloud Logging ingestion at $0.50/GiB after the
+first 50 GiB/project/month (the enable preview repeats this so it isn't a
+surprise).
+
+```bash
+gcloud dns logging status hlx-live
+gcloud dns logging enable hlx-live --confirm
+gcloud dns logging disable hlx-live --confirm
+```
+
+### Cloud Billing
+
+`gcloud billing` mirrors the Cloud Billing API. `accounts list/describe/
+get-iam-policy` and `projects list <ACCOUNT_ID>` operate on billing **account**
+resources and therefore need billing-account-level IAM (e.g. *Billing Account
+Viewer*) — without it `accounts list` returns an empty list (printed as "No
+billing accounts accessible."), which is normal, not an error.
+
+```bash
+gcloud billing accounts list
+gcloud billing accounts describe 002EE3-CC6C9E-B2B150   # prefix optional
+gcloud billing projects list 002EE3-CC6C9E-B2B150       # linked projects
+gcloud billing projects describe my-project-id          # this project's link
+gcloud billing projects link   my-project-id --billing-account 002EE3-CC6C9E-B2B150 --confirm
+gcloud billing projects unlink my-project-id --confirm
+```
+
+`projects describe <PROJECT_ID>` works with ordinary **project-level** access —
+it reads the project's `billingInfo` (billing account name + whether billing is
+enabled). Account IDs may be given with or without the `billingAccounts/`
+prefix; it is normalized either way. `link`/`unlink` mutate billing and are
+`--confirm`-gated with a preview.
+
+Note: this API exposes billing **configuration**, not **cost**. Per-project
+spend (dollar amounts, usage breakdowns) is **not** available here — use the
+BigQuery billing export or the Cloud Console billing reports instead
+(project-scoped cost reports require the `billing.resourceCosts.get`
+permission on the project).
 
 ### Raw API access
 

--- a/skills/gcloud/SKILL.md
+++ b/skills/gcloud/SKILL.md
@@ -154,10 +154,14 @@ prefix; it is normalized either way. `link`/`unlink` mutate billing and are
 `--confirm`-gated with a preview.
 
 Note: this API exposes billing **configuration**, not **cost**. Per-project
-spend (dollar amounts, usage breakdowns) is **not** available here — use the
-BigQuery billing export or the Cloud Console billing reports instead
-(project-scoped cost reports require the `billing.resourceCosts.get`
-permission on the project).
+spend (dollar amounts, usage breakdowns) is **not** available through the public
+Cloud Billing API. The supported programmatic source is the BigQuery billing
+export (needs the export enabled + BigQuery read access). Alternatively, for
+cost **and usage** without any billing-account IAM, see
+[`gcloud-ext billing cost`](#gcloud-ext-slicc-only-cost-and-usage-reports) below,
+which replays the Cloud Console's own report API from a logged-in browser
+session (project-level `billing.resourceCosts.get` is sufficient — the same
+permission the Console UI uses).
 
 ### Raw API access
 
@@ -169,6 +173,48 @@ gcloud api GET  "https://cloudresourcemanager.googleapis.com/v1/projects/my-proj
 gcloud api POST "https://compute.googleapis.com/compute/v1/projects/P/zones/Z/instances/I/start"
 gcloud api PATCH "https://.../resource" --data '{"field":"value"}'
 ```
+
+## gcloud-ext: SLICC-only cost and usage reports
+
+The real `gcloud` CLI has no command for cost/usage reports (Google offers them
+only via the Cloud Console UI or a BigQuery billing export). To keep `gcloud`
+command-compatible with the upstream tool, that capability lives in a separate
+binary, **`gcloud-ext`** (`scripts/gcloud-ext.jsh`).
+
+```bash
+gcloud-ext billing cost --project helix-225321
+gcloud-ext billing cost --project helix-225321 --group-by sku
+gcloud-ext billing cost --project P --group-by sku --from 2026-07-01 --to 2026-07-26 --json
+```
+
+`billing cost` reports per-service or per-SKU **cost and usage** for a project
+over a date range (defaults to the current month). With `--group-by sku` it
+includes the usage amount per SKU — e.g. actual DNS query counts:
+
+```
+Networking Cloud DNS Routing Policy Query   $2473.35  net $1978.68  6066731525 count
+DNS Query (port 53)                          $171.85  net $137.48    429635772 count
+```
+
+**How it works / requirements.** Google exposes cost data only through the
+Console's private first-party API (`cloudconsole-pa.clients6.google.com`),
+authenticated with a session `SAPISIDHASH` rather than an OAuth Bearer token.
+`gcloud-ext` therefore runs the request **inside a logged-in
+`console.cloud.google.com` browser tab** (via the `sliccy:browser` bridge),
+signing it with the session cookie. Requirements:
+
+- An open, signed-in GCP Console tab (any page under `console.cloud.google.com`).
+- Project-level **`billing.resourceCosts.get`** (what the Console UI itself
+  uses) — **no** billing-account IAM and **no** BigQuery export required.
+
+The billing account is resolved automatically from the project (override with
+`--billing-account ID`). Use `--json` for machine-readable output.
+
+> This relies on a **private, undocumented** Console API. Google may change the
+> query signature, API key, or schema without notice. If `billing cost` breaks,
+> re-capture the `BillingReportsEntityService … BillingData` request from
+> Billing → Reports in the Console and update the constants at the top of
+> `scripts/gcloud-ext.jsh`.
 
 ## How authentication works
 

--- a/skills/gcloud/SKILL.md
+++ b/skills/gcloud/SKILL.md
@@ -99,6 +99,13 @@ values are auto-quoted. `add` is an upsert — it replaces an existing record se
 of the same name+type in one transactional change (Cloud DNS requires
 delete-then-add), so you don't have to remove first.
 
+Records that use a **routing policy** (weighted round-robin, geo-location, or
+primary/backup failover) carry an empty top-level `rrdatas` and stash their real
+targets under `routingPolicy`. `records list` surfaces these — e.g. a weighted
+CNAME prints each item's weight and target (weight `0` is flagged as inactive) —
+so a routed record no longer renders as a blank line. Use `--json` for the raw
+`routingPolicy` structure.
+
 ### Raw API access
 
 For anything not wrapped above, `gcloud api` attaches a valid Bearer token to a

--- a/skills/gcloud/SKILL.md
+++ b/skills/gcloud/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: gcloud
+description: Interact with Google Cloud Platform from the command line via the `gcloud` CLI — list projects, Compute Engine instances and zones, Cloud Storage buckets, enabled services (APIs), and Cloud Run services, or make authenticated raw calls to any Google Cloud REST API. Authenticates by reusing the Google Cloud SDK's own public OAuth client through `oauth-token --intercept`, so a human completes the standard Google consent screen once and tokens auto-refresh thereafter — no service account key or pre-provisioned secret needed. Use whenever the user mentions Google Cloud, GCP, gcloud, Compute Engine, GCE, Cloud Storage, GCS buckets, Cloud Run, Google Cloud projects, enabled APIs/services, or wants to query or automate anything on Google Cloud without clicking through the Cloud Console. Activate on "gcloud", "google cloud", "GCP", "compute engine", "gcs bucket", "cloud run", "my gcp projects", "list instances", or related Google Cloud workflows.
+allowed-tools: bash
+command: gcloud
+script: scripts/gcloud.jsh
+---
+
+# Google Cloud (gcloud) Skill
+
+A `.jsh` CLI implementing a useful subset of the Google Cloud REST APIs. It
+authenticates the same way the real `gcloud` CLI does — by driving Google's
+OAuth authorization-code flow against the **Cloud SDK's own public OAuth
+client** — but the interactive browser step is handled by SLICC's
+`oauth-token --intercept`.
+
+## Step 1: Log in (once)
+
+```bash
+gcloud login
+```
+
+This opens a browser tab at Google's consent screen. A human signs in and
+approves the requested scopes (`cloud-platform`, `userinfo.email`, `openid`).
+`oauth-token --intercept` captures the loopback redirect
+(`http://127.0.0.1:8085/?code=…`), the script exchanges the authorization code
+for tokens, and stores the **refresh token** in the skill config. Access tokens
+are minted on demand and auto-refresh — you only re-run `gcloud login` if the
+refresh token is revoked.
+
+Verify:
+
+```bash
+gcloud whoami
+```
+
+## Step 2: Set a default project
+
+Most calls need a project. Set one so you don't pass `--project` every time:
+
+```bash
+gcloud config set-project my-project-id
+gcloud config              # show active config
+```
+
+Override per-call with `--project <id>` (or `-p`).
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `gcloud login` | Google consent → store refresh token |
+| `gcloud whoami` | Show authenticated identity + active project |
+| `gcloud logout` | Revoke and clear stored tokens |
+| `gcloud config` | Show active config |
+| `gcloud config set-project <id>` | Set default project |
+| `gcloud projects list` | Projects you can access (Cloud Resource Manager) |
+| `gcloud instances list [--zone Z]` | Compute Engine instances (aggregated across zones) |
+| `gcloud zones list` | Compute Engine zones |
+| `gcloud buckets list` | Cloud Storage buckets |
+| `gcloud services list` | Enabled APIs (Service Usage) |
+| `gcloud services enable <api.googleapis.com> --confirm` | Enable an API on the project |
+| `gcloud run list [--region R]` | Cloud Run services (`R` defaults to all) |
+| `gcloud dns zones list` | Managed DNS zones |
+| `gcloud dns zones create <name> --dns-name <domain.> --confirm` | Create a managed zone |
+| `gcloud dns records list <zone> [--name N] [--type T]` | List record sets in a zone |
+| `gcloud dns records add <zone> <name> <type> <data>... [--ttl 300] --confirm` | Add/replace a record set |
+| `gcloud dns records remove <zone> <name> <type> --confirm` | Delete a record set |
+| `gcloud api [METHOD] <full-url> [--data <json>]` | Authenticated raw call to any Google API |
+
+All commands accept `--json` for raw output, and `--project <id>` to override
+the active project. The gcloud-style two-word forms also work
+(`gcloud compute instances list`, `gcloud auth login`, `gcloud auth status`).
+
+**Flag values must use long flags** (`--project X`, `--zone X`, `--region X`,
+`--type X`): the runtime's flag parser treats single-dash short flags as
+booleans and never captures a following value, so short aliases are not
+offered.
+
+### Cloud DNS
+
+Cloud DNS is the primary use case. Managed zones and record sets are read
+freely; all **mutations require `--confirm`** and print a colored diff preview
+otherwise:
+
+```bash
+gcloud services enable dns.googleapis.com --confirm     # if not already enabled
+gcloud dns zones list
+gcloud dns records list my-zone --type A
+# add or replace (upsert): looks up any existing rrset of the same name+type
+# and swaps it in a single atomic change
+gcloud dns records add my-zone www.example.com A 203.0.113.10 --ttl 300 --confirm
+gcloud dns records add my-zone example.com TXT "v=spf1 include:_spf.google.com ~all" --confirm
+gcloud dns records remove my-zone old.example.com CNAME --confirm
+```
+
+Names are normalized to FQDNs (a trailing dot is appended if missing), and TXT
+values are auto-quoted. `add` is an upsert — it replaces an existing record set
+of the same name+type in one transactional change (Cloud DNS requires
+delete-then-add), so you don't have to remove first.
+
+### Raw API access
+
+For anything not wrapped above, `gcloud api` attaches a valid Bearer token to a
+request against any Google Cloud REST endpoint:
+
+```bash
+gcloud api GET  "https://cloudresourcemanager.googleapis.com/v1/projects/my-project-id"
+gcloud api POST "https://compute.googleapis.com/compute/v1/projects/P/zones/Z/instances/I/start"
+gcloud api PATCH "https://.../resource" --data '{"field":"value"}'
+```
+
+## How authentication works
+
+The Google Cloud SDK ships a **public "desktop app" OAuth client** — its client
+id and secret are compiled into the gcloud source
+(`CLOUDSDK_CLIENT_ID` = `32555940559.apps.googleusercontent.com`,
+`CLOUDSDK_CLIENT_NOTSOSECRET`). Desktop clients are non-confidential by design:
+Google protects them with loopback redirect-URI matching, not by keeping the
+"secret" secret. This skill reuses that client so that completing the normal
+Google consent screen yields a real `cloud-platform`-scoped token — exactly the
+credential `gcloud auth login` produces — without registering a new OAuth app or
+provisioning a service account key.
+
+- Authorize endpoint: `https://accounts.google.com/o/oauth2/auth`
+- Token endpoint: `https://oauth2.googleapis.com/token`
+- Redirect: `http://127.0.0.1:8085/` (loopback; captured by `oauth-token --intercept`)
+- Scopes: `openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/cloud-platform`
+
+If Google ever rotates the Cloud SDK client credentials, update the `CLIENT_ID`
+/ `CLIENT_SECRET` constants at the top of `scripts/gcloud.jsh` from the current
+gcloud source.
+
+### Security notes
+
+- The authorization-code flow here does **not** use PKCE (SLICC's intercept
+  mode can't inject an authorize-side `code_challenge`). The captured `code` is
+  handled entirely inside the script and exchanged immediately — it is never
+  printed to stdout — which keeps the exposure window minimal. See the gmail
+  skill's `references/oauth-bootstrap.md` for the fuller discussion of this
+  trade-off for public clients.
+- Tokens live in the skill config, not in stdout. `gcloud logout` revokes the
+  refresh token at Google and clears local state.
+- The consent screen will show "Google Cloud SDK" as the requesting app,
+  because that is the client being reused.

--- a/skills/gcloud/SKILL.md
+++ b/skills/gcloud/SKILL.md
@@ -65,6 +65,7 @@ Override per-call with `--project <id>` (or `-p`).
 | `gcloud dns zones create <name> --dns-name <domain.> --confirm` | Create a managed zone |
 | `gcloud dns records list <zone> [--name N] [--type T]` | List record sets in a zone |
 | `gcloud dns records add <zone> <name> <type> <data>... [--ttl 300] --confirm` | Add/replace a record set |
+| `gcloud dns records add <zone> <name> <type> --routing-policy wrr --routing-policy-data "W:rrdata;W:rrdata" --confirm` | Add/replace a weighted round-robin record set |
 | `gcloud dns records remove <zone> <name> <type> --confirm` | Delete a record set |
 | `gcloud dns logging status <zone>` | Show whether query logging is enabled for a zone |
 | `gcloud dns logging enable <zone> --confirm` | Enable Cloud DNS query logging on a zone |
@@ -114,7 +115,28 @@ primary/backup failover) carry an empty top-level `rrdatas` and stash their real
 targets under `routingPolicy`. `records list` surfaces these — e.g. a weighted
 CNAME prints each item's weight and target (weight `0` is flagged as inactive) —
 so a routed record no longer renders as a blank line. Use `--json` for the raw
-`routingPolicy` structure.
+`routingPolicy` structure. The `--confirm` **change preview** also renders the
+routing policy of both the record being deleted and the one being added, so
+flattening or restoring a weighted record shows exactly what changes.
+
+**Weighted round-robin (WRR) records.** `records add` can create a weighted
+record, not just a plain one — pass `--routing-policy wrr` with
+`--routing-policy-data "WEIGHT:rrdata[,rrdata];WEIGHT:rrdata…"` (`;` separates
+weighted groups, `,` separates rrdatas sharing a weight):
+
+```bash
+# Flatten a mostly-inactive WRR wildcard to a fixed CNAME (cheaper: plain queries
+# bill as "DNS Query" $0.40/M vs "Routing Policy Query" $0.70/M):
+gcloud dns records add my-zone '*.example.com.' CNAME target.example.net. --ttl 300 --confirm
+
+# Reconstruct the weighted policy (rollback), e.g. 100% weight to one target:
+gcloud dns records add my-zone '*.example.com.' CNAME --routing-policy wrr \
+       --routing-policy-data "0:backup.example.net.;1:primary.example.net." --ttl 300 --confirm
+```
+
+Because `add` is an upsert that deletes the existing rrset (routing policy and
+all) before adding the new one, the same command flattens WRR→plain **and**
+restores plain→WRR — the conversion is fully reversible with the skill.
 
 **Query logging.** `gcloud dns logging status <zone>` reports whether a managed
 zone records DNS queries (via the zone's `cloudLoggingConfig.enableLogging`

--- a/skills/gcloud/scripts/gcloud-ext.jsh
+++ b/skills/gcloud/scripts/gcloud-ext.jsh
@@ -1,0 +1,302 @@
+// gcloud-ext.jsh — SLICC-only extensions to the `gcloud` skill that are NOT part
+// of the real gcloud CLI, so `gcloud` itself stays command-compatible with the
+// upstream tool. Kept in a separate binary (`gcloud-ext`) for that reason.
+//
+// billing cost — per-service / per-SKU cost AND usage (e.g. DNS query counts)
+// for a project, over a date range. Google exposes cost/usage reports ONLY
+// through the Cloud Console (there is no public REST endpoint), so this command
+// replays the Console's own private first-party GraphQL API
+// (cloudconsole-pa.clients6.google.com … BillingReportsEntityService) from
+// inside your logged-in console.cloud.google.com browser tab, signing the call
+// with a session-derived SAPISIDHASH. It therefore needs an open, logged-in GCP
+// console tab and only project-level `billing.resourceCosts.get` (the same
+// permission the Console UI uses) — no billing-account IAM, no BigQuery export.
+//
+// Caveat: this is a private, undocumented API. Google may change the query
+// signature, API key, or schema without notice; if this breaks, re-capture the
+// request from the console (Billing → Reports) and update the constants below.
+
+const cli     = require('sliccy:cli');
+const skill   = require('sliccy:skill');
+const exec    = require('sliccy:exec');
+const c       = require('sliccy:color');
+const browser = require('sliccy:browser');
+
+// ─── Reverse-engineered Console billing-report API (may rotate) ───────────────
+const GQL_URL =
+  'https://cloudconsole-pa.clients6.google.com/v3/entityServices/' +
+  'BillingReportsEntityService/schemas/BILLING_REPORTS_GRAPHQL:batchGraphql' +
+  '?key=AIzaSyCI-zsRP85UVOi0DjtiCwWBwQ1djDy741g&prettyPrint=false';
+const GQL_SIGNATURE = '2/P3x4vaA9WY+xnwes1nLVFEjcmjlRDAC3DdoMSRWBi4w=';
+const GQL_OPERATION = 'BillingData';
+const COST_VIEW     = 'cloud_billing_data.public.costs.v2';
+
+function str(v) { return typeof v === 'string' ? v : undefined; }
+
+async function loadConfig() { return (await skill.config()) || {}; }
+
+// YYYY-MM-DD helpers (UTC, no Date-math surprises).
+function ymd(d) { return d.toISOString().slice(0, 10); }
+function addDays(iso, n) {
+  const d = new Date(iso + 'T00:00:00Z');
+  d.setUTCDate(d.getUTCDate() + n);
+  return ymd(d);
+}
+function firstOfMonth(iso) { return iso.slice(0, 8) + '01'; }
+
+/** Resolve the project's billing account via the public API (works with
+ *  project-level access) by shelling out to the sibling `gcloud` command. */
+async function resolveBillingAccount(project) {
+  const { stdout, exitCode } = await exec.spawn([
+    'gcloud', 'billing', 'projects', 'describe', project, '--json',
+  ]);
+  if (exitCode !== 0) return undefined;
+  try {
+    const j = JSON.parse(stdout);
+    return j.billingAccountName || undefined; // "billingAccounts/XXXX-…"
+  } catch { return undefined; }
+}
+
+async function findConsoleTab() {
+  const tab = await browser.findTab({ urlMatch: /console\.cloud\.google\.com/ });
+  if (!tab) {
+    cli.die(
+      'No logged-in GCP console tab found.\n' +
+      'Open https://console.cloud.google.com (signed in) and retry.',
+      { prefix: 'gcloud-ext' },
+    );
+  }
+  return tab;
+}
+
+// Column sets per grouping dimension.
+function columnsFor(groupBy) {
+  if (groupBy === 'sku') {
+    return {
+      dimension: 'SKU',
+      columns:
+        'sku_id AS skuId, sku_display_name AS name, service_display_name AS serviceName, ' +
+        'usage_cost AS usageCostMicros, subtotal AS subtotalMicros, ' +
+        'usage AS usageAmount, usage_with_unit AS usageWithUnit, price_unit AS priceUnit',
+      hasUsage: true,
+    };
+  }
+  return {
+    dimension: 'SERVICE',
+    columns:
+      'service_id AS serviceId, service_display_name AS name, ' +
+      'usage_cost AS usageCostMicros, subtotal AS subtotalMicros',
+    hasUsage: false,
+  };
+}
+
+async function cmdBillingCost(flags) {
+  const cfg = await loadConfig();
+  const project = str(flags.project) || cfg.project;
+  if (!project) {
+    cli.die('No project set. Pass --project <id> or set one via: gcloud config set-project <id>',
+      { prefix: 'gcloud-ext' });
+  }
+
+  const groupBy = (str(flags['group-by']) || 'service').toLowerCase();
+  if (groupBy !== 'service' && groupBy !== 'sku') {
+    cli.die('--group-by must be "service" or "sku".', { prefix: 'gcloud-ext' });
+  }
+
+  // Date range: default = start of current month → today.
+  const today = ymd(new Date());
+  const to    = str(flags.to)   || today;
+  const from  = str(flags.from) || firstOfMonth(to);
+  if (from > to) cli.die('--from must not be after --to.', { prefix: 'gcloud-ext' });
+  // Previous comparison window of equal length, immediately preceding `from`.
+  const spanDays = Math.round((new Date(to + 'T00:00:00Z') - new Date(from + 'T00:00:00Z')) / 86400000);
+  const prevEnd   = addDays(from, -1);
+  const prevStart = addDays(prevEnd, -spanDays);
+
+  let billingAccount = str(flags['billing-account']);
+  if (billingAccount && !billingAccount.startsWith('billingAccounts/')) {
+    billingAccount = 'billingAccounts/' + billingAccount;
+  }
+  if (!billingAccount) {
+    billingAccount = await resolveBillingAccount(project);
+    if (!billingAccount) {
+      cli.die(
+        `Could not resolve the billing account for ${project}.\n` +
+        'Pass it explicitly with --billing-account <ID>.',
+        { prefix: 'gcloud-ext' },
+      );
+    }
+  }
+
+  const col = columnsFor(groupBy);
+  const variables = {
+    request: {
+      view: COST_VIEW,
+      clientQueryId: 'gcloud_ext_billing_cost',
+      parents: [{ billingAccount, resource: `projects/${project}` }],
+      columns: col.columns,
+      groupBy: 'all',
+      filter: '(usage_cost != 0 OR subtotal != 0)',
+      substitutions: [
+        { target: 'FILTERING_TIME_COLUMN', stringId: 'usage_date' },
+        { target: 'GROUPING_TIME_COLUMN', stringId: 'usage_date' },
+      ],
+      parameters: [
+        { name: 'CURRENT_START', stringValue: from },
+        { name: 'CURRENT_END', stringValue: to },
+        { name: 'DIMENSIONS', stringArrayValue: { stringElements: [col.dimension] } },
+        { name: 'PREVIOUS_START', stringValue: prevStart },
+        { name: 'PREVIOUS_END', stringValue: prevEnd },
+        { name: 'PROJECT_NUMBERS_OR_IDS', stringArrayValue: { stringElements: [project] } },
+        { name: 'COST_TYPES', stringArrayValue: { stringElements: ['USAGE'] } },
+        { name: 'LIMIT_TO_TOP', int64Value: '0' },
+        { name: 'CREDIT_TYPES', stringArrayValue: { stringElements: [] } },
+        { name: 'EXCLUDE_NEGOTIATED_SAVINGS', boolValue: false },
+      ],
+      pageSize: 5000,
+      skip: 0,
+      orderBy: 'usageCostMicros DESC',
+    },
+  };
+  const gqlBody = JSON.stringify({
+    requestContext: { platformMetadata: { platformType: 'RIF' } },
+    querySignature: GQL_SIGNATURE,
+    operationName: GQL_OPERATION,
+    variables,
+  });
+
+  const tab = await findConsoleTab();
+
+  // Build the in-page function source with data injected (evalAsync runs it in
+  // the console origin, so document.cookie has SAPISID and the request is
+  // same-session; SAPISIDHASH is computed here, exactly as the console does).
+  const evalSrc = `
+    (async () => {
+      const sapisid = (document.cookie.match(/SAPISID=([^;]+)/) || [])[1];
+      if (!sapisid) return { error: 'No SAPISID cookie — is this tab logged into console.cloud.google.com?' };
+      const au = (location.search.match(/authuser=(\\d+)/) || [])[1] || '0';
+      const ts = Math.floor(Date.now() / 1000);
+      const digest = await crypto.subtle.digest('SHA-1', new TextEncoder().encode(ts + ' ' + sapisid + ' https://console.cloud.google.com'));
+      const hash = ts + '_' + Array.from(new Uint8Array(digest)).map(x => x.toString(16).padStart(2, '0')).join('');
+      const res = await fetch(${JSON.stringify(GQL_URL)}, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json', 'Authorization': 'SAPISIDHASH ' + hash, 'X-Goog-AuthUser': au },
+        body: ${JSON.stringify(gqlBody)},
+      });
+      const text = await res.text();
+      return { status: res.status, text };
+    })()
+  `;
+
+  let out;
+  try {
+    out = await browser.evalAsync(tab, evalSrc);
+  } catch (e) {
+    cli.die(`In-page billing request failed: ${e.message}`, { prefix: 'gcloud-ext' });
+  }
+  if (out && out.error) cli.die(out.error, { prefix: 'gcloud-ext' });
+  if (!out || out.status !== 200) {
+    cli.die(`Console billing API returned ${out ? out.status : 'no response'}.`, { prefix: 'gcloud-ext' });
+  }
+
+  let parsed;
+  try { parsed = typeof out.text === 'string' ? JSON.parse(out.text) : out.text; }
+  catch { cli.die('Could not parse billing API response.', { prefix: 'gcloud-ext' }); }
+
+  const result = parsed?.[0]?.results?.[0];
+  if (result?.errors?.length) {
+    cli.die(`Billing API error: ${result.errors[0].message}`, { prefix: 'gcloud-ext' });
+  }
+  const bd = result?.data?.billingDataQuery?.queryBillingData?.billingData;
+  if (!bd) cli.die('No billing data returned (check the date range and project).', { prefix: 'gcloud-ext' });
+
+  const cols = (bd.columnInfo || []).map(x => x.column);
+  const firstVal = v => { for (const k in v) if (v[k] !== null) return v[k]; return null; };
+  const rows = (bd.rows || []).map(r => {
+    const o = {};
+    r.values.forEach((v, i) => { o[cols[i]] = firstVal(v); });
+    return o;
+  });
+
+  const usd = micros => Number(micros || 0) / 1e6;
+
+  if (flags.json) {
+    cli.out({
+      project, billingAccount, groupBy, from, to,
+      rows: rows.map(r => ({
+        name: r.name,
+        serviceName: r.serviceName,
+        skuId: r.skuId,
+        serviceId: r.serviceId,
+        usageCostUSD: usd(r.usageCostMicros),
+        subtotalUSD: usd(r.subtotalMicros),
+        usageAmount: r.usageAmount,
+        usageWithUnit: r.usageWithUnit,
+        priceUnit: r.priceUnit,
+      })),
+    });
+    return;
+  }
+
+  console.log('');
+  console.log(`  ${c.dim(project)}  ${c.dim(from + ' → ' + to)}  ${c.dim('grouped by ' + groupBy)}`);
+  console.log('');
+  let totalGross = 0, totalNet = 0;
+  for (const r of rows) {
+    totalGross += usd(r.usageCostMicros);
+    totalNet   += usd(r.subtotalMicros);
+    const gross = '$' + usd(r.usageCostMicros).toFixed(2);
+    const net   = '$' + usd(r.subtotalMicros).toFixed(2);
+    const svc   = col.hasUsage && r.serviceName ? c.dim(' [' + r.serviceName + ']') : '';
+    const usage = col.hasUsage && (r.usageWithUnit || r.usageAmount)
+      ? '  ' + c.cyan(r.usageWithUnit || String(r.usageAmount))
+      : '';
+    console.log(`  ${c.bold((r.name || '(unknown)').padEnd(42))} ${gross.padStart(12)} ${c.dim('net ' + net)}${svc}${usage}`);
+  }
+  console.log('');
+  console.log(`  ${c.bold('TOTAL'.padEnd(42))} ${('$' + totalGross.toFixed(2)).padStart(12)} ${c.dim('net $' + totalNet.toFixed(2))}`);
+}
+
+// ─── args + main ─────────────────────────────────────────────────────────────
+
+const HELP = `
+gcloud-ext — SLICC-only extensions to the gcloud skill (not part of real gcloud).
+
+USAGE
+  gcloud-ext billing cost [--project P] [--group-by service|sku]
+                          [--from YYYY-MM-DD] [--to YYYY-MM-DD]
+                          [--billing-account ID] [--json]
+
+  Per-service or per-SKU cost AND usage for a project over a date range,
+  including usage counts (e.g. DNS query volume) when --group-by sku.
+
+  Requires an open, logged-in console.cloud.google.com browser tab. It replays
+  the Cloud Console's private billing-report API from that session (project-level
+  billing.resourceCosts.get is enough — no billing-account IAM). Defaults to the
+  current month if no dates are given.
+
+EXAMPLES
+  gcloud-ext billing cost --project helix-225321
+  gcloud-ext billing cost --project helix-225321 --group-by sku
+  gcloud-ext billing cost --project helix-225321 --group-by sku --from 2026-07-01 --to 2026-07-26 --json
+`.trim();
+
+const parsed     = process.argv.parseFlags();
+const subcommand = parsed.subcommand || '';
+const positional = parsed.positional.slice(1);
+const flags      = parsed.flags;
+
+async function main() {
+  if (flags.help || flags.h || !subcommand || subcommand === 'help') cli.help(HELP);
+  try {
+    if (subcommand === 'billing' && positional[0] === 'cost') return await cmdBillingCost(flags);
+    cli.die(`unknown command: ${subcommand} ${positional[0] || ''}\nRun 'gcloud-ext --help' for usage.`,
+      { prefix: 'gcloud-ext' });
+  } catch (err) {
+    if (err?.name === 'NodeExitError') throw err; // MANDATORY re-throw
+    cli.die(err.message, { prefix: 'gcloud-ext' });
+  }
+}
+
+await main();

--- a/skills/gcloud/scripts/gcloud.jsh
+++ b/skills/gcloud/scripts/gcloud.jsh
@@ -447,6 +447,55 @@ function normalizeRrdata(type, data) {
   return data;
 }
 
+/** Parse --routing-policy-data "WEIGHT:rrdata[,rrdata];WEIGHT:rrdata…" into
+ *  weighted-round-robin items. Each ';'-separated segment is one weighted
+ *  target group; ','-separated rrdatas share that weight. */
+function parseWrrData(type, dataStr) {
+  const items = dataStr.split(';').map(s => s.trim()).filter(Boolean).map(seg => {
+    const ci = seg.indexOf(':');
+    if (ci < 0) {
+      cli.die(`Invalid --routing-policy-data segment "${seg}" (expected WEIGHT:rrdata[,rrdata]).`, { prefix: 'gcloud' });
+    }
+    const weight = Number(seg.slice(0, ci).trim());
+    if (!Number.isFinite(weight)) cli.die(`Invalid weight in "${seg}".`, { prefix: 'gcloud' });
+    const rrdatas = seg.slice(ci + 1).split(',').map(x => x.trim()).filter(Boolean)
+      .map(d => normalizeRrdata(type, d));
+    if (!rrdatas.length) cli.die(`No rrdata in segment "${seg}".`, { prefix: 'gcloud' });
+    return { weight, rrdatas };
+  });
+  if (!items.length) cli.die('--routing-policy-data produced no items.', { prefix: 'gcloud' });
+  return items;
+}
+
+/** Plain (uncolored) per-line description of an rrset's data for change
+ *  previews — renders routingPolicy targets, not just top-level rrdatas. */
+function changeDetailLines(r) {
+  if (Array.isArray(r.rrdatas) && r.rrdatas.length) return r.rrdatas.slice();
+  const rp = r.routingPolicy;
+  if (!rp) return ['(no data)'];
+  const lines = [];
+  if (rp.wrr?.items) {
+    lines.push('routing: weighted (wrr)');
+    let i = 0;
+    for (const it of rp.wrr.items) {
+      const tgt = (it.rrdatas || []).join(', ') || '(empty)';
+      const w = it.weight ?? 0;
+      lines.push(`  [${i}] weight ${w}${w === 0 ? ' (inactive)' : ''}: ${tgt}`);
+      i++;
+    }
+  } else if (rp.geo?.items) {
+    lines.push('routing: geo');
+    for (const it of rp.geo.items) {
+      lines.push(`  ${it.location || '?'}: ${(it.rrdatas || []).join(', ') || '(empty)'}`);
+    }
+  } else if (rp.primaryBackup) {
+    lines.push('routing: primary/backup (failover)');
+  } else {
+    lines.push('routing policy: ' + JSON.stringify(rp));
+  }
+  return lines;
+}
+
 async function cmdDnsZonesList(flags) {
   const project = await requireProject(flags);
   const zones = await gfetchAll(`${DNS_BASE}/projects/${encodeURIComponent(project)}/managedZones`, 'managedZones');
@@ -559,10 +608,19 @@ async function cmdDnsRecordsChange(positional, flags, mode) {
   const rawName = positional[1];
   const type = (positional[2] || '').toUpperCase();
   const data = positional.slice(3);
-  if (!zone || !rawName || !type || (mode === 'add' && !data.length)) {
+  // Routing-policy support (add only): create a weighted round-robin rrset
+  // instead of a plain one. This is what makes a WRR record reproducible —
+  // e.g. rolling back a flattened wildcard back to its weighted policy.
+  const rpType = str(flags['routing-policy']);
+  const rpData = str(flags['routing-policy-data']);
+  const usingRP = mode === 'add' && !!rpType;
+  if (!zone || !rawName || !type || (mode === 'add' && !usingRP && !data.length)) {
     cli.die(
       mode === 'add'
-        ? 'usage: gcloud dns records add <zone> <name> <type> <data> [<data>...] [--ttl 300] --confirm'
+        ? 'usage:\n' +
+          '  gcloud dns records add <zone> <name> <type> <data> [<data>...] [--ttl 300] --confirm\n' +
+          '  gcloud dns records add <zone> <name> <type> --routing-policy wrr \\\n' +
+          '         --routing-policy-data "WEIGHT:rrdata[,rrdata];WEIGHT:rrdata" [--ttl 300] --confirm'
         : 'usage: gcloud dns records remove <zone> <name> <type> --confirm',
       { prefix: 'gcloud' },
     );
@@ -571,25 +629,42 @@ async function cmdDnsRecordsChange(positional, flags, mode) {
   const base = `${DNS_BASE}/projects/${encodeURIComponent(project)}/managedZones/${encodeURIComponent(zone)}`;
 
   // Look up the existing rrset (name+type) so we can replace/delete it correctly.
+  // The fetched object carries any routingPolicy verbatim, so pushing it into
+  // deletions correctly removes a weighted/geo record (whose top-level rrdatas
+  // are empty) — this is what lets `add` flatten a WRR record to a plain one.
   const existing = await gfetchAll(`${base}/rrsets?name=${encodeURIComponent(name)}&type=${encodeURIComponent(type)}`, 'rrsets');
   const change = { additions: [], deletions: [] };
   if (existing.length) change.deletions.push(existing[0]);
   if (mode === 'add') {
     const ttl = Number.isFinite(parseInt(flags.ttl, 10)) ? parseInt(flags.ttl, 10) : 300;
-    change.additions.push({ name, type, ttl, rrdatas: data.map(d => normalizeRrdata(type, d)) });
+    if (usingRP) {
+      if (rpType.toLowerCase() !== 'wrr') {
+        cli.die('Only --routing-policy wrr (weighted round-robin) is supported.', { prefix: 'gcloud' });
+      }
+      if (!rpData) {
+        cli.die('--routing-policy wrr requires --routing-policy-data "WEIGHT:rrdata[,rrdata];WEIGHT:rrdata".', { prefix: 'gcloud' });
+      }
+      // A routing-policy rrset carries no top-level rrdatas.
+      change.additions.push({ name, type, ttl, routingPolicy: { wrr: { items: parseWrrData(type, rpData) } } });
+    } else {
+      change.additions.push({ name, type, ttl, rrdatas: data.map(d => normalizeRrdata(type, d)) });
+    }
   } else if (!existing.length) {
     cli.die(`No ${type} record found for ${name} in zone ${zone}.`, { prefix: 'gcloud' });
   }
 
-  // Preview
+  // Preview — render rrdatas AND routing policies so a weighted record no longer
+  // shows a misleading blank target.
   console.log('');
   if (change.deletions.length) {
     const d = change.deletions[0];
-    console.log(c.red(`  - ${d.type} ${d.name} ttl:${d.ttl}  ${(d.rrdatas || []).join(' ')}`));
+    console.log(c.red(`  - ${d.type} ${d.name} ttl:${d.ttl}`));
+    for (const line of changeDetailLines(d)) console.log(c.red(`      ${line}`));
   }
   if (change.additions.length) {
     const a = change.additions[0];
-    console.log(c.green(`  + ${a.type} ${a.name} ttl:${a.ttl}  ${(a.rrdatas || []).join(' ')}`));
+    console.log(c.green(`  + ${a.type} ${a.name} ttl:${a.ttl}`));
+    for (const line of changeDetailLines(a)) console.log(c.green(`      ${line}`));
   }
   if (!flags.confirm) {
     console.log(c.dim('\n  Re-run with --confirm to apply this change.'));
@@ -649,7 +724,7 @@ async function cmdDns(positional, flags) {
   if (group === 'logging' && action === 'enable') return await cmdDnsLoggingSet(rest, flags, 'enable');
   if (group === 'logging' && action === 'disable') return await cmdDnsLoggingSet(rest, flags, 'disable');
   cli.die(
-    'usage:\n  gcloud dns zones list\n  gcloud dns zones create <name> --dns-name <domain.> --confirm\n  gcloud dns records list <zone> [--name N] [--type T]\n  gcloud dns records add <zone> <name> <type> <data>... [--ttl 300] --confirm\n  gcloud dns records remove <zone> <name> <type> --confirm\n  gcloud dns logging status <zone>\n  gcloud dns logging enable <zone> --confirm\n  gcloud dns logging disable <zone> --confirm',
+    'usage:\n  gcloud dns zones list\n  gcloud dns zones create <name> --dns-name <domain.> --confirm\n  gcloud dns records list <zone> [--name N] [--type T]\n  gcloud dns records add <zone> <name> <type> <data>... [--ttl 300] --confirm\n  gcloud dns records add <zone> <name> <type> --routing-policy wrr --routing-policy-data "W:rrdata;W:rrdata" [--ttl 300] --confirm\n  gcloud dns records remove <zone> <name> <type> --confirm\n  gcloud dns logging status <zone>\n  gcloud dns logging enable <zone> --confirm\n  gcloud dns logging disable <zone> --confirm',
     { prefix: 'gcloud' },
   );
 }
@@ -822,6 +897,8 @@ USAGE
   gcloud dns zones create <name> --dns-name <domain.> --confirm
   gcloud dns records list <zone> [--name N] [--type T]
   gcloud dns records add    <zone> <name> <type> <data>... [--ttl 300] --confirm
+  gcloud dns records add    <zone> <name> <type> --routing-policy wrr
+         --routing-policy-data "W:rrdata;W:rrdata" [--ttl 300] --confirm
   gcloud dns records remove <zone> <name> <type> --confirm
   gcloud dns logging status  <zone> [--project P]   Query-logging state for a zone
   gcloud dns logging enable  <zone> [--project P] --confirm

--- a/skills/gcloud/scripts/gcloud.jsh
+++ b/skills/gcloud/scripts/gcloud.jsh
@@ -543,7 +543,9 @@ function rrdataLines(r) {
       || pb.primaryTargets?.rrdatas || [];
     if (prim.length) lines.push(`primary: ${prim.join(', ')}`);
     const backup = pb.backupGeoTargets?.items || [];
-    backup.forEach(it => lines.push(`backup ${it.location || '?'}: ${(it.rrdatas || []).join(', ')}`));
+    for (const it of backup) {
+      lines.push(`backup ${it.location || '?'}: ${(it.rrdatas || []).join(', ')}`);
+    }
   }
   // Fallback: unknown policy shape — show something rather than nothing.
   if (!lines.length) lines.push(c.dim('routing policy: ' + JSON.stringify(rp)));

--- a/skills/gcloud/scripts/gcloud.jsh
+++ b/skills/gcloud/scripts/gcloud.jsh
@@ -1,0 +1,638 @@
+// gcloud.jsh — a subset of the Google Cloud API, authenticated via the
+// gcloud CLI's own public "Cloud SDK" OAuth client through oauth-token --intercept.
+//
+// Auth model (mirrors `gcloud auth login`): the Google Cloud SDK ships a public
+// "desktop app" OAuth client whose id/secret are baked into the gcloud source
+// (googlecloudsdk/core/config.py: CLOUDSDK_CLIENT_ID / CLOUDSDK_CLIENT_NOTSOSECRET).
+// Desktop clients are non-confidential — Google protects them with loopback
+// redirect-URI matching, not secrecy of the "secret". We reuse that client so a
+// human completing the standard Google consent screen yields a real
+// cloud-platform-scoped token, exchanged + refreshed exactly like gcloud does.
+
+const cli   = require('sliccy:cli');
+const fmt   = require('sliccy:fmt');
+const skill = require('sliccy:skill');
+const exec  = require('sliccy:exec');
+const c     = require('sliccy:color');
+
+// ─── Constants ─────────────────────────────────────────────────────────────
+
+// Public Cloud SDK OAuth client (see header). If Google ever rotates these,
+// re-check the gcloud source constants CLOUDSDK_CLIENT_ID /
+// CLOUDSDK_CLIENT_NOTSOSECRET.
+const CLIENT_ID     = '32555940559.apps.googleusercontent.com';
+const CLIENT_SECRET = 'ZmssLNjJy2998hD4CTg2ejr2';
+const AUTH_URL      = 'https://accounts.google.com/o/oauth2/auth';
+const TOKEN_URL     = 'https://oauth2.googleapis.com/token';
+const REVOKE_URL    = 'https://oauth2.googleapis.com/revoke';
+// Loopback redirect. Desktop-app clients accept 127.0.0.1 on any port; we fix
+// a port so the redirect-pattern below matches deterministically.
+const REDIRECT_PORT = 8085;
+const REDIRECT_URI  = `http://127.0.0.1:${REDIRECT_PORT}/`;
+const SCOPES = [
+  'openid',
+  'https://www.googleapis.com/auth/userinfo.email',
+  'https://www.googleapis.com/auth/cloud-platform',
+].join(' ');
+
+// ─── Token management ────────────────────────────────────────────────────────
+
+async function loadConfig() {
+  // Must await before the `|| {}` fallback — skill.config() returns a Promise
+  // (always truthy); `skill.config() || {}` never falls back and reading a
+  // property off a null resolved config throws (confirmed-live garmin bug).
+  return (await skill.config()) || {};
+}
+
+async function saveConfig(updates) {
+  const cur = await loadConfig();
+  await skill.config({ ...cur, ...updates });
+}
+
+/** Flag values are strings only when a value was actually supplied; single-dash
+ *  short flags and value-less long flags come back as boolean true. Coerce those
+ *  to undefined so they never leak into URLs or config. */
+function str(v) { return typeof v === 'string' ? v : undefined; }
+
+async function exchangeCode(code) {
+  const body = new URLSearchParams({
+    grant_type:    'authorization_code',
+    code,
+    client_id:     CLIENT_ID,
+    client_secret: CLIENT_SECRET,
+    redirect_uri:  REDIRECT_URI,
+  });
+  const res = await fetch(TOKEN_URL, {
+    method:  'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body:    body.toString(),
+  });
+  if (!res.ok) {
+    cli.die(`Code exchange failed (${res.status}): ${await res.text()}`, { prefix: 'gcloud' });
+  }
+  return await res.json();
+}
+
+async function refreshAccessToken(refreshToken) {
+  const body = new URLSearchParams({
+    grant_type:    'refresh_token',
+    client_id:     CLIENT_ID,
+    client_secret: CLIENT_SECRET,
+    refresh_token: refreshToken,
+  });
+  const res = await fetch(TOKEN_URL, {
+    method:  'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body:    body.toString(),
+  });
+  if (!res.ok) {
+    throw new Error(`Refresh failed (${res.status}): ${await res.text()}`);
+  }
+  return await res.json();
+}
+
+/** Returns a valid access token, refreshing if needed. Dies actionably otherwise. */
+async function getAccessToken() {
+  const cfg = await loadConfig();
+  if (!cfg.refresh_token) {
+    cli.die('Not logged in. Run: gcloud login', { prefix: 'gcloud' });
+  }
+  const now = Date.now();
+  if (cfg.access_token && cfg.expires_at && now < cfg.expires_at - 60_000) {
+    return cfg.access_token;
+  }
+  try {
+    const tok = await refreshAccessToken(cfg.refresh_token);
+    const updates = {
+      access_token: tok.access_token,
+      expires_at:   Date.now() + (tok.expires_in || 3600) * 1000,
+    };
+    if (tok.refresh_token) updates.refresh_token = tok.refresh_token;
+    await saveConfig(updates);
+    return updates.access_token;
+  } catch (err) {
+    cli.die(`Could not refresh token: ${err.message}\nRun: gcloud login`, { prefix: 'gcloud' });
+  }
+}
+
+/** Authenticated JSON fetch against any Google API host. Full URL in, parsed body out. */
+async function gfetch(url, opts = {}) {
+  const token = await getAccessToken();
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept:        'application/json',
+    ...(opts.headers || {}),
+  };
+  let body = opts.body;
+  if (body && typeof body !== 'string') {
+    body = JSON.stringify(body);
+    headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+  }
+  const res = await fetch(url, { method: opts.method || 'GET', headers, body });
+  const text = await res.text();
+  if (res.ok) {
+    if (!text) return {};
+    try { return JSON.parse(text); }
+    catch { return { raw: text }; }
+  }
+
+  // Error path — parse Google's structured error to give a targeted message
+  // rather than a raw JSON dump or a blanket "session expired" for every 403.
+  let err = {};
+  try { err = (JSON.parse(text).error) || {}; } catch { /* non-JSON */ }
+  const msg = err.message || text || res.statusText;
+  // Gather every reason string Google scatters across status/errors[]/details[].
+  const reasons = [
+    err.status,
+    ...(err.errors || []).map(e => e?.reason),
+    ...(err.details || []).map(d => d?.reason),
+  ].filter(Boolean);
+  const has = re => reasons.some(r => re.test(r)) || re.test(msg);
+  const label = err.status || reasons[0] || '';
+
+  // Credential problems (vs. project/IAM state) — the only case that warrants re-login.
+  if (res.status === 401 || has(/UNAUTHENTICATED|ACCESS_TOKEN|authError|invalid.?token/i)) {
+    cli.die(`Google rejected the token (${res.status}). Run: gcloud login`, { prefix: 'gcloud' });
+  }
+  if (has(/SERVICE_DISABLED|accessNotConfigured/)) {
+    const svc = err.details?.find(d => d?.metadata?.service)?.metadata?.service || 'the required API';
+    cli.die(
+      `${svc} is not enabled on this project.\nEnable it, then retry:\n  gcloud services enable ${svc} --confirm\n(or enable it in the Cloud Console).`,
+      { prefix: 'gcloud' },
+    );
+  }
+  cli.die(`Google returned ${res.status}${label ? ' (' + label + ')' : ''}: ${msg}`, { prefix: 'gcloud' });
+}
+
+/** Fully paginate a Google list endpoint that uses ?pageToken / .nextPageToken. */
+async function gfetchAll(url, itemsKey) {
+  const out = [];
+  let pageToken = '';
+  for (let i = 0; i < 50; i++) {
+    const sep = url.includes('?') ? '&' : '?';
+    const pageUrl = pageToken ? `${url}${sep}pageToken=${encodeURIComponent(pageToken)}` : url;
+    const data = await gfetch(pageUrl);
+    const items = data[itemsKey] || data.items || [];
+    if (Array.isArray(items)) out.push(...items);
+    if (!data.nextPageToken) break;
+    pageToken = data.nextPageToken;
+  }
+  return out;
+}
+
+/** Resolve the active project: --project flag > stored config. Dies if unset. */
+async function requireProject(flags) {
+  const cfg = await loadConfig();
+  // parseFlags returns boolean true for single-dash flags and never captures
+  // their value, so only the long --project form is honored here; str() also
+  // stops a bare --project (no value → true) from leaking "true" into a URL.
+  const proj = str(flags.project) || cfg.project;
+  if (!proj) {
+    cli.die(
+      'No project set. Pass --project <id> or run: gcloud config set-project <id>',
+      { prefix: 'gcloud' },
+    );
+  }
+  return proj;
+}
+
+// ─── Subcommands ─────────────────────────────────────────────────────────────
+
+async function cmdLogin() {
+  console.log(c.cyan('Opening Google sign-in…'));
+  console.log(c.dim('A browser tab will open. Complete the Google consent screen, then return here.'));
+
+  const authorizeUrl =
+    `${AUTH_URL}?client_id=${encodeURIComponent(CLIENT_ID)}` +
+    `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}` +
+    `&response_type=code&access_type=offline&prompt=consent` +
+    `&scope=${encodeURIComponent(SCOPES)}`;
+
+  const { stdout, stderr, exitCode } = await exec.spawn([
+    'oauth-token', '--intercept',
+    '--authorize-url', authorizeUrl,
+    '--redirect-pattern', `http://127.0.0.1:${REDIRECT_PORT}/*`,
+  ]);
+
+  if (exitCode !== 0) {
+    cli.die(`oauth-token intercept failed:\n${stderr}`, { prefix: 'gcloud' });
+  }
+
+  const redirectUrl = (stdout || '').trim();
+  const m = redirectUrl.match(/[?&]code=([^&\s]+)/);
+  if (!m) {
+    cli.die(`Could not find authorization code in redirect URL.\nGot: ${redirectUrl}`, { prefix: 'gcloud' });
+  }
+  const code = decodeURIComponent(m[1]);
+
+  console.log(c.cyan('Exchanging authorization code for tokens…'));
+  const tok = await exchangeCode(code);
+  if (!tok.refresh_token) {
+    cli.die(
+      'No refresh_token returned. Re-run gcloud login and ensure you approve the consent screen (access_type=offline&prompt=consent).',
+      { prefix: 'gcloud' },
+    );
+  }
+
+  await saveConfig({
+    refresh_token: tok.refresh_token,
+    access_token:  tok.access_token,
+    expires_at:    Date.now() + (tok.expires_in || 3600) * 1000,
+  });
+
+  // Resolve and show the authenticated identity.
+  let email = '';
+  try {
+    const info = await gfetch('https://openidconnect.googleapis.com/v1/userinfo');
+    email = info.email || '';
+  } catch { /* non-fatal */ }
+
+  console.log(c.green('✓ Logged in to Google Cloud') + (email ? c.dim(`  (${email})`) : ''));
+  console.log(c.dim('  Refresh token stored in skill config. Access tokens auto-refresh.'));
+}
+
+async function cmdWhoami(flags) {
+  const cfg = await loadConfig();
+  if (!cfg.refresh_token) cli.die('Not logged in. Run: gcloud login', { prefix: 'gcloud' });
+  const info = await gfetch('https://openidconnect.googleapis.com/v1/userinfo');
+  if (flags.json) { cli.out({ ...info, project: cfg.project || null }); return; }
+  console.log('');
+  console.log(`  ${c.cyan(c.bold(info.email || info.sub || 'unknown'))}`);
+  if (info.name) console.log(`  ${c.dim(info.name)}`);
+  console.log(`  ${c.dim('project: ' + (cfg.project || '(unset — gcloud config set-project <id>)'))}`);
+}
+
+async function cmdLogout() {
+  const cfg = await loadConfig();
+  if (cfg.refresh_token) {
+    try {
+      await fetch(REVOKE_URL, {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body:    new URLSearchParams({ token: cfg.refresh_token }).toString(),
+      });
+    } catch { /* best effort */ }
+  }
+  await skill.config({ project: cfg.project }); // keep project, drop tokens
+  console.log(c.green('✓ Logged out (tokens revoked and cleared).'));
+}
+
+async function cmdConfig(positional, flags) {
+  const cfg = await loadConfig();
+  const sub = positional[0];
+  // `gcloud config set-project <id>` or `gcloud config set project <id>`
+  if (sub === 'set-project' || (sub === 'set' && positional[1] === 'project')) {
+    const id = sub === 'set-project' ? positional[1] : positional[2];
+    if (!id) cli.die('usage: gcloud config set-project <project-id>', { prefix: 'gcloud' });
+    await saveConfig({ project: id });
+    console.log(c.green(`✓ Active project set to ${c.bold(id)}`));
+    return;
+  }
+  // show
+  if (flags.json) { cli.out({ project: cfg.project || null, logged_in: !!cfg.refresh_token }); return; }
+  console.log('');
+  console.log(`  ${c.dim('project')}    ${cfg.project || c.dim('(unset)')}`);
+  console.log(`  ${c.dim('logged in')}  ${cfg.refresh_token ? c.green('yes') : c.red('no')}`);
+}
+
+async function cmdProjectsList(flags) {
+  const projects = await gfetchAll('https://cloudresourcemanager.googleapis.com/v1/projects', 'projects');
+  if (flags.json) { cli.out(projects); return; }
+  if (!projects.length) { console.log(c.dim('  No projects found.')); return; }
+  console.log('');
+  for (const p of projects) {
+    const state = p.lifecycleState === 'ACTIVE' ? c.green('●') : c.dim('○');
+    console.log(`  ${state} ${c.cyan(c.bold(p.projectId))}  ${c.dim(p.name || '')}  ${c.dim('num:' + (p.projectNumber || '?'))}`);
+  }
+}
+
+async function cmdComputeInstances(flags) {
+  const project = await requireProject(flags);
+  // aggregatedList spans all zones in one call.
+  const data = await gfetch(`https://compute.googleapis.com/compute/v1/projects/${encodeURIComponent(project)}/aggregated/instances`);
+  const rows = [];
+  for (const [zoneKey, bucket] of Object.entries(data.items || {})) {
+    for (const inst of (bucket.instances || [])) {
+      rows.push({ ...inst, _zone: (inst.zone || zoneKey).split('/').pop() });
+    }
+  }
+  const zoneFilter = str(flags.zone);
+  const filtered = zoneFilter ? rows.filter(r => r._zone === zoneFilter) : rows;
+  if (flags.json) { cli.out(filtered); return; }
+  if (!filtered.length) { console.log(c.dim('  No instances found.')); return; }
+  console.log('');
+  for (const i of filtered) {
+    const up = i.status === 'RUNNING' ? c.green('●') : c.dim('○');
+    const machine = (i.machineType || '').split('/').pop();
+    console.log(`  ${up} ${c.cyan(c.bold(i.name))}  ${c.dim(i._zone)}  ${c.dim(machine)}  ${c.dim(i.status)}`);
+  }
+}
+
+async function cmdComputeZones(flags) {
+  const project = await requireProject(flags);
+  const zones = await gfetchAll(`https://compute.googleapis.com/compute/v1/projects/${encodeURIComponent(project)}/zones`, 'items');
+  if (flags.json) { cli.out(zones); return; }
+  if (!zones.length) { console.log(c.dim('  No zones found.')); return; }
+  console.log('');
+  for (const z of zones) {
+    const up = z.status === 'UP' ? c.green('●') : c.dim('○');
+    console.log(`  ${up} ${c.cyan(z.name)}  ${c.dim((z.region || '').split('/').pop())}`);
+  }
+}
+
+async function cmdBuckets(flags) {
+  const project = await requireProject(flags);
+  const buckets = await gfetchAll(`https://storage.googleapis.com/storage/v1/b?project=${encodeURIComponent(project)}`, 'items');
+  if (flags.json) { cli.out(buckets); return; }
+  if (!buckets.length) { console.log(c.dim('  No buckets found.')); return; }
+  console.log('');
+  for (const b of buckets) {
+    console.log(`  ${c.cyan(c.bold('gs://' + b.name))}  ${c.dim(b.location || '')}  ${c.dim(b.storageClass || '')}`);
+  }
+}
+
+async function cmdServicesEnable(positional, flags) {
+  const project = await requireProject(flags);
+  const api = positional[1]; // positional[0] === 'enable'
+  if (!api || !/^[a-z0-9.-]+\.googleapis\.com$/.test(api)) {
+    cli.die('usage: gcloud services enable <api.googleapis.com> --confirm', { prefix: 'gcloud' });
+  }
+  if (!flags.confirm) {
+    console.log('');
+    console.log(c.yellow(`  Would enable ${c.bold(api)} on project ${c.bold(project)}.`));
+    console.log(c.dim('  Re-run with --confirm to apply.'));
+    return;
+  }
+  await gfetch(`https://serviceusage.googleapis.com/v1/projects/${encodeURIComponent(project)}/services/${encodeURIComponent(api)}:enable`, { method: 'POST', body: {} });
+  console.log(c.green(`✓ Enabled ${c.bold(api)} on ${project}`) + c.dim('  (may take a minute to propagate)'));
+}
+
+async function cmdServices(positional, flags) {
+  if (positional[0] === 'enable') return await cmdServicesEnable(positional, flags);
+  const project = await requireProject(flags);
+  const svcs = await gfetchAll(
+    `https://serviceusage.googleapis.com/v1/projects/${encodeURIComponent(project)}/services?filter=state:ENABLED`,
+    'services',
+  );
+  if (flags.json) { cli.out(svcs); return; }
+  if (!svcs.length) { console.log(c.dim('  No enabled services found.')); return; }
+  console.log('');
+  for (const s of svcs) {
+    const name = (s.config?.name) || s.name.split('/').pop();
+    console.log(`  ${c.green('✓')} ${c.cyan(name)}  ${c.dim(s.config?.title || '')}`);
+  }
+}
+
+async function cmdRun(flags) {
+  const project = await requireProject(flags);
+  const region = str(flags.region) || '-'; // '-' = all regions
+  const svcs = await gfetchAll(
+    `https://run.googleapis.com/v2/projects/${encodeURIComponent(project)}/locations/${encodeURIComponent(region)}/services`,
+    'services',
+  );
+  if (flags.json) { cli.out(svcs); return; }
+  if (!svcs.length) { console.log(c.dim('  No Cloud Run services found.')); return; }
+  console.log('');
+  for (const s of svcs) {
+    const name = (s.name || '').split('/').pop();
+    const loc  = (s.name || '').split('/locations/')[1]?.split('/')[0] || '';
+    console.log(`  ${c.cyan(c.bold(name))}  ${c.dim(loc)}  ${c.dim(s.uri || '')}`);
+  }
+}
+
+// ── Cloud DNS ────────────────────────────────────────────────────────────────
+
+const DNS_BASE = 'https://dns.googleapis.com/dns/v1';
+
+/** Ensure a DNS name is a FQDN with the trailing dot Cloud DNS requires. */
+function fqdn(name) {
+  return name.endsWith('.') ? name : `${name}.`;
+}
+
+/** TXT rrdatas must be double-quoted; quote any value that isn't already. */
+function normalizeRrdata(type, data) {
+  if (type.toUpperCase() === 'TXT' && !/^".*"$/.test(data)) {
+    return `"${data.replace(/"/g, '\\"')}"`;
+  }
+  return data;
+}
+
+async function cmdDnsZonesList(flags) {
+  const project = await requireProject(flags);
+  const zones = await gfetchAll(`${DNS_BASE}/projects/${encodeURIComponent(project)}/managedZones`, 'managedZones');
+  if (flags.json) { cli.out(zones); return; }
+  if (!zones.length) { console.log(c.dim('  No managed zones found.')); return; }
+  console.log('');
+  for (const z of zones) {
+    const vis = z.visibility && z.visibility !== 'public' ? c.dim(`[${z.visibility}]`) : '';
+    console.log(`  ${c.cyan(c.bold(z.name))}  ${c.dim(z.dnsName)}  ${vis}`.trimEnd());
+    if (z.description) console.log(`      ${c.dim(z.description)}`);
+    if (Array.isArray(z.nameServers) && z.nameServers.length) {
+      console.log(`      ${c.dim('NS: ' + z.nameServers.join(', '))}`);
+    }
+  }
+}
+
+async function cmdDnsZonesCreate(positional, flags) {
+  const project = await requireProject(flags);
+  const name = positional[0];
+  const dnsName = str(flags['dns-name']) || str(flags.dnsName);
+  if (!name || !dnsName) {
+    cli.die('usage: gcloud dns zones create <zone-name> --dns-name <domain.> [--description <text>] --confirm', { prefix: 'gcloud' });
+  }
+  const body = {
+    name,
+    dnsName: fqdn(dnsName),
+    description: flags.description || `Managed by gcloud.jsh`,
+    visibility: flags.private ? 'private' : 'public',
+  };
+  if (!flags.confirm) {
+    console.log('');
+    console.log(c.yellow('  Would create managed zone:'));
+    console.log(`    ${c.bold(name)}  dnsName=${body.dnsName}  visibility=${body.visibility}`);
+    console.log(c.dim('  Re-run with --confirm to apply.'));
+    return;
+  }
+  const z = await gfetch(`${DNS_BASE}/projects/${encodeURIComponent(project)}/managedZones`, { method: 'POST', body });
+  console.log(c.green(`✓ Created zone ${c.bold(z.name)}`) + c.dim(`  (${z.dnsName})`));
+  if (Array.isArray(z.nameServers)) console.log(`  ${c.dim('NS: ' + z.nameServers.join(', '))}`);
+}
+
+async function cmdDnsRecordsList(positional, flags) {
+  const project = await requireProject(flags);
+  const zone = positional[0];
+  if (!zone) cli.die('usage: gcloud dns records list <zone> [--name N] [--type T]', { prefix: 'gcloud' });
+  let url = `${DNS_BASE}/projects/${encodeURIComponent(project)}/managedZones/${encodeURIComponent(zone)}/rrsets`;
+  const qs = [];
+  if (str(flags.name)) qs.push(`name=${encodeURIComponent(fqdn(flags.name))}`);
+  if (str(flags.type)) qs.push(`type=${encodeURIComponent(str(flags.type).toUpperCase())}`);
+  if (qs.length) url += `?${qs.join('&')}`;
+  const rrsets = await gfetchAll(url, 'rrsets');
+  if (flags.json) { cli.out(rrsets); return; }
+  if (!rrsets.length) { console.log(c.dim('  No records found.')); return; }
+  console.log('');
+  for (const r of rrsets) {
+    console.log(`  ${c.cyan(c.bold(r.type.padEnd(6)))} ${r.name}  ${c.dim('ttl:' + r.ttl)}`);
+    for (const d of (r.rrdatas || [])) console.log(`      ${d}`);
+  }
+}
+
+/** add = upsert (replace existing rrset of same name+type); remove = delete it. */
+async function cmdDnsRecordsChange(positional, flags, mode) {
+  const project = await requireProject(flags);
+  const zone = positional[0];
+  const rawName = positional[1];
+  const type = (positional[2] || '').toUpperCase();
+  const data = positional.slice(3);
+  if (!zone || !rawName || !type || (mode === 'add' && !data.length)) {
+    cli.die(
+      mode === 'add'
+        ? 'usage: gcloud dns records add <zone> <name> <type> <data> [<data>...] [--ttl 300] --confirm'
+        : 'usage: gcloud dns records remove <zone> <name> <type> --confirm',
+      { prefix: 'gcloud' },
+    );
+  }
+  const name = fqdn(rawName);
+  const base = `${DNS_BASE}/projects/${encodeURIComponent(project)}/managedZones/${encodeURIComponent(zone)}`;
+
+  // Look up the existing rrset (name+type) so we can replace/delete it correctly.
+  const existing = await gfetchAll(`${base}/rrsets?name=${encodeURIComponent(name)}&type=${encodeURIComponent(type)}`, 'rrsets');
+  const change = { additions: [], deletions: [] };
+  if (existing.length) change.deletions.push(existing[0]);
+  if (mode === 'add') {
+    const ttl = Number.isFinite(parseInt(flags.ttl, 10)) ? parseInt(flags.ttl, 10) : 300;
+    change.additions.push({ name, type, ttl, rrdatas: data.map(d => normalizeRrdata(type, d)) });
+  } else if (!existing.length) {
+    cli.die(`No ${type} record found for ${name} in zone ${zone}.`, { prefix: 'gcloud' });
+  }
+
+  // Preview
+  console.log('');
+  if (change.deletions.length) {
+    const d = change.deletions[0];
+    console.log(c.red(`  - ${d.type} ${d.name} ttl:${d.ttl}  ${(d.rrdatas || []).join(' ')}`));
+  }
+  if (change.additions.length) {
+    const a = change.additions[0];
+    console.log(c.green(`  + ${a.type} ${a.name} ttl:${a.ttl}  ${(a.rrdatas || []).join(' ')}`));
+  }
+  if (!flags.confirm) {
+    console.log(c.dim('\n  Re-run with --confirm to apply this change.'));
+    return;
+  }
+  const res = await gfetch(`${base}/changes`, { method: 'POST', body: change });
+  console.log(c.green(`✓ Change ${res.id || ''} submitted`) + c.dim(`  status: ${res.status || 'pending'}`));
+}
+
+async function cmdDns(positional, flags) {
+  const group = positional[0];
+  const action = positional[1];
+  const rest = positional.slice(2);
+  if (group === 'zones' && (action === 'list' || !action)) return await cmdDnsZonesList(flags);
+  if (group === 'zones' && action === 'create') return await cmdDnsZonesCreate(rest, flags);
+  if (group === 'records' && (action === 'list' || !action)) return await cmdDnsRecordsList(rest, flags);
+  if (group === 'records' && action === 'add') return await cmdDnsRecordsChange(rest, flags, 'add');
+  if (group === 'records' && (action === 'remove' || action === 'delete')) return await cmdDnsRecordsChange(rest, flags, 'remove');
+  cli.die(
+    'usage:\n  gcloud dns zones list\n  gcloud dns zones create <name> --dns-name <domain.> --confirm\n  gcloud dns records list <zone> [--name N] [--type T]\n  gcloud dns records add <zone> <name> <type> <data>... [--ttl 300] --confirm\n  gcloud dns records remove <zone> <name> <type> --confirm',
+    { prefix: 'gcloud' },
+  );
+}
+
+async function cmdApi(positional, flags) {
+  // gcloud api <METHOD> <url> [--data <json>]
+  let method = 'GET', url;
+  if (positional.length >= 2 && /^(GET|POST|PUT|PATCH|DELETE)$/i.test(positional[0])) {
+    method = positional[0].toUpperCase();
+    url = positional[1];
+  } else {
+    url = positional[0];
+  }
+  if (!url) cli.die('usage: gcloud api [METHOD] <full-url> [--data <json>]', { prefix: 'gcloud' });
+  let body;
+  if (flags.data) {
+    try { body = JSON.parse(flags.data); }
+    catch { body = flags.data; }
+  }
+  const data = await gfetch(url, { method, body });
+  cli.out(data);
+}
+
+// ─── args + main ─────────────────────────────────────────────────────────────
+
+const HELP = `
+gcloud — a subset of the Google Cloud API, authenticated via the gcloud CLI's
+         own public OAuth client (oauth-token --intercept).
+
+USAGE
+  gcloud login                          Sign in with Google (browser consent)
+  gcloud whoami                         Show the authenticated identity
+  gcloud logout                         Revoke + clear stored tokens
+
+  gcloud config                         Show active config
+  gcloud config set-project <id>        Set the default project
+
+  gcloud projects list                  List accessible projects
+  gcloud instances list  [--project P] [--zone Z]   Compute Engine instances
+  gcloud zones list      [--project P]              Compute Engine zones
+  gcloud buckets list    [--project P]              Cloud Storage buckets
+  gcloud services list   [--project P]              Enabled APIs
+  gcloud run list        [--project P] [--region R] Cloud Run services
+  gcloud services enable <api.googleapis.com> [--project P] --confirm
+
+  gcloud dns zones list                             Managed DNS zones
+  gcloud dns zones create <name> --dns-name <domain.> --confirm
+  gcloud dns records list <zone> [--name N] [--type T]
+  gcloud dns records add    <zone> <name> <type> <data>... [--ttl 300] --confirm
+  gcloud dns records remove <zone> <name> <type> --confirm
+
+  gcloud api [METHOD] <full-url> [--data <json>]    Authenticated raw call
+
+FLAGS
+  --project <id>       Override the active project for this call
+  --confirm            Actually apply a create/add/remove/enable (else preview only)
+  --json               Output raw JSON
+
+  (Use long flags with a value: --project X, --zone X, --region X, --type X.
+   Single-dash short flags are not supported.)
+
+REQUIRES
+  Run 'gcloud login' once. A human completes the Google consent screen in the
+  browser; tokens are then stored in skill config and auto-refresh.
+`.trim();
+
+const parsed      = process.argv.parseFlags();
+const subcommand  = parsed.subcommand || '';
+const positional  = parsed.positional.slice(1);
+const flags       = parsed.flags;
+
+async function main() {
+  if (flags.help || flags.h || !subcommand || subcommand === 'help') cli.help(HELP);
+
+  try {
+    // normalize gcloud-style two-word forms
+    const s = subcommand;
+    const p0 = positional[0];
+
+    if (s === 'login' || (s === 'auth' && p0 === 'login')) return await cmdLogin();
+    if (s === 'whoami' || (s === 'auth' && p0 === 'status')) return await cmdWhoami(flags);
+    if (s === 'logout' || (s === 'auth' && p0 === 'revoke')) return await cmdLogout();
+    if (s === 'config') return await cmdConfig(positional, flags);
+
+    if (s === 'projects') return await cmdProjectsList(flags);
+    if (s === 'instances' || (s === 'compute' && p0 === 'instances')) return await cmdComputeInstances(flags);
+    if (s === 'zones' || (s === 'compute' && p0 === 'zones')) return await cmdComputeZones(flags);
+    if (s === 'buckets' || s === 'storage') return await cmdBuckets(flags);
+    if (s === 'services') return await cmdServices(positional, flags);
+    if (s === 'run') return await cmdRun(flags);
+    if (s === 'dns') return await cmdDns(positional, flags);
+    if (s === 'api') return await cmdApi(positional, flags);
+
+    cli.die(`unknown command: ${s}\nRun 'gcloud --help' for usage.`, { prefix: 'gcloud' });
+  } catch (err) {
+    if (err?.name === 'NodeExitError') throw err; // MANDATORY re-throw
+    cli.die(err.message, { prefix: 'gcloud' });
+  }
+}
+
+await main();

--- a/skills/gcloud/scripts/gcloud.jsh
+++ b/skills/gcloud/scripts/gcloud.jsh
@@ -503,8 +503,51 @@ async function cmdDnsRecordsList(positional, flags) {
   console.log('');
   for (const r of rrsets) {
     console.log(`  ${c.cyan(c.bold(r.type.padEnd(6)))} ${r.name}  ${c.dim('ttl:' + r.ttl)}`);
-    for (const d of (r.rrdatas || [])) console.log(`      ${d}`);
+    for (const line of rrdataLines(r)) console.log(`      ${line}`);
   }
+}
+
+/**
+ * Render an rrset's data. Plain records expose `rrdatas`, but records with a
+ * routing policy (WRR / GEO / failover) leave `rrdatas` empty and stash the
+ * real targets under `routingPolicy` — surface those instead of a blank line.
+ */
+function rrdataLines(r) {
+  if (Array.isArray(r.rrdatas) && r.rrdatas.length) return r.rrdatas.slice();
+  const rp = r.routingPolicy;
+  if (!rp) return [];
+  const lines = [];
+  // Weighted round-robin
+  if (rp.wrr?.items) {
+    lines.push(c.dim('routing: weighted (wrr)'));
+    rp.wrr.items.forEach((it, i) => {
+      const targets = (it.rrdatas || []).join(', ') || c.dim('(empty)');
+      const w = it.weight ?? 0;
+      const tag = w === 0 ? c.dim(`weight ${w} — inactive`) : `weight ${w}`;
+      lines.push(`[${i}] ${tag}: ${targets}`);
+    });
+  }
+  // Geo-location
+  if (rp.geo?.items) {
+    lines.push(c.dim('routing: geo'));
+    rp.geo.items.forEach(it => {
+      const targets = (it.rrdatas || []).join(', ') || c.dim('(empty)');
+      lines.push(`${it.location || '?'}: ${targets}`);
+    });
+  }
+  // Primary/backup failover
+  if (rp.primaryBackup) {
+    const pb = rp.primaryBackup;
+    lines.push(c.dim('routing: primary/backup (failover)'));
+    const prim = pb.primaryTargets?.internalLoadBalancers?.map(l => l.ipAddress).filter(Boolean)
+      || pb.primaryTargets?.rrdatas || [];
+    if (prim.length) lines.push(`primary: ${prim.join(', ')}`);
+    const backup = pb.backupGeoTargets?.items || [];
+    backup.forEach(it => lines.push(`backup ${it.location || '?'}: ${(it.rrdatas || []).join(', ')}`));
+  }
+  // Fallback: unknown policy shape — show something rather than nothing.
+  if (!lines.length) lines.push(c.dim('routing policy: ' + JSON.stringify(rp)));
+  return lines;
 }
 
 /** add = upsert (replace existing rrset of same name+type); remove = delete it. */

--- a/skills/gcloud/scripts/gcloud.jsh
+++ b/skills/gcloud/scripts/gcloud.jsh
@@ -115,8 +115,29 @@ async function getAccessToken() {
   }
 }
 
+/**
+ * Guard against leaking the account's cloud-platform Bearer token to arbitrary
+ * hosts (e.g. `gcloud api https://attacker.example/`). Every credentialed call
+ * funnels through gfetch, so validating here covers the raw `api` passthrough
+ * and every built-in command. Allow only HTTPS Google API hosts.
+ */
+function assertGoogleHost(url) {
+  let u;
+  try { u = new URL(url); }
+  catch { cli.die(`Invalid URL: ${url}`, { prefix: 'gcloud' }); }
+  const okHost = u.hostname === 'googleapis.com' || u.hostname.endsWith('.googleapis.com');
+  if (u.protocol !== 'https:' || !okHost) {
+    cli.die(
+      `Refusing to send Google credentials to ${u.protocol}//${u.hostname}. ` +
+      `Only HTTPS *.googleapis.com hosts are allowed.`,
+      { prefix: 'gcloud' },
+    );
+  }
+}
+
 /** Authenticated JSON fetch against any Google API host. Full URL in, parsed body out. */
 async function gfetch(url, opts = {}) {
+  assertGoogleHost(url);
   const token = await getAccessToken();
   const headers = {
     Authorization: `Bearer ${token}`,
@@ -308,13 +329,22 @@ async function cmdProjectsList(flags) {
 
 async function cmdComputeInstances(flags) {
   const project = await requireProject(flags);
-  // aggregatedList spans all zones in one call.
-  const data = await gfetch(`https://compute.googleapis.com/compute/v1/projects/${encodeURIComponent(project)}/aggregated/instances`);
+  // aggregatedList spans all zones, but large fleets are paginated: the
+  // response carries a nextPageToken and .items is a zone-keyed OBJECT (not an
+  // array), so gfetchAll can't be used directly — follow the tokens by hand.
+  const base = `https://compute.googleapis.com/compute/v1/projects/${encodeURIComponent(project)}/aggregated/instances`;
   const rows = [];
-  for (const [zoneKey, bucket] of Object.entries(data.items || {})) {
-    for (const inst of (bucket.instances || [])) {
-      rows.push({ ...inst, _zone: (inst.zone || zoneKey).split('/').pop() });
+  let pageToken = '';
+  for (let i = 0; i < 50; i++) {
+    const pageUrl = pageToken ? `${base}?pageToken=${encodeURIComponent(pageToken)}` : base;
+    const data = await gfetch(pageUrl);
+    for (const [zoneKey, bucket] of Object.entries(data.items || {})) {
+      for (const inst of (bucket.instances || [])) {
+        rows.push({ ...inst, _zone: (inst.zone || zoneKey).split('/').pop() });
+      }
     }
+    if (!data.nextPageToken) break;
+    pageToken = data.nextPageToken;
   }
   const zoneFilter = str(flags.zone);
   const filtered = zoneFilter ? rows.filter(r => r._zone === zoneFilter) : rows;

--- a/skills/gcloud/scripts/gcloud.jsh
+++ b/skills/gcloud/scripts/gcloud.jsh
@@ -599,6 +599,43 @@ async function cmdDnsRecordsChange(positional, flags, mode) {
   console.log(c.green(`✓ Change ${res.id || ''} submitted`) + c.dim(`  status: ${res.status || 'pending'}`));
 }
 
+async function cmdDnsLoggingStatus(positional, flags) {
+  const project = await requireProject(flags);
+  const zone = positional[0];
+  if (!zone) cli.die('usage: gcloud dns logging status <zone> [--project P]', { prefix: 'gcloud' });
+  const z = await gfetch(`${DNS_BASE}/projects/${encodeURIComponent(project)}/managedZones/${encodeURIComponent(zone)}`);
+  const enabled = z.cloudLoggingConfig?.enableLogging || false;
+  if (flags.json) { cli.out(z.cloudLoggingConfig || { enableLogging: enabled }); return; }
+  console.log('');
+  const state = enabled ? c.green('enabled') : c.dim('disabled');
+  console.log(`  ${c.cyan(c.bold(zone))}  logging: ${state}`);
+}
+
+/** enable = turn query logging on; disable = turn it off. */
+async function cmdDnsLoggingSet(positional, flags, mode) {
+  const project = await requireProject(flags);
+  const zone = positional[0];
+  if (!zone) cli.die(`usage: gcloud dns logging ${mode} <zone> [--project P] --confirm`, { prefix: 'gcloud' });
+  const enable = mode === 'enable';
+  if (!flags.confirm) {
+    console.log('');
+    console.log(c.yellow(`  Would ${enable ? 'ENABLE' : 'DISABLE'} query logging on zone ${c.bold(zone)} (project ${c.bold(project)}).`));
+    if (enable) {
+      console.log(c.dim('  Note: DNS query logs bill through Cloud Logging ingestion at $0.50/GiB'));
+      console.log(c.dim('  after the first 50 GiB/project/month (free tier).'));
+    }
+    console.log(c.dim('  Re-run with --confirm to apply.'));
+    return;
+  }
+  const body = { cloudLoggingConfig: { enableLogging: enable } };
+  const z = await gfetch(
+    `${DNS_BASE}/projects/${encodeURIComponent(project)}/managedZones/${encodeURIComponent(zone)}`,
+    { method: 'PATCH', body },
+  );
+  const applied = z.cloudLoggingConfig?.enableLogging || false;
+  console.log(c.green(`✓ Query logging ${applied ? 'enabled' : 'disabled'} on zone ${c.bold(zone)}`) + c.dim(`  (enableLogging: ${applied})`));
+}
+
 async function cmdDns(positional, flags) {
   const group = positional[0];
   const action = positional[1];
@@ -608,8 +645,134 @@ async function cmdDns(positional, flags) {
   if (group === 'records' && (action === 'list' || !action)) return await cmdDnsRecordsList(rest, flags);
   if (group === 'records' && action === 'add') return await cmdDnsRecordsChange(rest, flags, 'add');
   if (group === 'records' && (action === 'remove' || action === 'delete')) return await cmdDnsRecordsChange(rest, flags, 'remove');
+  if (group === 'logging' && (action === 'status' || !action)) return await cmdDnsLoggingStatus(rest, flags);
+  if (group === 'logging' && action === 'enable') return await cmdDnsLoggingSet(rest, flags, 'enable');
+  if (group === 'logging' && action === 'disable') return await cmdDnsLoggingSet(rest, flags, 'disable');
   cli.die(
-    'usage:\n  gcloud dns zones list\n  gcloud dns zones create <name> --dns-name <domain.> --confirm\n  gcloud dns records list <zone> [--name N] [--type T]\n  gcloud dns records add <zone> <name> <type> <data>... [--ttl 300] --confirm\n  gcloud dns records remove <zone> <name> <type> --confirm',
+    'usage:\n  gcloud dns zones list\n  gcloud dns zones create <name> --dns-name <domain.> --confirm\n  gcloud dns records list <zone> [--name N] [--type T]\n  gcloud dns records add <zone> <name> <type> <data>... [--ttl 300] --confirm\n  gcloud dns records remove <zone> <name> <type> --confirm\n  gcloud dns logging status <zone>\n  gcloud dns logging enable <zone> --confirm\n  gcloud dns logging disable <zone> --confirm',
+    { prefix: 'gcloud' },
+  );
+}
+
+// ── Cloud Billing ────────────────────────────────────────────────────────────
+
+const BILLING_BASE = 'https://cloudbilling.googleapis.com/v1';
+
+/** Normalize an account id to the bare XXXX-XXXX-XXXX form (strip prefix). */
+function billingAccountId(raw) {
+  return (raw || '').replace(/^billingAccounts\//, '');
+}
+
+async function cmdBillingAccountsList(flags) {
+  const accounts = await gfetchAll(`${BILLING_BASE}/billingAccounts`, 'billingAccounts');
+  if (flags.json) { cli.out(accounts); return; }
+  if (!accounts.length) { console.log(c.dim('  No billing accounts accessible.')); return; }
+  console.log('');
+  for (const a of accounts) {
+    const open = a.open ? c.green('open') : c.dim('closed');
+    console.log(`  ${c.cyan(c.bold(a.displayName || a.name))}  ${c.dim(a.name)}  ${open}`);
+  }
+}
+
+async function cmdBillingAccountsDescribe(positional, flags) {
+  const id = billingAccountId(positional[0]);
+  if (!id) cli.die('usage: gcloud billing accounts describe <ACCOUNT_ID>', { prefix: 'gcloud' });
+  const a = await gfetch(`${BILLING_BASE}/billingAccounts/${encodeURIComponent(id)}`);
+  if (flags.json) { cli.out(a); return; }
+  console.log('');
+  console.log(`  ${c.cyan(c.bold(a.displayName || a.name))}`);
+  console.log(`  ${c.dim('name')}         ${a.name}`);
+  console.log(`  ${c.dim('open')}         ${a.open ? c.green('yes') : c.red('no')}`);
+  if (a.masterBillingAccount) console.log(`  ${c.dim('master')}       ${a.masterBillingAccount}`);
+}
+
+async function cmdBillingAccountsGetIamPolicy(positional, flags) {
+  const id = billingAccountId(positional[0]);
+  if (!id) cli.die('usage: gcloud billing accounts get-iam-policy <ACCOUNT_ID>', { prefix: 'gcloud' });
+  const policy = await gfetch(`${BILLING_BASE}/billingAccounts/${encodeURIComponent(id)}:getIamPolicy`, { method: 'POST', body: {} });
+  if (flags.json) { cli.out(policy); return; }
+  const bindings = policy.bindings || [];
+  if (!bindings.length) { console.log(c.dim('  No IAM bindings.')); return; }
+  console.log('');
+  for (const b of bindings) {
+    console.log(`  ${c.cyan(c.bold(b.role))}`);
+    for (const m of (b.members || [])) console.log(`      ${c.dim(m)}`);
+  }
+}
+
+async function cmdBillingProjectsList(positional, flags) {
+  const id = billingAccountId(positional[0]);
+  if (!id) cli.die('usage: gcloud billing projects list <ACCOUNT_ID>', { prefix: 'gcloud' });
+  const projects = await gfetchAll(`${BILLING_BASE}/billingAccounts/${encodeURIComponent(id)}/projects`, 'projectBillingInfo');
+  if (flags.json) { cli.out(projects); return; }
+  if (!projects.length) { console.log(c.dim('  No linked projects.')); return; }
+  console.log('');
+  for (const p of projects) {
+    const on = p.billingEnabled ? c.green('●') : c.dim('○');
+    console.log(`  ${on} ${c.cyan(c.bold(p.projectId))}  ${c.dim(p.billingAccountName || '')}`);
+  }
+}
+
+async function cmdBillingProjectsDescribe(positional, flags) {
+  const projectId = positional[0];
+  if (!projectId) cli.die('usage: gcloud billing projects describe <PROJECT_ID>', { prefix: 'gcloud' });
+  const info = await gfetch(`${BILLING_BASE}/projects/${encodeURIComponent(projectId)}/billingInfo`);
+  if (flags.json) { cli.out(info); return; }
+  console.log('');
+  console.log(`  ${c.cyan(c.bold(info.projectId || projectId))}`);
+  console.log(`  ${c.dim('billingAccountName')}  ${info.billingAccountName || c.dim('(none)')}`);
+  console.log(`  ${c.dim('billingEnabled')}      ${info.billingEnabled ? c.green('yes') : c.red('no')}`);
+}
+
+async function cmdBillingProjectsLink(positional, flags) {
+  const projectId = positional[0];
+  const account = billingAccountId(str(flags['billing-account']));
+  if (!projectId || !account) {
+    cli.die('usage: gcloud billing projects link <PROJECT_ID> --billing-account <ACCOUNT_ID> --confirm', { prefix: 'gcloud' });
+  }
+  const billingAccountName = `billingAccounts/${account}`;
+  if (!flags.confirm) {
+    console.log('');
+    console.log(c.yellow(`  Would LINK project ${c.bold(projectId)} to ${c.bold(billingAccountName)}.`));
+    console.log(c.dim('  Re-run with --confirm to apply.'));
+    return;
+  }
+  const info = await gfetch(
+    `${BILLING_BASE}/projects/${encodeURIComponent(projectId)}/billingInfo`,
+    { method: 'PUT', body: { billingAccountName } },
+  );
+  console.log(c.green(`✓ Linked ${c.bold(projectId)} to ${info.billingAccountName || billingAccountName}`) + c.dim(`  (billingEnabled: ${!!info.billingEnabled})`));
+}
+
+async function cmdBillingProjectsUnlink(positional, flags) {
+  const projectId = positional[0];
+  if (!projectId) cli.die('usage: gcloud billing projects unlink <PROJECT_ID> --confirm', { prefix: 'gcloud' });
+  if (!flags.confirm) {
+    console.log('');
+    console.log(c.yellow(`  Would UNLINK billing from project ${c.bold(projectId)} (disables billing).`));
+    console.log(c.dim('  Re-run with --confirm to apply.'));
+    return;
+  }
+  const info = await gfetch(
+    `${BILLING_BASE}/projects/${encodeURIComponent(projectId)}/billingInfo`,
+    { method: 'PUT', body: { billingAccountName: '' } },
+  );
+  console.log(c.green(`✓ Unlinked billing from ${c.bold(projectId)}`) + c.dim(`  (billingEnabled: ${!!info.billingEnabled})`));
+}
+
+async function cmdBilling(positional, flags) {
+  const group = positional[0];
+  const action = positional[1];
+  const rest = positional.slice(2);
+  if (group === 'accounts' && (action === 'list' || !action)) return await cmdBillingAccountsList(flags);
+  if (group === 'accounts' && action === 'describe') return await cmdBillingAccountsDescribe(rest, flags);
+  if (group === 'accounts' && action === 'get-iam-policy') return await cmdBillingAccountsGetIamPolicy(rest, flags);
+  if (group === 'projects' && (action === 'list' || !action)) return await cmdBillingProjectsList(rest, flags);
+  if (group === 'projects' && action === 'describe') return await cmdBillingProjectsDescribe(rest, flags);
+  if (group === 'projects' && action === 'link') return await cmdBillingProjectsLink(rest, flags);
+  if (group === 'projects' && action === 'unlink') return await cmdBillingProjectsUnlink(rest, flags);
+  cli.die(
+    'usage:\n  gcloud billing accounts list\n  gcloud billing accounts describe <ACCOUNT_ID>\n  gcloud billing accounts get-iam-policy <ACCOUNT_ID>\n  gcloud billing projects list <ACCOUNT_ID>\n  gcloud billing projects describe <PROJECT_ID>\n  gcloud billing projects link <PROJECT_ID> --billing-account <ACCOUNT_ID> --confirm\n  gcloud billing projects unlink <PROJECT_ID> --confirm',
     { prefix: 'gcloud' },
   );
 }
@@ -660,6 +823,17 @@ USAGE
   gcloud dns records list <zone> [--name N] [--type T]
   gcloud dns records add    <zone> <name> <type> <data>... [--ttl 300] --confirm
   gcloud dns records remove <zone> <name> <type> --confirm
+  gcloud dns logging status  <zone> [--project P]   Query-logging state for a zone
+  gcloud dns logging enable  <zone> [--project P] --confirm
+  gcloud dns logging disable <zone> [--project P] --confirm
+
+  gcloud billing accounts list                      Billing accounts you can access
+  gcloud billing accounts describe <ACCOUNT_ID>
+  gcloud billing accounts get-iam-policy <ACCOUNT_ID>
+  gcloud billing projects list <ACCOUNT_ID>         Projects linked to a billing account
+  gcloud billing projects describe <PROJECT_ID>     A project's billing link + state
+  gcloud billing projects link   <PROJECT_ID> --billing-account <ACCOUNT_ID> --confirm
+  gcloud billing projects unlink <PROJECT_ID> --confirm
 
   gcloud api [METHOD] <full-url> [--data <json>]    Authenticated raw call
 
@@ -701,6 +875,7 @@ async function main() {
     if (s === 'services') return await cmdServices(positional, flags);
     if (s === 'run') return await cmdRun(flags);
     if (s === 'dns') return await cmdDns(positional, flags);
+    if (s === 'billing') return await cmdBilling(positional, flags);
     if (s === 'api') return await cmdApi(positional, flags);
 
     cli.die(`unknown command: ${s}\nRun 'gcloud --help' for usage.`, { prefix: 'gcloud' });


### PR DESCRIPTION
## Summary

Adds a `gcloud` skill: a `.jsh` CLI implementing a useful subset of the Google Cloud REST APIs, authenticated the same way the real `gcloud` CLI authenticates — by driving Google's OAuth authorization-code flow against the **Cloud SDK's own public OAuth client** (`CLOUDSDK_CLIENT_ID` / `CLOUDSDK_CLIENT_NOTSOSECRET`), with the interactive browser step handled by `oauth-token --intercept`. No service-account key or pre-provisioned secret is needed; a human completes the standard Google consent screen once and tokens auto-refresh thereafter.

## Commands

- `login` / `whoami` / `logout` (revokes at Google)
- `config` / `config set-project <id>`
- `projects list`
- `instances list [--zone Z]` / `zones list` (Compute Engine)
- `buckets list` (Cloud Storage)
- `services list` / `services enable <api> --confirm` (Service Usage)
- `run list [--region R]` (Cloud Run)
- **`dns zones list` / `dns zones create` / `dns records list` / `dns records add` / `dns records remove`** (Cloud DNS — the primary use case; mutations are `--confirm`-gated with a colored diff preview; `add` is a transactional upsert)
- `api [METHOD] <url> [--data <json>]` — authenticated raw passthrough to any Google API

All commands support `--json`. Project resolves from `--project <id>` or `config set-project`.

## Live verification (against a real authenticated Google account)

- OAuth intercept → consent → code capture → token exchange → refresh-token storage: **verified**
- `whoami`, `projects list` (17 projects, paginated), `services list` (paginated + `state:ENABLED` filter), `config set-project`, `buckets list`, `api GET <project>`: **verified with real data**
- **Token auto-refresh**: forced cache expiry, next call silently minted a fresh token via the refresh grant: **verified**
- Error handling: `SERVICE_DISABLED` / `accessNotConfigured` now yield an actionable `services enable …` hint (not a misleading "session expired"); genuine token failures route to re-login; other errors print a concise `status: message`: **verified against disabled Compute/Run/DNS APIs**

Cloud DNS was disabled on all of the test account's projects, so the DNS record-mutation happy path was exercised only through its preview/validation and shared fetch layer (same code path as the verified `projects`/`services` calls); `services enable` provides the one-step unblock.

## Notes

- Follows the repo's `.jsh` conventions (garmin is the token-lifecycle reference): `sliccy:` bridges, single `gfetch`/`gfetchAll` wrapper, NodeExitError re-throw, `(await skill.config()) || {}`.
- The runtime's `parseFlags` treats single-dash short flags as booleans and never captures a following value, so only long flags with values are offered (`--project X`, `--zone X`, …); a `str()` guard prevents a value-less flag from leaking the string `"true"` into a URL.
- Security: the authorization `code` is exchanged inside the script and never printed; tokens live in skill config (never stdout); `logout` revokes the refresh token. The flow does not use PKCE (intercept mode can't inject an authorize-side `code_challenge`) — see the gmail skill's `references/oauth-bootstrap.md` for the public-client trade-off discussion.
