### PR TITLE
ci: lint .jsh skills with @ai-ecoverse/biome-jsh (drop the temp-.js mirror hack)

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -1,9 +1,11 @@
 name: Lint (Biome)
 
-# Lints the repo's .jsh/.bsh skill scripts with Biome. Biome's CLI ignores the
-# .jsh/.bsh extensions in file mode, so tools/lint-jsh.sh mirrors each script to
-# a temporary .js file and lints those against biome.json. Complements the
-# Tessl skill-lint workflows, which validate skill *content* rather than JS.
+# Lints the repo's .jsh/.bsh skill scripts with @ai-ecoverse/biome-jsh, a
+# jsh-aware Biome runner (wraps each AsyncFunction body so top-level await/return
+# don't trip a false parse error, discovers biome.json, and shifts diagnostics
+# back onto the real file). tools/lint-jsh.sh collects the .jsh/.bsh files and
+# runs `biome-jsh lint`. Complements the Tessl skill-lint workflows, which
+# validate skill *content* rather than JS.
 
 on:
   push:
@@ -24,7 +26,7 @@ jobs:
         with:
           node-version: 22
 
-      - name: Install Biome
+      - name: Install dependencies
         run: npm install
 
       - name: Lint .jsh/.bsh skills

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "check": "biome check"
   },
   "devDependencies": {
+    "@ai-ecoverse/biome-jsh": "5.67.0",
     "@biomejs/biome": "2.5.5"
   }
 }

--- a/tools/lint-jsh.sh
+++ b/tools/lint-jsh.sh
@@ -1,43 +1,41 @@
 #!/usr/bin/env bash
 #
-# Lint the repo's `.jsh` / `.bsh` skill scripts with Biome.
+# Lint the repo's `.jsh` / `.bsh` skill scripts with @ai-ecoverse/biome-jsh — a
+# jsh-aware Biome runner that wraps each AsyncFunction body before Biome parses
+# it (so top-level `await`/`return` don't raise a false "return outside of a
+# function" error), discovers this repo's biome.json, and shifts diagnostics
+# back onto the real file.
 #
-# Biome's CLI recognises files by extension: in file mode it silently ignores
-# `.jsh`/`.bsh`, and in stdin mode it emits no diagnostics. So we mirror each
-# script to a temporary `.js` file and lint those with the repo's biome.json
-# (passed via --config-path). The SLICC biome shim already treats `.jsh`/`.bsh`
-# as JavaScript; once the Biome CLI does too, this reduces to `biome check .`.
+# Scoped to `.jsh`/`.bsh`; the `.js`/`.ts` tooling is not gated here. `lint`
+# (not `check`) is used deliberately — it runs only the linter, so legacy skills
+# are not failed on formatting.
 #
-# Exit code is Biome's: non-zero if any error-level diagnostic is found.
+# Exit code is biome-jsh's: non-zero if any error-level diagnostic is found.
 set -uo pipefail
 
-repo_root="$(cd "$(dirname "$0")/.." && pwd)"
-cd "$repo_root"
+cd "$(dirname "$0")/.."
 
-biome="${BIOME:-npx --no-install @biomejs/biome}"
-tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"' EXIT
-
-count=0
+# Collect .jsh/.bsh, skipping files Biome ignores anyway. Biome's default
+# maxSize is 1 MiB; larger files (e.g. generated bundles like xlsx.jsh) are
+# silently skipped by Biome, so exclude them here rather than have the per-file
+# runner report them as unprocessable. The ${#arr[@]} guard keeps an empty
+# array safe under `set -u` (bash < 4.4).
+max_size=1048576
+files=()
 while IFS= read -r f; do
-  # mirror path with '/' -> '@' so temp names round-trip back to real paths
-  key="$(printf '%s' "$f" | tr '/' '@')"
-  key="${key%.*}.js"
-  cp "$f" "$tmp/$key"
-  count=$((count + 1))
+  size=$(wc -c <"$f" 2>/dev/null || echo 0)
+  if [ "$size" -gt "$max_size" ]; then
+    echo "lint-jsh: skipping $f (${size}B > ${max_size}B Biome maxSize)" >&2
+    continue
+  fi
+  files+=("$f")
 done < <(git ls-files '*.jsh' '*.bsh')
-
-if [ "$count" -eq 0 ]; then
+if [ "${#files[@]}" -eq 0 ]; then
   echo "lint-jsh: no .jsh/.bsh files found"
   exit 0
 fi
 
-# Lint the mirrors with this repo's config; rewrite temp names back to real paths.
-out="$($biome lint --config-path "$repo_root" "$tmp" 2>&1)"
-code=$?
-printf '%s\n' "$out" | sed -E "s#${tmp}/##g; s#([A-Za-z0-9._@-]+)\.js#\1#g; s#@#/#g"
-
-if [ "$code" -eq 0 ]; then
-  echo "lint-jsh: $count .jsh/.bsh file(s) clean (no error-level diagnostics)"
-fi
-exit "$code"
+# BIOME_JSH overrides the runner (e.g. a local checkout) for testing.
+biomejsh="${BIOME_JSH:-npx --no-install @ai-ecoverse/biome-jsh}"
+# shellcheck disable=SC2086
+exec $biomejsh lint "${files[@]}"


### PR DESCRIPTION
## What

Switches the `.jsh`/`.bsh` skill lint to the published **`@ai-ecoverse/biome-jsh@5.67.0`** runner (from ai-ecoverse/slicc#1642 + #1650) and **deletes the temp-`.js` mirror hack**.

Before, `tools/lint-jsh.sh` copied every `.jsh` to a temporary `.js`, ran `biome lint --config-path …`, and demangled the paths back — because Biome's CLI ignores `.jsh` and, worse, a naive rename makes it emit a bogus `Illegal return statement outside of a function` on the top-level `await`/`return` that jsh scripts legitimately use.

`biome-jsh` now owns all of that: it wraps each body in an `async function` before Biome parses it, discovers `biome.json`, and shifts diagnostics back onto the real file. The script is now a thin collector.

## Details

- devDep **`@ai-ecoverse/biome-jsh@5.67.0`** (installed via `@biomejs/biome@2.5.5`, already present).
- Uses **`biome-jsh lint`** (not `check`) — lint-only, so legacy skills aren't retroactively failed on formatting (matches prior behavior).
- Scoped to `.jsh`/`.bsh` (the `.js` tooling isn't gated), and skips files over Biome's **1 MiB `maxSize`** — e.g. the generated 1.25 MB `xlsx.jsh` bundle — exactly as the batch run silently did.
- `.github/workflows/biome.yml` unchanged in shape (`npm install` → `npm run lint:jsh`); only comments/step name updated.

## Verification

`biome-jsh lint` over the 32 in-range `.jsh` files → **0 errors, 120 warnings, exit 0** — byte-for-byte the old hack's result. No temp files left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
