### PR TITLE
feat(elevenlabs): TTS, STT (Scribe), and raw ElevenLabs API skill

### DIFF
--- a/skills/elevenlabs/SKILL.md
+++ b/skills/elevenlabs/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: elevenlabs
+description: Text-to-speech, speech-to-text, and the raw ElevenLabs API from the command line. Use when the user wants realistic AI voices, to speak/read text aloud with a specific voice, generate voiceovers or narration, list or pick ElevenLabs voices, transcribe an audio or video file to text (with word timestamps or speaker diarization), or call any ElevenLabs API endpoint. Provides `eleven` (raw API + convenience), `say-11` (an ElevenLabs-backed drop-in for the built-in `say`), and `hear-11` (Scribe speech-to-text, a file-based counterpart to `hear`). Triggers on "ElevenLabs", "text to speech", "TTS", "read this aloud", "say this in <voice>", "voiceover", "narration", "clone a voice", "transcribe", "speech to text", "STT", "Scribe".
+metadata:
+  tags: elevenlabs, tts, text-to-speech, stt, speech-to-text, voice, audio, transcription, scribe
+allowed-tools: bash
+---
+
+# ElevenLabs
+
+Three commands, backed by the ElevenLabs API:
+
+- **`eleven`** — raw API client + convenience subcommands (voices, models, tts, stt, api passthrough).
+- **`say-11`** — speak text aloud (or to a file) with an ElevenLabs voice. Drop-in for the built-in `say`.
+- **`hear-11`** — transcribe an audio/video **file** with ElevenLabs Scribe. File-based counterpart to `hear`.
+
+## Setup (API key)
+
+Store the key once — it is saved in the skill's `scripts/.config` (git-ignored; never commit it):
+
+```bash
+eleven auth <your-key>      # or: export ELEVENLABS_API_KEY=<key>, or pass --key <key>
+eleven auth --show          # verify (masked)
+```
+
+Auth priority for every command: `--key` flag → `ELEVENLABS_API_KEY` env → stored config.
+
+Note: API keys are scoped. A key without the `user_read` permission will 401 on `eleven user`
+but still work for TTS/STT/voices — that's expected.
+
+## say-11 — speak text (replaces `say`)
+
+Same interface as the built-in `say`:
+
+```bash
+say-11 "Hello there"                     # synthesize + play aloud (default voice: Rachel)
+say-11 -v Sarah "Reading in Sarah's voice"   # -v = voice name (partial match) or voice_id
+say-11 -o out.mp3 "Save instead of play"     # -o writes MP3 to a file
+say-11 -r 1.25 "A little faster"             # -r playback rate (applied via afplay)
+say-11 -m eleven_turbo_v2_5 "Low latency"    # -m model id
+say-11 --list                                # list voices
+```
+
+Output is MP3 (ElevenLabs' native format). On success it plays and prints nothing to stdout
+(a short byte note goes to stderr), matching `say`'s quiet behavior.
+
+## hear-11 — transcribe a file (Scribe STT)
+
+```bash
+hear-11 recording.mp3                     # prints the transcript
+hear-11 -i recording.m4a -l en            # -i file, -l language hint (ISO 639)
+hear-11 clip.mp4 --words                  # word-level timestamps
+hear-11 meeting.mp3 --diarize             # label speakers (speaker_0, speaker_1, …)
+hear-11 clip.wav --json                   # full JSON (words, timings, speakers)
+```
+
+**Does NOT record the microphone** — ElevenLabs STT needs a file. For live mic input use the
+built-in `hear`, then transcribe the resulting file here.
+
+## eleven — raw API + convenience
+
+```bash
+eleven voices [--search rachel] [--json]  # list / filter voices
+eleven models [--json]                    # list TTS models
+eleven tts "text" [--voice v] [--model m] [--out f] [--format fmt] [--play]
+eleven stt <file> [--lang xx] [--diarize] [--num-speakers n] [--json]
+eleven user                               # subscription (needs user_read scope)
+eleven config [--voice <id|name>] [--model <id>] [--stability n] [--similarity n] [--style n]  # per-user defaults
+eleven api <METHOD> <path> [--data '<json>'] [--query k=v]   # any endpoint
+```
+
+Examples:
+
+```bash
+eleven api GET /voices/settings/default
+eleven api POST /text-to-speech/21m00Tcm4TlvDq8ikWAM --data '{"text":"hi","model_id":"eleven_multilingual_v2"}'
+eleven config --voice "George" --model eleven_multilingual_v2   # persist defaults
+```
+
+## Defaults
+
+- Voice: `21m00Tcm4TlvDq8ikWAM` (Rachel) unless overridden or set via `eleven config --voice`.
+- Voice settings (stability / similarity_boost / style, each 0–1) can be tuned per call
+  (`say-11 --stability 0.3 --style 0.4 --similarity 0.9`) or persisted per user via `eleven config`.
+  Lower stability = more expressive/variable; higher similarity = closer to the source voice;
+  higher style = more expressive delivery. These are personal settings in `.config`, not skill defaults.
+- TTS model: `eleven_multilingual_v2` (auto-detects language). Alternatives: `eleven_turbo_v2_5`
+  / `eleven_flash_v2_5` (low latency), `eleven_v3` (newest).
+- STT model: `scribe_v1`.
+
+## Notes / gotchas
+
+- The key is stored in `scripts/.config` (git-ignored). Rotate with `eleven auth <newkey>`.
+- TTS returns binary audio; the tools fetch it and write faithful MP3 via the VFS binary bridge.
+- STT uploads a multipart file via `curl` (the proxied `fetch` cannot send binary bodies).
+- `-v`, `-o`, `-r`, `-l`, `-i`, `-m` are single-dash value flags — the tools hand-parse argv
+  because the runtime's `parseFlags()` treats single-dash flags as booleans.
+- Playback uses the built-in `afplay`; `say-11 -o file` skips playback and just writes the file.

--- a/skills/elevenlabs/SKILL.md
+++ b/skills/elevenlabs/SKILL.md
@@ -66,12 +66,15 @@ eleven tts "text" [--voice v] [--model m] [--out f] [--format fmt] [--play]
 eleven stt <file> [--lang xx] [--diarize] [--num-speakers n] [--json]
 eleven user                               # subscription (needs user_read scope)
 eleven config [--voice <id|name>] [--model <id>] [--stability n] [--similarity n] [--style n]  # per-user defaults
-eleven api <METHOD> <path> [--data '<json>'] [--query k=v]   # any endpoint
+eleven api <METHOD> <path> [--data '<json>'] [--query k=v] [--out <file>]   # any endpoint
 ```
 
 Examples:
 
 ```bash
+# Binary responses (e.g. text-to-speech audio) are written to a file, not printed:
+eleven api POST /text-to-speech/21m00Tcm4TlvDq8ikWAM --data '{"text":"hi","model_id":"eleven_multilingual_v2"}' --out /tmp/hi.mp3
+
 eleven api GET /voices/settings/default
 eleven api POST /text-to-speech/21m00Tcm4TlvDq8ikWAM --data '{"text":"hi","model_id":"eleven_multilingual_v2"}'
 eleven config --voice "George" --model eleven_multilingual_v2   # persist defaults

--- a/skills/elevenlabs/scripts/.gitignore
+++ b/skills/elevenlabs/scripts/.gitignore
@@ -1,0 +1,3 @@
+# Holds the ElevenLabs API key — never commit.
+.config
+.env

--- a/skills/elevenlabs/scripts/eleven.jsh
+++ b/skills/elevenlabs/scripts/eleven.jsh
@@ -1,0 +1,145 @@
+// eleven.jsh — raw ElevenLabs API client + convenience subcommands.
+//
+//   eleven auth <key>                 store API key in skill config
+//   eleven auth --show                show masked stored key
+//   eleven config                     show effective config (voice/model)
+//   eleven config --voice <id|name> --model <id>   set defaults
+//   eleven user                       GET /user (needs user_read scope)
+//   eleven voices [--search <q>] [--json]
+//   eleven models [--json]
+//   eleven tts <text> [--voice v] [--model m] [--out f] [--format fmt]
+//   eleven stt <file> [--model m] [--lang xx] [--diarize] [--json]
+//   eleven api <METHOD> <path> [--data '<json>'] [--query k=v ...] [--raw]
+//
+// Auth priority: --key | ELEVENLABS_API_KEY | skill config.
+
+const cli = require('sliccy:cli');
+const fmt = require('sliccy:fmt');
+const fs  = require('fs');
+const L   = require('./elevenlib.jsh');
+
+function str(v) { return typeof v === 'string' ? v : undefined; }
+const HELP = `eleven — ElevenLabs API
+
+  eleven auth <key> | --show
+  eleven config [--voice <id|name>] [--model <id>]
+  eleven user
+  eleven voices [--search <q>] [--json]
+  eleven models [--json]
+  eleven tts <text> [--voice v] [--model m] [--out file] [--format fmt] [--play]
+  eleven stt <file> [--model m] [--lang xx] [--diarize] [--num-speakers n] [--json]
+  eleven api <METHOD> <path> [--data '<json>'] [--query k=v]
+
+Auth: --key <k> | ELEVENLABS_API_KEY | \`eleven auth <key>\` (stored in skill config).`;
+
+async function main() {
+  const { positional, flags } = process.argv.parseFlags();
+  const [cmd] = positional;
+
+  if (!cmd || flags.help || flags.h) return cli.help(HELP);
+
+  // auth doesn't need an existing key
+  if (cmd === 'auth') {
+    if (flags.show) {
+      const cfg = await L.loadConfig();
+      if (!cfg.apiKey) return cli.out('No key stored.');
+      const k = cfg.apiKey;
+      return cli.out(`Stored key: ${k.slice(0, 6)}…${k.slice(-4)}`);
+    }
+    const key = str(flags.key) || positional[1];
+    if (!key) return cli.die('usage: eleven auth <key>  (or: eleven auth --show)');
+    await L.saveConfig({ apiKey: key });
+    return cli.out('API key saved to skill config.');
+  }
+
+  if (cmd === 'config') {
+    const updates = {};
+    if (str(flags.voice)) updates.defaultVoice = await L.resolveVoice(await L.getKey(str(flags.key)), str(flags.voice));
+    if (str(flags.model)) updates.defaultModel = str(flags.model);
+    // Optional per-user voice settings (stored in git-ignored .config, not the skill).
+    const cur = await L.loadConfig();
+    const vs = { ...(cur.voiceSettings || {}) };
+    if (str(flags.stability) != null) vs.stability = Number(flags.stability);
+    if (str(flags.similarity) != null) vs.similarity_boost = Number(flags.similarity);
+    if (str(flags.style) != null) vs.style = Number(flags.style);
+    if (flags['clear-settings']) { updates.voiceSettings = undefined; }
+    else if (Object.keys(vs).length && (str(flags.stability) != null || str(flags.similarity) != null || str(flags.style) != null)) {
+      updates.voiceSettings = vs;
+    }
+    if (Object.keys(updates).length) await L.saveConfig(updates);
+    const cfg = await L.loadConfig();
+    return cli.out({
+      defaultVoice: cfg.defaultVoice || L.DEFAULT_VOICE,
+      defaultModel: cfg.defaultModel || L.DEFAULT_MODEL,
+      voiceSettings: cfg.voiceSettings || null,
+      keyStored: Boolean(cfg.apiKey),
+    });
+  }
+
+  const key = await L.getKey(str(flags.key));
+
+  switch (cmd) {
+    case 'user': {
+      const j = await L.api(key, 'GET', '/user');
+      return cli.out(j);
+    }
+    case 'voices': {
+      let voices = await L.listVoices(key);
+      const q = str(flags.search);
+      if (q) voices = voices.filter((v) => v.name?.toLowerCase().includes(q.toLowerCase()));
+      if (flags.json) return cli.out(voices);
+      const rows = [['voice_id', 'name', 'category']];
+      for (const v of voices) rows.push([v.voice_id, fmt.trunc(v.name || '', 40), v.category || '']);
+      return cli.out(fmt.table(rows));
+    }
+    case 'models': {
+      const j = await L.api(key, 'GET', '/models');
+      if (flags.json) return cli.out(j);
+      const rows = [['model_id', 'name', 'tts', 'langs']];
+      for (const m of j) rows.push([m.model_id, fmt.trunc(m.name || '', 34), m.can_do_text_to_speech ? 'y' : '-', String((m.languages || []).length)]);
+      return cli.out(fmt.table(rows));
+    }
+    case 'tts': {
+      const text = positional.slice(1).join(' ') || str(flags.text);
+      if (!text) return cli.die('usage: eleven tts <text> [--voice v] [--out file]');
+      const voiceId = await L.resolveVoice(key, str(flags.voice));
+      const cfg = await L.loadConfig();
+      const buf = await L.tts(key, { text, voiceId, modelId: str(flags.model) || cfg.defaultModel, outputFormat: str(flags.format), voiceSettings: cfg.voiceSettings });
+      const out = str(flags.out) || str(flags.o);
+      if (out) { await fs.writeFileBinary(out, buf); return cli.out(`Wrote ${buf.length} bytes to ${out}`); }
+      // no --out: write temp and (optionally) play
+      const tmp = `/tmp/eleven-tts-${Date.now()}.mp3`;
+      await fs.writeFileBinary(tmp, buf);
+      if (flags.play) { await L.play(tmp); return cli.out(`Played (${buf.length} bytes).`); }
+      return cli.out(`Wrote ${buf.length} bytes to ${tmp}  (add --play to hear it, or use say-11)`);
+    }
+    case 'stt': {
+      const file = positional[1] || str(flags.file) || str(flags.i);
+      if (!file) return cli.die('usage: eleven stt <file> [--lang xx] [--diarize] [--json]');
+      const j = await L.stt(key, {
+        file, modelId: str(flags.model),
+        languageCode: str(flags.lang) || str(flags.l),
+        diarize: Boolean(flags.diarize),
+        numSpeakers: str(flags['num-speakers']),
+      });
+      if (flags.json) return cli.out(j);
+      return cli.out(j.text || '');
+    }
+    case 'api': {
+      const method = (positional[1] || 'GET').toUpperCase();
+      const path = positional[2];
+      if (!path) return cli.die('usage: eleven api <METHOD> <path> [--data \'<json>\'] [--query k=v]');
+      let body;
+      const data = str(flags.data);
+      if (data) { try { body = JSON.parse(data); } catch { body = data; } }
+      const query = {};
+      if (str(flags.query)) { const [k, ...r] = str(flags.query).split('='); query[k] = r.join('='); }
+      const j = await L.api(key, method, path, { body, query });
+      return cli.out(j);
+    }
+    default:
+      return cli.die(`unknown command: ${cmd}\n\n${HELP}`);
+  }
+}
+
+await main().catch((e) => cli.die(e.message + (e.status ? ` (HTTP ${e.status})` : ''), { prefix: 'eleven' }));

--- a/skills/elevenlabs/scripts/eleven.jsh
+++ b/skills/elevenlabs/scripts/eleven.jsh
@@ -104,7 +104,7 @@ async function main() {
       if (!text) return cli.die('usage: eleven tts <text> [--voice v] [--out file]');
       const voiceId = await L.resolveVoice(key, str(flags.voice));
       const cfg = await L.loadConfig();
-      const buf = await L.tts(key, { text, voiceId, modelId: str(flags.model) || cfg.defaultModel, outputFormat: str(flags.format), voiceSettings: cfg.voiceSettings });
+      const buf = await L.tts(key, { text, voiceId, modelId: str(flags.model) || cfg.defaultModel, outputFormat: str(flags.format), voiceSettings: cfg.voiceSettings, languageCode: str(flags.lang) || str(flags.l) });
       const out = str(flags.out) || str(flags.o);
       if (out) { await fs.writeFileBinary(out, buf); return cli.out(`Wrote ${buf.length} bytes to ${out}`); }
       // no --out: write temp and (optionally) play
@@ -135,6 +135,14 @@ async function main() {
       const query = {};
       if (str(flags.query)) { const [k, ...r] = str(flags.query).split('='); query[k] = r.join('='); }
       const j = await L.api(key, method, path, { body, query });
+      // Binary responses (e.g. audio from text-to-speech) come back as raw bytes —
+      // write them to a file instead of printing corrupted text.
+      if (j && j.__binary) {
+        const ext = /mpeg|mp3/.test(j.contentType) ? 'mp3' : /wav/.test(j.contentType) ? 'wav' : /json/.test(j.contentType) ? 'json' : 'bin';
+        const out = str(flags.out) || str(flags.o) || `/tmp/eleven-api-${Date.now()}.${ext}`;
+        await fs.writeFileBinary(out, j.buffer);
+        return cli.out(`Wrote ${j.buffer.length} bytes (${j.contentType}) to ${out}`);
+      }
       return cli.out(j);
     }
     default:

--- a/skills/elevenlabs/scripts/elevenlib.jsh
+++ b/skills/elevenlabs/scripts/elevenlib.jsh
@@ -1,0 +1,142 @@
+// elevenlib.jsh — shared helpers for the ElevenLabs skill.
+// Required (not run directly) by eleven.jsh, say-11.jsh, hear-11.jsh.
+//
+// Auth: the API key is read (in priority order) from an explicit key arg,
+// the ELEVENLABS_API_KEY env var, or skill config (`eleven auth <key>`).
+// Never hard-code the key.
+
+const skill = require('sliccy:skill');
+const { exec } = require('sliccy:exec');
+
+const BASE = 'https://api.elevenlabs.io/v1';
+const DEFAULT_VOICE = '21m00Tcm4TlvDq8ikWAM'; // "Rachel" (premade)
+const DEFAULT_MODEL = 'eleven_multilingual_v2';
+const DEFAULT_STT_MODEL = 'scribe_v1';
+
+// ─── config ──────────────────────────────────────────────────────────────
+async function loadConfig() {
+  // skill.config() returns a Promise (always truthy) — await before `|| {}`.
+  return (await skill.config()) || {};
+}
+async function saveConfig(updates) {
+  await skill.config({ ...(await loadConfig()), ...updates });
+}
+
+async function getKey(explicit) {
+  const k = (typeof explicit === 'string' && explicit) ||
+            process.env.ELEVENLABS_API_KEY ||
+            (await loadConfig()).apiKey;
+  if (!k) {
+    throw new Error(
+      'No ElevenLabs API key. Set one with `eleven auth <key>`, ' +
+      'or pass --key, or export ELEVENLABS_API_KEY.');
+  }
+  return k;
+}
+
+// ─── raw JSON api ──────────────────────────────────────────────────────────
+// method/path e.g. ('GET', '/voices'). body: object (JSON) or undefined.
+// Returns parsed JSON, or throws Error with the API message on non-2xx.
+async function api(key, method, path, { body, query } = {}) {
+  let url = path.startsWith('http') ? path : BASE + (path.startsWith('/') ? path : '/' + path);
+  if (query && Object.keys(query).length) {
+    const qs = new URLSearchParams(query).toString();
+    url += (url.includes('?') ? '&' : '?') + qs;
+  }
+  const headers = { 'xi-api-key': key };
+  let payload;
+  if (body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+    payload = typeof body === 'string' ? body : JSON.stringify(body);
+  }
+  const res = await fetch(url, { method, headers, body: payload });
+  const text = await res.text();
+  let json;
+  try { json = text ? JSON.parse(text) : {}; } catch { json = { raw: text }; }
+  if (!res.ok) {
+    const msg = json?.detail?.message || json?.detail || json?.message || text || res.statusText;
+    const err = new Error(typeof msg === 'string' ? msg : JSON.stringify(msg));
+    err.status = res.status;
+    throw err;
+  }
+  return json;
+}
+
+// ─── voices ─────────────────────────────────────────────────────────────────
+async function listVoices(key) {
+  const j = await api(key, 'GET', '/voices');
+  return j.voices || [];
+}
+
+// Accept a raw voice_id (20-char token) or resolve a (partial, case-insensitive)
+// name to an id via /voices. Falls back to the configured/default voice.
+function looksLikeVoiceId(v) { return /^[A-Za-z0-9]{20}$/.test(v || ''); }
+
+async function resolveVoice(key, nameOrId) {
+  const cfg = await loadConfig();
+  if (!nameOrId) return cfg.defaultVoice || DEFAULT_VOICE;
+  if (looksLikeVoiceId(nameOrId)) return nameOrId;
+  const voices = await listVoices(key);
+  const q = String(nameOrId).toLowerCase();
+  const exact = voices.find((v) => v.name?.toLowerCase() === q);
+  if (exact) return exact.voice_id;
+  const partial = voices.find((v) => v.name?.toLowerCase().includes(q));
+  if (partial) return partial.voice_id;
+  throw new Error(`No voice matching "${nameOrId}". Try \`eleven voices --search ${nameOrId}\`.`);
+}
+
+// ─── TTS (binary response is faithful over the proxied fetch) ────────────────
+// Returns a Buffer of audio bytes.
+async function tts(key, { text, voiceId, modelId, outputFormat, voiceSettings }) {
+  const q = outputFormat ? { output_format: outputFormat } : undefined;
+  const url = `${BASE}/text-to-speech/${voiceId || DEFAULT_VOICE}` +
+    (q ? '?' + new URLSearchParams(q).toString() : '');
+  const payload = { text, model_id: modelId || DEFAULT_MODEL };
+  if (voiceSettings && Object.keys(voiceSettings).length) payload.voice_settings = voiceSettings;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'xi-api-key': key, 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    let msg; try { const j = JSON.parse(await res.text()); msg = j?.detail?.message || j?.detail || j?.message; } catch {}
+    const err = new Error(msg || `TTS failed (HTTP ${res.status})`);
+    err.status = res.status; throw err;
+  }
+  return Buffer.from(await res.arrayBuffer());
+}
+
+// ─── STT (multipart binary upload — proxied fetch can't send binary bodies,
+//     so shell out to curl via exec.spawn; args are not shell-interpolated) ──
+async function stt(key, { file, modelId, languageCode, diarize, numSpeakers }) {
+  const args = ['-s', '-X', 'POST', `${BASE}/speech-to-text`,
+    '-H', `xi-api-key: ${key}`,
+    '-F', `model_id=${modelId || DEFAULT_STT_MODEL}`,
+    '-F', `file=@${file}`];
+  if (languageCode) args.push('-F', `language_code=${languageCode}`);
+  if (diarize) args.push('-F', 'diarize=true');
+  if (numSpeakers) args.push('-F', `num_speakers=${numSpeakers}`);
+  const { stdout, exitCode } = await exec.spawn(['curl', ...args]);
+  if (exitCode !== 0) throw new Error(`curl failed (exit ${exitCode}): ${stdout}`);
+  let j; try { j = JSON.parse(stdout); } catch { throw new Error(`Unexpected STT response: ${stdout.slice(0, 300)}`); }
+  if (j?.detail) {
+    const msg = j.detail?.message || j.detail;
+    throw new Error(typeof msg === 'string' ? msg : JSON.stringify(msg));
+  }
+  return j;
+}
+
+async function play(file, { rate, volume } = {}) {
+  const args = ['afplay'];
+  if (volume != null) args.push('-v', String(volume));
+  if (rate != null) args.push('-r', String(rate));
+  args.push(file);
+  return exec.spawn(args);
+}
+
+module.exports = {
+  BASE, DEFAULT_VOICE, DEFAULT_MODEL, DEFAULT_STT_MODEL,
+  loadConfig, saveConfig, getKey, api,
+  listVoices, resolveVoice, looksLikeVoiceId,
+  tts, stt, play,
+};

--- a/skills/elevenlabs/scripts/elevenlib.jsh
+++ b/skills/elevenlabs/scripts/elevenlib.jsh
@@ -50,6 +50,19 @@ async function api(key, method, path, { body, query } = {}) {
     payload = typeof body === 'string' ? body : JSON.stringify(body);
   }
   const res = await fetch(url, { method, headers, body: payload });
+  const ct = res.headers.get('content-type') || '';
+  // Non-JSON responses (e.g. audio/mpeg from text-to-speech) must NOT be run
+  // through res.text() or they get corrupted. Return the raw bytes instead so
+  // the caller (e.g. `eleven api`) can write a usable file.
+  if (!ct.includes('json')) {
+    const buffer = Buffer.from(await res.arrayBuffer());
+    if (!res.ok) {
+      const err = new Error(buffer.slice(0, 300).toString() || res.statusText);
+      err.status = res.status;
+      throw err;
+    }
+    return { __binary: true, contentType: ct, buffer, status: res.status };
+  }
   const text = await res.text();
   let json;
   try { json = text ? JSON.parse(text) : {}; } catch { json = { raw: text }; }
@@ -87,12 +100,15 @@ async function resolveVoice(key, nameOrId) {
 
 // ─── TTS (binary response is faithful over the proxied fetch) ────────────────
 // Returns a Buffer of audio bytes.
-async function tts(key, { text, voiceId, modelId, outputFormat, voiceSettings }) {
+async function tts(key, { text, voiceId, modelId, outputFormat, voiceSettings, languageCode }) {
   const q = outputFormat ? { output_format: outputFormat } : undefined;
   const url = `${BASE}/text-to-speech/${voiceId || DEFAULT_VOICE}` +
     (q ? '?' + new URLSearchParams(q).toString() : '');
   const payload = { text, model_id: modelId || DEFAULT_MODEL };
   if (voiceSettings && Object.keys(voiceSettings).length) payload.voice_settings = voiceSettings;
+  // Enforce a language when requested (-l). Supported by Turbo/Flash v2.5 and v3;
+  // accepted (no-op) by multilingual v2.
+  if (languageCode) payload.language_code = languageCode;
   const res = await fetch(url, {
     method: 'POST',
     headers: { 'xi-api-key': key, 'Content-Type': 'application/json' },

--- a/skills/elevenlabs/scripts/hear-11.jsh
+++ b/skills/elevenlabs/scripts/hear-11.jsh
@@ -1,0 +1,85 @@
+// hear-11.jsh — ElevenLabs Scribe (speech-to-text) replacement for `hear`.
+// Mirrors the file path of `hear`:  hear-11 [-i file] [-l lang] <file>
+//
+//   hear-11 <file>                 transcribe an audio/video file
+//   hear-11 -i <file> -l en        with a language hint
+//   hear-11 <file> --diarize       label speakers
+//   hear-11 <file> --json          full JSON (words, timestamps, speakers)
+//   hear-11 <file> --words         word-level timestamps (compact)
+//
+// NOTE: unlike the built-in `hear`, this does NOT capture the microphone —
+// ElevenLabs STT works on a file. Record/produce a file first (or use the
+// built-in `hear` for live mic input), then transcribe it here.
+//
+// Single-dash value flags (-i -l -m) are hand-parsed (parseFlags drops them).
+
+const cli = require('sliccy:cli');
+const fs  = require('fs');
+const L   = require('./elevenlib.jsh');
+
+const HELP = `hear-11 — transcribe audio with ElevenLabs Scribe (file-based)
+
+  hear-11 <file>                 transcribe (prints text)
+  hear-11 -i <file>              same (\`hear\`-style flag)
+  hear-11 <file> -l <lang>       language hint (ISO 639, e.g. en, de)
+  hear-11 <file> --diarize [--num-speakers n]   label speakers
+  hear-11 <file> --words         word-level timestamps
+  hear-11 <file> --json          full JSON response
+  hear-11 <file> -m <model>      model id (default scribe_v1)
+  --key <k>   override API key
+
+Does NOT record the mic — give it an audio/video file. For live mic capture
+use the built-in \`hear\`, then transcribe the recording here.`;
+
+function parse(argv) {
+  const valueFlags = { '-i': 'file', '--file': 'file', '-l': 'lang', '--lang': 'lang',
+    '-m': 'model', '--model': 'model', '--num-speakers': 'numSpeakers', '--key': 'key' };
+  const boolFlags = { '--diarize': 'diarize', '--words': 'words', '--json': 'json', '-h': 'help', '--help': 'help' };
+  const opts = {}; const rest = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (Object.prototype.hasOwnProperty.call(valueFlags, a)) { opts[valueFlags[a]] = argv[++i]; }
+    else if (a.startsWith('--') && a.includes('=')) { const [k, ...v] = a.slice(2).split('='); opts[k] = v.join('='); }
+    else if (Object.prototype.hasOwnProperty.call(boolFlags, a)) { opts[boolFlags[a]] = true; }
+    else rest.push(a);
+  }
+  return { opts, file: opts.file || rest[0] };
+}
+
+async function main() {
+  const { opts, file } = parse(process.argv.slice(2));
+  if (opts.help) return cli.help(HELP);
+  if (!file) return cli.die('no input file.\n\n' + HELP);
+  if (!(await fs.exists(file))) return cli.die(`file not found: ${file}`);
+
+  const key = await L.getKey(opts.key);
+  const j = await L.stt(key, {
+    file, modelId: opts.model, languageCode: opts.lang,
+    diarize: Boolean(opts.diarize), numSpeakers: opts.numSpeakers,
+  });
+
+  if (opts.json) return cli.out(j);
+
+  if (opts.words) {
+    const lines = (j.words || [])
+      .filter((w) => w.type === 'word')
+      .map((w) => `[${(w.start ?? 0).toFixed(2)}-${(w.end ?? 0).toFixed(2)}]${w.speaker_id ? ' ' + w.speaker_id : ''} ${w.text}`);
+    return cli.out(lines.join('\n'));
+  }
+
+  if (opts.diarize && (j.words || []).some((w) => w.speaker_id)) {
+    // group consecutive words by speaker
+    const out = []; let cur = null;
+    for (const w of j.words) {
+      if (w.type !== 'word' && w.type !== 'spacing') continue;
+      const sp = w.speaker_id || 'speaker';
+      if (!cur || cur.sp !== sp) { cur = { sp, text: '' }; out.push(cur); }
+      cur.text += (w.type === 'spacing' ? ' ' : w.text);
+    }
+    return cli.out(out.map((s) => `${s.sp}: ${s.text.trim()}`).join('\n'));
+  }
+
+  return cli.out(j.text || '');
+}
+
+await main().catch((e) => cli.die(e.message + (e.status ? ` (HTTP ${e.status})` : ''), { prefix: 'hear-11' }));

--- a/skills/elevenlabs/scripts/say-11.jsh
+++ b/skills/elevenlabs/scripts/say-11.jsh
@@ -1,0 +1,86 @@
+// say-11.jsh — ElevenLabs-backed replacement for the built-in `say`.
+// Mirrors:  say [-v voice] [-r rate] [-l lang] [-o file] [--list] <text>
+//
+// By default it synthesizes the text and plays it aloud (via afplay). With -o
+// it writes the audio to a file instead. -v accepts a voice name (partial,
+// case-insensitive) or a raw voice_id. Output is MP3 (ElevenLabs' native
+// format) regardless of the -o extension.
+//
+// Single-dash value flags (-v -r -l -o -m) are hand-parsed here because the
+// runtime's parseFlags() treats single-dash flags as booleans and would drop
+// their values.
+
+const cli = require('sliccy:cli');
+const fmt = require('sliccy:fmt');
+const fs  = require('fs');
+const L   = require('./elevenlib.jsh');
+
+const HELP = `say-11 — speak text with ElevenLabs (drop-in for \`say\`)
+
+  say-11 [-v voice] [-r rate] [-l lang] [-o file] [-m model] <text>
+  say-11 --list | --voices        list available voices
+  say-11 --play <text>            (default) speak aloud
+
+  -v  voice name (partial match) or voice_id
+  -r  playback rate 0.25–4 (applied on playback via afplay)
+  -l  language hint (ElevenLabs multilingual models auto-detect; optional)
+  -o  write audio (MP3) to file instead of playing
+  -m  model id (default eleven_multilingual_v2)
+  --key <k>   override API key
+
+Auth: --key | ELEVENLABS_API_KEY | \`eleven auth <key>\`.`;
+
+// Manual argv parse: value flags take the next token; bare/long flags are bools.
+function parse(argv) {
+  const valueFlags = { '-v': 'voice', '--voice': 'voice', '-r': 'rate', '--rate': 'rate',
+    '-l': 'lang', '--lang': 'lang', '-o': 'out', '--out': 'out', '-m': 'model', '--model': 'model',
+    '--key': 'key', '--stability': 'stability', '--similarity': 'similarity', '--style': 'style' };
+  const boolFlags = { '--list': 'list', '--voices': 'list', '--play': 'play', '-h': 'help', '--help': 'help' };
+  const opts = {}; const rest = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (Object.prototype.hasOwnProperty.call(valueFlags, a)) { opts[valueFlags[a]] = argv[++i]; }
+    else if (a.startsWith('--') && a.includes('=')) { const [k, ...v] = a.slice(2).split('='); opts[k] = v.join('='); }
+    else if (Object.prototype.hasOwnProperty.call(boolFlags, a)) { opts[boolFlags[a]] = true; }
+    else rest.push(a);
+  }
+  return { opts, text: rest.join(' ') };
+}
+
+async function main() {
+  const { opts, text } = parse(process.argv.slice(2));
+  if (opts.help) return cli.help(HELP);
+
+  const key = await L.getKey(opts.key);
+
+  if (opts.list) {
+    const voices = await L.listVoices(key);
+    const rows = [['voice_id', 'name', 'category']];
+    for (const v of voices) rows.push([v.voice_id, fmt.trunc(v.name || '', 44), `[elevenlabs] ${v.category || ''}`]);
+    return cli.out(fmt.table(rows));
+  }
+
+  if (!text) return cli.die('no text to speak.\n\n' + HELP);
+
+  const voiceId = await L.resolveVoice(key, opts.voice);
+  const cfg = await L.loadConfig();
+  const voiceSettings = { ...(cfg.voiceSettings || {}) };
+  if (opts.stability != null) voiceSettings.stability = Number(opts.stability);
+  if (opts.similarity != null) voiceSettings.similarity_boost = Number(opts.similarity);
+  if (opts.style != null) voiceSettings.style = Number(opts.style);
+  const buf = await L.tts(key, { text, voiceId, modelId: opts.model || cfg.defaultModel, voiceSettings });
+
+  if (opts.out) {
+    await fs.writeFileBinary(opts.out, buf);
+    return cli.out(`Wrote ${buf.length} bytes (MP3) to ${opts.out}`);
+  }
+
+  const tmp = `/tmp/say-11-${Date.now()}.mp3`;
+  await fs.writeFileBinary(tmp, buf);
+  const rate = opts.rate != null ? Number(opts.rate) : undefined;
+  await L.play(tmp, { rate: Number.isFinite(rate) ? rate : undefined });
+  // stay quiet on success, like `say` (no stdout); comment for the agent:
+  process.stderr.write(`spoke ${buf.length} bytes via ElevenLabs\n`);
+}
+
+await main().catch((e) => cli.die(e.message + (e.status ? ` (HTTP ${e.status})` : ''), { prefix: 'say-11' }));

--- a/skills/elevenlabs/scripts/say-11.jsh
+++ b/skills/elevenlabs/scripts/say-11.jsh
@@ -68,7 +68,7 @@ async function main() {
   if (opts.stability != null) voiceSettings.stability = Number(opts.stability);
   if (opts.similarity != null) voiceSettings.similarity_boost = Number(opts.similarity);
   if (opts.style != null) voiceSettings.style = Number(opts.style);
-  const buf = await L.tts(key, { text, voiceId, modelId: opts.model || cfg.defaultModel, voiceSettings });
+  const buf = await L.tts(key, { text, voiceId, modelId: opts.model || cfg.defaultModel, voiceSettings, languageCode: opts.lang });
 
   if (opts.out) {
     await fs.writeFileBinary(opts.out, buf);


### PR DESCRIPTION
## elevenlabs skill

Adds a new `elevenlabs` skill with three command-line tools backed by the ElevenLabs API.

### Tools
- **`eleven`** — raw API client + conveniences: `voices`, `models`, `user`, `tts`, `stt`, `auth`, `config`, and a generic `eleven api <METHOD> <path> --data '<json>'` passthrough.
- **`say-11`** — an ElevenLabs-backed drop-in for the built-in `say` (same `-v/-r/-l/-o/--list` interface; speaks aloud, or `-o` writes MP3; `--stability/--similarity/--style` voice settings).
- **`hear-11`** — ElevenLabs Scribe speech-to-text, a file-based counterpart to `hear` (`--words`, `--diarize`, `--json`). Does not capture the mic.

Shared helpers in `scripts/elevenlib.jsh`.

### Auth
Key read from `--key` → `ELEVENLABS_API_KEY` → per-user config (`eleven auth <key>`), stored in `scripts/.config` which is **git-ignored and never committed**.

### Notes
- TTS writes faithful MP3 via the VFS binary bridge; STT uploads multipart via `curl` (proxied fetch cannot send binary bodies).
- Single-dash value flags are hand-parsed to match the `say`/`hear` interfaces.

### Testing
Exercised live: TTS→valid MP3, STT round-trips (word timestamps + diarization), voice-by-name resolution, afplay playback, full TTS↔STT round-trip.