### PR TITLE
feat(slack): upload & download commands for files/images

### DIFF
--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -62,8 +62,14 @@ slack post W5BPKRLUA "Hey, quick question..."
 # Search for channels
 slack channels --search=one-aem
 
-# Read a thread
+# Read a thread (file/image attachments are shown with their [F...] id)
 slack thread C087NCG774J 1774539502.747989
+
+# Download a file shared in a thread (e.g. a screenshot) to view it locally
+slack download F0BK6BADTKK --out=/tmp/shot.png
+
+# Upload a file to a channel/DM/thread (optionally with a comment)
+slack upload C087NCG774J /tmp/clip.mp3 --thread_ts=1774539502.747989 --comment="voice note"
 
 # Find a user by name (or email) → get their user ID
 slack find "Dragos Dascalita"
@@ -226,7 +232,32 @@ member count, and purpose.
 ### slack thread \<channel_id\> \<thread_ts\> [--limit=N]
 
 Read thread replies. Provide the channel ID and the thread's parent timestamp.
-Default limit is 50.
+Default limit is 50. Messages that carry files/images show an extra line per
+attachment with its name, type, dimensions, and file id, plus a ready-to-run
+`slack download <file_id>` hint — so screenshots shared in a thread are visible
+and fetchable.
+
+### slack download \<file_id\> [--out=\<path\>]
+
+Download a file (e.g. a screenshot shared in a thread) to a local path so you can
+view it. Resolves the file via `files.info`, then fetches the bytes authenticated
+inside the Slack tab (`files.slack.com` needs the session cookie) and writes them
+to disk. Get the `<file_id>` from `slack thread` / `slack history` output (shown as
+`[F...]`). Alternatively pass `--url=<url_private>` directly. Defaults the output to
+`/tmp/<original-name>` when `--out` is omitted.
+
+### slack upload \<channel_id\> \<file\> [--thread_ts=TS] [--comment="..."] [--title="..."]
+
+Upload a local file to a channel, DM, or thread. Accepts a conversation ID or a
+user ID (`U.../W...` opens a DM automatically). Uses Slack's 3-step external upload
+flow: `files.getUploadURLExternal` → POST the raw bytes (via `curl --data-binary`) →
+`files.completeUploadExternal`. `--comment` becomes the message text; `--thread_ts`
+posts it as a threaded reply.
+
+```bash
+slack upload C087NCG774J /tmp/report.pdf --comment="Q3 numbers"
+slack upload C087NCG774J /tmp/voice.mp3 --thread_ts=1774539502.747989 --comment="voice note"
+```
 
 ### slack find \<name or email\> [--limit=N]
 

--- a/skills/slack/scripts/slack.jsh
+++ b/skills/slack/scripts/slack.jsh
@@ -274,7 +274,18 @@ function formatMessage(msg) {
   const time = formatTimestamp(msg.ts);
   const text = msg.text || '';
   const thread = msg.reply_count ? ` [${msg.reply_count} replies]` : '';
-  return `[${time}] ${name}: ${text}${thread}`;
+  let out = `[${time}] ${name}: ${text}${thread}`;
+  // Surface file/image attachments so threads with screenshots are legible and
+  // the file id is available for `slack download <file_id>`.
+  if (Array.isArray(msg.files) && msg.files.length) {
+    for (const f of msg.files) {
+      const isImg = (f.mimetype || '').startsWith('image/');
+      const dims = (f.original_w && f.original_h) ? ` ${f.original_w}x${f.original_h}` : '';
+      out += `\n    ↳ ${isImg ? 'image' : 'file'}: ${f.name || f.title || '(unnamed)'} (${f.mimetype || f.filetype || '?'}${dims}) [${f.id}]` +
+             `  → slack download ${f.id}`;
+    }
+  }
+  return out;
 }
 
 // --- Commands ---
@@ -459,6 +470,88 @@ const commands = {
     if (data.message) {
       console.log(`Text: ${data.message.text}`);
     }
+  },
+
+  // Download a file (e.g. an image shared in a thread) to a local path. Fetches
+  // it authenticated in the Slack tab (files.slack.com needs the session cookie),
+  // returns the bytes as base64, and writes them to disk. Get the <file_id> from
+  // `slack thread`/`slack history` output (shown as [F...]).
+  async download(args, globalFlags) {
+    const { flags, positional } = parseArgs(args);
+    const fileId = positional[0];
+    if (!fileId && !flags.url) {
+      console.error('Usage: slack download <file_id> [--out=<path>]');
+      console.error('   or: slack download --url=<url_private> --out=<path>');
+      console.error('File ids appear in `slack thread`/`slack history` output as [F...].');
+      process.exit(1);
+    }
+    const wsId = await resolveWorkspace(globalFlags);
+    let url = typeof flags.url === 'string' ? flags.url : null;
+    let name = typeof flags.out === 'string' ? flags.out : null;
+    if (fileId && !url) {
+      const info = await slackApi('files.info', { file: fileId }, wsId);
+      if (!info.ok) { console.error('Error:', info.error); process.exit(1); }
+      url = info.file.url_private_download || info.file.url_private;
+      if (!name) name = `/tmp/${info.file.name || (info.file.id + '.' + (info.file.filetype || 'bin'))}`;
+    }
+    const out = name || `/tmp/slack-download-${Date.now()}`;
+    const tab = await findSlackTab();
+    const code = `(async()=>{const r=await fetch(${JSON.stringify(url)},{credentials:'include'});if(!r.ok)return JSON.stringify({ok:false,status:r.status});const u=new Uint8Array(await r.arrayBuffer());let s='';for(let i=0;i<u.length;i+=8192){s+=String.fromCharCode.apply(null,u.subarray(i,i+8192));}return JSON.stringify({ok:true,b64:btoa(s),len:u.length});})()`;
+    const raw = await browser.evalAsync(tab, code);
+    const res = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    if (!res || !res.ok) { console.error('Error: fetch failed', res && res.status ? `(HTTP ${res.status})` : ''); process.exit(1); }
+    await fs.writeFileBinary(out, Buffer.from(res.b64, 'base64'));
+    console.log(`Downloaded ${res.len} bytes to ${out}`);
+  },
+
+  // Upload a local file to a channel/DM/thread using Slack's 3-step external
+  // upload flow (getUploadURLExternal → POST bytes → completeUploadExternal).
+  async upload(args, globalFlags) {
+    const { flags, positional } = parseArgs(args);
+    const channel = positional[0];
+    const file = positional[1];
+    if (!channel || !file) {
+      console.error('Usage: slack upload <channel_id> <file> [--thread_ts=TS] [--comment="text"] [--title="..."]');
+      process.exit(1);
+    }
+    if (!(await fs.exists(file))) { console.error(`Error: file not found: ${file}`); process.exit(1); }
+    const wsId = await resolveWorkspace(globalFlags);
+    const size = (await fs.stat(file)).size;
+    const filename = file.split('/').pop();
+
+    // Resolve a user ID to a DM channel, mirroring `post`.
+    let targetChannel = channel;
+    if (/^[UW][A-Z0-9]+$/.test(channel)) {
+      const dm = await slackApi('conversations.open', { users: channel, return_im: 'true' }, wsId);
+      if (!dm.ok) { console.error(`Error opening DM with ${channel}:`, dm.error); process.exit(1); }
+      targetChannel = dm.channel.id;
+    }
+
+    // Step 1: reserve an upload URL.
+    const up = await slackApi('files.getUploadURLExternal', { filename, length: String(size) }, wsId);
+    if (!up.ok) { console.error('Error (getUploadURL):', up.error); process.exit(1); }
+
+    // Step 2: POST the raw bytes with --data-binary (NOT multipart -F: the
+    // pre-signed S3 upload URL expects exactly `length` raw bytes; multipart
+    // boundary overhead makes small files fail with "internal error: s3_upload").
+    // The URL is pre-signed, so plain curl (no cookie) works, and this keeps the
+    // binary out of the eval bridge.
+    const post = await exec.spawn(['curl', '-s', '-X', 'POST', up.upload_url, '--data-binary', `@${file}`]);
+    if (post.exitCode !== 0 || !/\bOK\b/.test(post.stdout)) {
+      console.error('Error uploading bytes:', post.stdout || post.stderr || `exit ${post.exitCode}`);
+      process.exit(1);
+    }
+
+    // Step 3: finalize into the channel/thread.
+    const params = { files: JSON.stringify([{ id: up.file_id, title: (typeof flags.title === 'string' ? flags.title : filename) }]), channel_id: targetChannel };
+    if (typeof flags.thread_ts === 'string') params.thread_ts = flags.thread_ts;
+    if (typeof flags.comment === 'string') params.initial_comment = flags.comment;
+    const done = await slackApi('files.completeUploadExternal', params, wsId);
+    if (!done.ok) { console.error('Error (completeUpload):', done.error); process.exit(1); }
+
+    console.log(`Uploaded ${filename} (${size} bytes) to ${targetChannel}${params.thread_ts ? ' (in thread)' : ''}.`);
+    const f = done.files && done.files[0];
+    if (f) console.log(`  file: ${f.id}${f.permalink ? '  ' + f.permalink : ''}`);
   },
 
   async channels(args, globalFlags) {
@@ -1655,8 +1748,11 @@ if (!cmd || cmd === 'help' || cmd === '--help') {
   console.log('  deny <message_ts> [--channel=<id>]       Deny an interactive action (e.g. invite request)');
   console.log('  history <channel_id> [--limit=N]          Read channel messages');
   console.log('  post <id> <message> [--thread_ts=TS]      Post a message to any channel, DM, or user');
+  console.log('  upload <channel_id> <file> [--thread_ts=TS] [--comment="..."] [--title="..."]');
+  console.log('                                           Upload a file to a channel/DM/thread');
+  console.log('  download <file_id> [--out=<path>]         Download a file (e.g. thread image) locally');
   console.log('  channels --search=<term>                  Search for channels');
-  console.log('  thread <channel_id> <thread_ts> [--limit] Read thread replies');
+  console.log('  thread <channel_id> <thread_ts> [--limit] Read thread replies (shows [F...] file ids)');
   console.log('  find <name or email> [--limit=N]          Search users by name/email → user IDs');
   console.log('  user <user_id>                            Look up user info');
   console.log('  info <channel_id>                         Get channel info');

--- a/skills/slack/scripts/slack.jsh
+++ b/skills/slack/scripts/slack.jsh
@@ -495,10 +495,10 @@ const commands = {
       if (!name) name = `/tmp/${info.file.name || (info.file.id + '.' + (info.file.filetype || 'bin'))}`;
     }
     const out = name || `/tmp/slack-download-${Date.now()}`;
-    const tab = await findSlackTab();
+    // Route through evalInSlackTab so a double-encoded JSON eval result is parsed
+    // correctly (a single JSON.parse would leave `res` a string and misreport failure).
     const code = `(async()=>{const r=await fetch(${JSON.stringify(url)},{credentials:'include'});if(!r.ok)return JSON.stringify({ok:false,status:r.status});const u=new Uint8Array(await r.arrayBuffer());let s='';for(let i=0;i<u.length;i+=8192){s+=String.fromCharCode.apply(null,u.subarray(i,i+8192));}return JSON.stringify({ok:true,b64:btoa(s),len:u.length});})()`;
-    const raw = await browser.evalAsync(tab, code);
-    const res = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    const res = await evalInSlackTab(code, { fatal: false });
     if (!res || !res.ok) { console.error('Error: fetch failed', res && res.status ? `(HTTP ${res.status})` : ''); process.exit(1); }
     await fs.writeFileBinary(out, Buffer.from(res.b64, 'base64'));
     console.log(`Downloaded ${res.len} bytes to ${out}`);


### PR DESCRIPTION
## Slack file upload & download

Adds two commands so the `slack` skill can move files, not just text — and makes screenshots shared in threads visible/fetchable.

### `slack upload <channel_id> <file> [--thread_ts=TS] [--comment="..."] [--title="..."]`
Uploads a local file to a channel, DM, or thread using Slack's 3-step external upload flow: `files.getUploadURLExternal` → POST the raw bytes → `files.completeUploadExternal`. A user ID (`U.../W...`) auto-opens a DM. `--comment` becomes the message text; `--thread_ts` posts it as a threaded reply.

**Note:** the pre-signed upload URL is fed with `curl --data-binary` (raw body), NOT multipart `-F` — multipart boundary overhead makes small files fail with `internal error: s3_upload`.

### `slack download <file_id> [--out=<path>] [--url=<url_private>]`
Downloads a file (e.g. a screenshot shared in a thread) to a local path. Resolves the file via `files.info`, then fetches the bytes authenticated inside the Slack tab (`files.slack.com` needs the session cookie), and writes them to disk.

### Thread/history attachments
`formatMessage` now surfaces `msg.files` — each attachment shows name, type, dimensions and file id, with a ready-to-run `slack download <id>` hint.

### Testing
All three exercised live against a real workspace: uploaded audio + image to a thread and a DM; downloaded a full-res screenshot from a thread; verified the attachment lines render. Additive only — existing helpers (`escapeShellArg`, webhook watch code) untouched.
