### PR TITLE
feat(clickhouse-cloud): ClickHouse Cloud cost & utilization skill

### DIFF
--- a/skills/clickhouse-cloud/SKILL.md
+++ b/skills/clickhouse-cloud/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: clickhouse-cloud
+description: Report on ClickHouse Cloud cost, spend, and utilization via the ClickHouse Cloud console/control-plane API. Use when the user asks about ClickHouse Cloud billing, spend, cost, usage report, compute unit hours, storage cost, data transfer cost, or wants to inspect ClickHouse Cloud services — their size, replica count, memory/autoscaling configuration, state, or region — or to check utilization metrics (CPU, memory, disk/S3 storage, queries per second, connections, network) for a service over time. Activate on mentions of "ClickHouse Cloud cost", "ClickHouse spend", "ClickHouse usage report", "ClickHouse Cloud services", "ClickHouse replicas", "ClickHouse utilization", "ClickHouse metrics", "ClickHouse Cloud billing". For running SQL against a ClickHouse service, use the `klickhaus` skill instead — this skill covers the cloud console (cost + infra + metrics), NOT SQL.
+allowed-tools: bash
+---
+
+# clickhouse-cloud
+
+Cost and utilization reporting for **ClickHouse Cloud** — the management console
+(organizations, service inventory, billing/usage reports, and utilization
+metrics). This is distinct from the `klickhaus` skill, which runs SQL against a
+ClickHouse service's data plane.
+
+## Setup
+
+The CLI is a `.jsh` script. Register it once per session:
+
+```bash
+touch /usr/bin/clickhouse-cloud; hash -r
+```
+
+## Auth (page-context, no secrets stored)
+
+The ClickHouse Cloud internal APIs
+(`control-plane-internal.clickhouse.cloud`, `console-api-internal.clickhouse.cloud`)
+require **both** an `Authorization: Bearer <JWT>` **and** an
+`Origin: https://console.clickhouse.cloud` header. SLICC's own `fetch()` sends
+`Origin: localhost` and cannot attach the app's live token, so a direct fetch is
+CORS/401-rejected.
+
+Instead, every call runs as a **page-context fetch inside the logged-in console
+tab** via `playwright-cli eval-file`. The Auth0 access token is read from
+`localStorage` in-page and used only there — it is never printed, stored, or
+committed. This requires an open, signed-in **console.clickhouse.cloud** tab. If
+none is found (or the session expired), the CLI tells the user to sign in at
+https://console.clickhouse.cloud and retry.
+
+## Commands
+
+```
+clickhouse-cloud orgs                             # list organizations
+clickhouse-cloud services [--org ID]              # services: state, tier, replicas, memory, idle scaling
+clickhouse-cloud service <svcId> [--org ID]       # full detail for one service
+clickhouse-cloud cost [--org ID] [--period P]     # usage/billing report: per-service cost + line items + total
+clickhouse-cloud metrics <svcId> [FLAGS]          # utilization summary (min/max/avg/latest)
+clickhouse-cloud api <METHOD> <URL> [--body=..]   # raw authenticated passthrough
+```
+
+Global flags: `--org=ID` (auto-detected when you have exactly one org),
+`--json` (raw JSON instead of a table).
+
+### cost
+
+`getUsageReport` for the current billing period. Prints a per-service cost table,
+a grand total, and a per-service line-item breakdown (compute unit hours,
+storage TB-months for tables + backups, public/inter-region data transfer,
+ClickPipes). `--period` defaults to `BILL_DATE`.
+
+### metrics
+
+Two data sources:
+
+- **Default / `--type=TYPE`** → control-plane `queryMetrics` (per-node
+  time-series). This is the reliable source and works even when the console
+  time-series is empty. Default batch: `CPU_USAGE_MAX`, `MEMORY_USAGE_MAX`,
+  `ALLOCATED_MEMORY`, `S3_STORAGE_USAGE`, `QUERIES_PER_SECOND`.
+  `--period` ∈ `LAST_15_MINUTES, LAST_HOUR, LAST_DAY, LAST_WEEK, LAST_MONTH, LAST_YEAR`
+  (default `LAST_DAY`). Byte-valued metrics are auto-formatted (GB/TB).
+- **`--metric=NAME`** → console-api time-series (`node_chart_max` aggregation,
+  times in **unix seconds**). Flags: `--from=SEC --to=SEC --step=SEC --agg=AGG`.
+  May return no points when a service is idle/scaled to zero.
+
+See `references/endpoints.md` for the full endpoint surface, the complete list of
+instance metric types + console metric names, cost line-item keys, and response
+schemas.
+
+## Examples
+
+```bash
+clickhouse-cloud cost --org=22dae0af-de0d-46cf-ad85-d0f8b8fcdd94
+clickhouse-cloud services --org=22dae0af-de0d-46cf-ad85-d0f8b8fcdd94
+clickhouse-cloud metrics 6f3c51d6-c282-421a-a46d-54fc08d4ce99 --org=<org> --period=LAST_WEEK
+clickhouse-cloud metrics 6f3c51d6-c282-421a-a46d-54fc08d4ce99 --org=<org> --type=S3_STORAGE_USAGE --period=LAST_MONTH
+clickhouse-cloud metrics 6f3c51d6-c282-421a-a46d-54fc08d4ce99 --metric=disk_storage
+```

--- a/skills/clickhouse-cloud/SKILL.md
+++ b/skills/clickhouse-cloud/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clickhouse-cloud
-description: Report on ClickHouse Cloud cost, spend, and utilization via the ClickHouse Cloud console/control-plane API. Use when the user asks about ClickHouse Cloud billing, spend, cost, usage report, compute unit hours, storage cost, data transfer cost, or wants to inspect ClickHouse Cloud services — their size, replica count, memory/autoscaling configuration, state, or region — or to check utilization metrics (CPU, memory, disk/S3 storage, queries per second, connections, network) for a service over time. Activate on mentions of "ClickHouse Cloud cost", "ClickHouse spend", "ClickHouse usage report", "ClickHouse Cloud services", "ClickHouse replicas", "ClickHouse utilization", "ClickHouse metrics", "ClickHouse Cloud billing". For running SQL against a ClickHouse service, use the `klickhaus` skill instead — this skill covers the cloud console (cost + infra + metrics), NOT SQL.
+description: Report on ClickHouse Cloud cost, spend, and utilization via the ClickHouse Cloud console/control-plane API. Use when the user asks about ClickHouse Cloud billing, spend, cost, usage report, compute unit hours, storage cost, data transfer cost, or wants to inspect ClickHouse Cloud services — their size, replica count, memory/autoscaling configuration, state, or region — or to check utilization metrics (CPU, memory, disk/S3 storage, queries per second, connections, network) for a service over time. Activate on mentions of "ClickHouse Cloud cost", "ClickHouse spend", "ClickHouse usage report", "ClickHouse Cloud services", "ClickHouse replicas", "ClickHouse utilization", "ClickHouse metrics", "ClickHouse Cloud billing". It can also run ad-hoc SQL against a service via the Cloud SQL-console query proxy (session-authenticated, no DB password). For the dedicated, purpose-built AEM CDN-logs investigation workflow, use the `klickhaus` skill instead.
 allowed-tools: bash
 ---
 
@@ -8,8 +8,11 @@ allowed-tools: bash
 
 Cost and utilization reporting for **ClickHouse Cloud** — the management console
 (organizations, service inventory, billing/usage reports, and utilization
-metrics). This is distinct from the `klickhaus` skill, which runs SQL against a
-ClickHouse service's data plane.
+metrics), plus ad-hoc **SQL** against a service through the Cloud SQL-console
+query proxy (session-authenticated, no separate database password). The
+`klickhaus` skill remains the dedicated, purpose-built CDN-logs investigation
+workflow (fixed service, its own credentials); use this skill's `query` when you
+want to run arbitrary SQL against any service you can see in the console.
 
 ## Setup
 
@@ -43,11 +46,34 @@ clickhouse-cloud services [--org ID]              # services: state, tier, repli
 clickhouse-cloud service <svcId> [--org ID]       # full detail for one service
 clickhouse-cloud cost [--org ID] [--period P]     # usage/billing report: per-service cost + line items + total
 clickhouse-cloud metrics <svcId> [FLAGS]          # utilization summary (min/max/avg/latest)
+clickhouse-cloud query "<SQL>" [FLAGS]            # run SQL against a service (session-auth, no DB password)
 clickhouse-cloud api <METHOD> <URL> [--body=..]   # raw authenticated passthrough
 ```
 
 Global flags: `--org=ID` (auto-detected when you have exactly one org),
 `--json` (raw JSON instead of a table).
+
+### query
+
+Runs arbitrary SQL against a service through the **Cloud SQL-console query
+proxy** (`queries.clickhouse.cloud/service/<id>/run`) — the same endpoint the
+console's SQL console uses. It is signed with the in-page Auth0 session token, so
+**no separate database username/password is needed** (unlike a direct
+native/HTTP connection). Any service visible in the logged-in console is
+queryable.
+
+```bash
+clickhouse-cloud query "SELECT count() FROM system.query_log" --service=<svcId>
+clickhouse-cloud query "SELECT now(), version()" --org=<orgId>         # auto-picks the org's only service
+clickhouse-cloud query --file=report.sql --service=<svcId> --json
+```
+
+Flags: `--service=ID` (the service to run against; auto-detected when the org has
+exactly one), `--database=DB` (default `default`), `--file=PATH` (read SQL from a
+file instead of the argument), `--json` / `--tsv` (machine-readable output instead
+of a table). Use `clusterAllReplicas(default, system.<table>)` to aggregate system
+tables across replicas. SQL errors are surfaced with the ClickHouse error code +
+message.
 
 ### cost
 

--- a/skills/clickhouse-cloud/references/endpoints.md
+++ b/skills/clickhouse-cloud/references/endpoints.md
@@ -1,0 +1,208 @@
+# ClickHouse Cloud console API — discovered endpoints
+
+Reverse-engineered from the logged-in console (`console.clickhouse.cloud`) via
+page-context fetch + the app JS bundle. Two internal hosts:
+
+- **control-plane** — `https://control-plane-internal.clickhouse.cloud`
+- **console-api**   — `https://console-api-internal.clickhouse.cloud`
+
+## Auth
+
+All internal endpoints require **both**:
+
+- `Authorization: Bearer <JWT>` — Auth0 RS256 access token. Lives in
+  `localStorage` under the key
+  `@@auth0spajs@@::<clientId>::control-plane-web::openid profile email`
+  → `JSON.parse(value).body.access_token`.
+- `Origin: https://console.clickhouse.cloud` — server validates it.
+
+Because SLICC `fetch()` forces `Origin: localhost` and cannot inject the token,
+calls must be made **from the page context** of an open, signed-in console tab
+(`playwright-cli eval-file`). Direct Node `fetch()` returns 401 `UNAUTHORIZED`
+even with the token; page-context without the token also returns 401 — you need
+both. Confirmed live: token + page origin ⇒ 200.
+
+## RPC convention (control-plane)
+
+Control-plane endpoints are POST with `Content-Type: text/plain;charset=UTF-8`.
+The body is JSON `{ rpcAction, ...args }` and the action is *also* appended as a
+query string, e.g. `POST /api/instance?list` with body `{"rpcAction":"list", ...}`.
+
+---
+
+## Cost / billing — `POST control-plane/api/billing`
+
+`rpcAction` values found in the bundle (billing class):
+`getUsageReport`, `getUsageStatement`, `getOrganizationBillingDetails`,
+`updateOrganizationBillingDetails`, `updateOrganizationBillingContact`,
+`updateOrganizationTier`, `getPricingForAllRegions`, `getMigrationPricing`,
+`getSpendAlertConfig`, `updateSpendAlertConfig`, `requestCredits`,
+`transferCredits`, `getCreditTransferHistory`, `getClientSecret`,
+`confirmUpdatedPaymentMethod`, `handleTackleSubscription`,
+`cancelTackleSubscription`, `getTackleEligibleOrganizations`.
+
+### getUsageReport (used by `cost`)
+
+Request:
+```json
+{ "rpcAction": "getUsageReport", "organizationId": "<orgId>", "usagePeriod": { "type": "BILL_DATE" } }
+```
+
+Response `report`:
+```
+{ organizationId, startDate, endDateExclusive, endDateInclusive, currency,
+  dataWarehouseReports: [ {
+    organizationTier, cloudProvider, region, id, name, billLocked, deleted, timestamp,
+    datawarehouseStorageTBMonthsBackups: { metricValue, cost },
+    datawarehouseStorageTBMonthsTables:  { metricValue, cost },
+    instanceReports: [ { id, name, profile, dataWarehouseId, cloudProvider, region,
+      instanceComputeUnitHours:            { metricValue, cost },
+      instancePublicDataTransferGB:        { metricValue, cost },
+      instanceInterRegionTier1..4DataTransferGB: { metricValue, cost },
+      clickpipeReports: [...], totalClickpipeReport: {...} } ],
+    totalInstanceReport: { ...same instance-level line items aggregated... }
+  } ],
+  pgInstanceReports: [...],           // managed Postgres (empty here)
+  totalUsageReport: { ...every line item summed across the org... } }
+```
+
+**Cost line-item keys** (each `{ metricValue, cost }`):
+`instanceComputeUnitHours`, `instancePublicDataTransferGB`,
+`instanceInterRegionTier1DataTransferGB` … `Tier4`,
+`datawarehouseStorageTBMonthsBackups`, `datawarehouseStorageTBMonthsTables`,
+`clickpipeComputeUnitHours`, `clickpipeDataTransferGB`,
+`clickpipeInitialDataTransferGB`, plus `byocInstanceComputeUnitHours` and the
+`pgInstance*` family (managed Postgres). Total cost for a service = sum of all
+its line-item `cost` values (compute dominates; e.g. a test service was ~$314
+period-to-date, of which ~$311 was `instanceComputeUnitHours`).
+
+Storage line items are on the data-warehouse node; compute/transfer are under
+`totalInstanceReport` (the `cost` command sums both).
+
+---
+
+## Organizations — `POST control-plane/api/organization`
+
+- `?list` `{ "rpcAction": "list" }` → `{ "<orgId>": { id, name, users, invitations, ... }, ... }`
+  (map keyed by org id).
+- `?listActivities` `{ rpcAction, organizationId, pagination }` → audit activity.
+
+---
+
+## Services / instances — `POST control-plane/api/instance`
+
+`rpcAction` values (instance class): `list`, `getInstanceDetails`, `create`,
+`delete`, `stop`, `start`, `rename`, `warehouseSize`, `updateAutoScaling`,
+`saveDefaultAutoscalingConfig`, `updateAutoscalingSchedule`, `getLimits`,
+`resetPassword`, `updateIpAccessList`, `updateInstanceState`, `wakeupInstance`,
+`updateInstanceBackupConfiguration`, `updateReleaseChannel`,
+`startMaintenanceManually`, `updateUpgradeWindow`, `triggerFailover`,
+`triggerRecovery`, and many more.
+
+### list (used by `services`)
+
+`{ "rpcAction": "list", "organizationId": "<orgId>" }` → `{ instances: [ ... ] }`.
+
+Instance object keys (relevant to size/replicas/scaling):
+```
+id, name, state, regionId, cloudProvider, clickhouseVersion, instanceTier,
+minReplicas, maxReplicas,                       // replica autoscaling range
+minAutoScalingReplicaMemory, maxAutoScalingReplicaMemory,  // per-replica RAM (GB)
+minRequiredMemoryGb, customAutoscaleReplicaMemoryValues, autoscalingMode,
+enableIdleScaling, idleTimeoutMinutes,          // scale-to-zero config
+releaseChannel, dataWarehouseId, isPrimary, isReadonly, database,
+endpoints{ https{hostname,port}, nativesecure{hostname,port} },
+lastBackupStarted, ipAccessList, backupConfiguration, maintenanceWindows,
+creationDate, features[...]
+```
+
+### getInstanceDetails
+
+`{ rpcAction:"getInstanceDetails", organizationId, instanceId }` → low-level infra
+detail (`iamPrincipal`, cross-tenant ids). The replica/memory config comes from
+`list`, not here.
+
+---
+
+## Utilization metrics
+
+### Control-plane batch — `POST control-plane/api/metrics/queryMetrics` (used by `metrics` default / `--type`)
+
+```json
+{ "organizationId": "<org>", "instanceId": "<svc>",
+  "batch": [ { "type": "CPU_USAGE_MAX", "timePeriod": "LAST_DAY" } ] }
+```
+Response: `{ batch: [ { type, timePeriod, data: [ [ { node, data: [[tsMs, value], ...] }, ... ] ] } ] }`.
+Values can be `null` while a service is idle. (There is also `queryMetricsV2`
+and `queryInsights` on the same base.)
+
+**`type` values** (LAST_15_MINUTES | LAST_HOUR | LAST_DAY | LAST_WEEK | LAST_MONTH | LAST_YEAR):
+```
+CPU_USAGE, CPU_USAGE_MAX, CPU_WAIT, ALLOCATED_CPU_NODE,
+OS_USER_CPU_USAGE_NORMALIZED, OS_KERNEL_CPU_USAGE_NORMALIZED,
+CGROUP_USER_CPU_USAGE, CGROUP_KERNEL_CPU_USAGE,
+MEMORY_USAGE, MEMORY_USAGE_MAX, MEMORY_TRACKED_BYTES,
+ALLOCATED_MEMORY, ALLOCATED_MEMORY_NODE,
+S3_STORAGE_USAGE, QUERIES_PER_SECOND, SELECTED_BYTES_PER_SEC,
+S3_READ_WAIT, S3_READ_ERRORS_PER_SEC, S3_DISK_READ_REQ_PER_SEC, S3_DISK_WRITE_REQ_PER_SEC,
+READ_FROM_DISK_BYTES_PER_SEC, READ_FROM_FS_BYTES_PER_SEC, READ_FROM_S3_BYTES_PER_SECOND,
+NETWORK_RECEIVE_BYTES_PER_SEC, NETWORK_SEND_BYTES_PER_SEC,
+CONCURENT_TCP_CONNECTIONS, CONCURENT_MYSQL_CONNECTIONS, CONCURENT_HTTP_CONNECTIONS
+```
+(also ClickPipe variants: `CLICKPIPE_CPU_USAGE`, `CLICKPIPE_MEMORY_USAGE`,
+`CLICKPIPE_CPU_LIMITS`, `CLICKPIPE_MEMORY_LIMITS`.)
+
+Byte-valued types (formatted GB/TB by the CLI): `S3_STORAGE_USAGE`,
+`ALLOCATED_MEMORY(_NODE)`, `MEMORY_USAGE(_MAX)`, `MEMORY_TRACKED_BYTES`,
+`SELECTED_BYTES_PER_SEC`, `READ_FROM_*_BYTES_PER_SEC(OND)`, `NETWORK_*_BYTES_PER_SEC`.
+
+### Console time-series — `POST console-api/.api/metrics` (used by `metrics --metric`)
+
+```json
+{ "query": { "aggregation": "node_chart_max", "aggregationPeriod": 3600,
+             "startTime": <unixSeconds>, "endTime": <unixSeconds>, "metric": "disk_storage" },
+  "serviceId": "<svc>" }
+```
+**Times are in unix SECONDS** (ms → 500 error). Response:
+`{ metrics: { boundaries:{xMin,xMax,yMin,yMax}, series:[{ name, values:[{x,y}] }] } }`.
+`aggregation` ∈ `node_chart_avg | node_chart_max | node_chart_sum | node_chart_p50 |
+node_chart_p90 | node_chart_p95 | node_chart_p99` (also `chart_last` for
+autoscaling). Returns empty `series` when a service is idle/scaled to zero.
+
+**`metric` names:**
+```
+resident_memory_without_page_cache, server_usage_cores, cluster_size_active_replicas,
+allocated_memory, allocated_cpu, recommendation_desired_memory,
+merges_finished, merges_failed, current_merges, created_mutations, current_mutations,
+disk_storage, selected_bytes, inserted_bytes, select_query, insert_query,
+successful_all_query, failed_all_query, selected_rows, inserted_rows,
+ingress_data_transfer, egress_data_transfer, attached_databases, attached_tables,
+total_parts_of_merge_tree_tables
+```
+
+Related console-api endpoints on the same `${apiUrl}` base:
+`/.api/metrics` (scalar variant `consoleMetricsScalarUrl`), `/.api/autoscaling`
+(scaling config; needs specific params — returned 403 with a bare `serviceId`),
+`/.api/services/<svcId>`, `/.api/query-endpoints`, `/.api/savedQuery`,
+`/.api/clickpipes/v1`, `/.api/env`, `/.api/ubicloud/postgres`.
+
+---
+
+## Other control-plane RPC endpoints (not wired into the CLI, reachable via `api`)
+
+- `/api/account` — user/account RPCs (`addUserToCloudWaitlist`, `listOrganizations`
+  via `{rpcAction:"list"}`, invitations, `changeUserRole`, `leave`, Stripe linking…).
+- `/api/notification` — `getNotifications`, `getLastUINotifications`,
+  `getChannelSettings`, Slack channel settings, `updateMarkAsRead`.
+- `/api/autoScaling` — autoscaling RPCs.
+- `/api/galaxy` — telemetry (`sendGalaxyForensicEvent`); ignore.
+
+## Notes
+
+- Discovery was done live (the recorded HAR lives on the tray and was not
+  reachable from the scoop filesystem); the endpoint list came from the app's
+  `performance.getEntriesByType('resource')` plus grepping the JS bundle for
+  `rpcAction:"..."`, metric enums, and URL builders, then validated with live
+  calls against org `22dae0af-…` / service `6f3c51d6-…`.
+- Test IDs: org `22dae0af-de0d-46cf-ad85-d0f8b8fcdd94`,
+  service `6f3c51d6-c282-421a-a46d-54fc08d4ce99`.

--- a/skills/clickhouse-cloud/references/endpoints.md
+++ b/skills/clickhouse-cloud/references/endpoints.md
@@ -188,6 +188,34 @@ Related console-api endpoints on the same `${apiUrl}` base:
 
 ---
 
+## SQL query proxy — `POST queries.clickhouse.cloud/service/<serviceId>/run` (used by `query`)
+
+The Cloud **SQL console** runs statements through a dedicated query proxy on a
+separate host (`queries.clickhouse.cloud`, *not* the `*-internal` control-plane).
+It is authenticated with the **same Auth0 bearer token** as everything else — so
+no database username/password is needed.
+
+```
+POST https://queries.clickhouse.cloud/service/<serviceId>/run
+       ?enable_http_compression=1&format=JSONEachRowWithProgress&request_timeout=3600000
+Authorization: Bearer <auth0 access_token>
+Content-Type:  text/plain;charset=UTF-8
+
+body: { "runId": "liveQueries:<uuid>", "sql": "<SQL>", "database": "default" }
+```
+
+Response is **newline-delimited** JSON (`JSONEachRowWithProgress`): interleaved
+`{"progress":{…}}` lines, one `{"meta":[{name,type},…]}` line, then a
+`{"row":{…}}` line per result row; a query error arrives as `{"exception":"…"}`
+(HTTP 200) or as an HTTP 400 with `{"error":{"code","details"}}`. The console
+wraps system-table reads in `clusterAllReplicas(default, 'system.<table>')` to
+span all replicas, and tags its own internal queries with
+`Settings['log_comment']='sql console internal query'` (filter these out when
+inspecting `system.query_log`). `queries.clickhouse.cloud` is in the CLI's
+allowed-host set alongside the two `*-internal` hosts.
+
+---
+
 ## Other control-plane RPC endpoints (not wired into the CLI, reachable via `api`)
 
 - `/api/account` — user/account RPCs (`addUserToCloudWaitlist`, `listOrganizations`

--- a/skills/clickhouse-cloud/scripts/clickhouse-cloud.jsh
+++ b/skills/clickhouse-cloud/scripts/clickhouse-cloud.jsh
@@ -1,0 +1,500 @@
+// clickhouse-cloud — cost & utilization reporting for ClickHouse Cloud.
+//
+// This is the *console / control-plane* API (org billing, service inventory,
+// utilization metrics) — NOT the SQL data-plane (see the `klickhaus` skill for
+// running SQL against a ClickHouse service).
+//
+// Auth model (see references/endpoints.md): the internal APIs
+// (control-plane-internal.clickhouse.cloud, console-api-internal.clickhouse.cloud)
+// require BOTH an `Authorization: Bearer <JWT>` AND an
+// `Origin: https://console.clickhouse.cloud` header. SLICC's own fetch() sends
+// Origin: localhost and cannot attach the app's live token, so every call runs
+// as a page-context fetch INSIDE the logged-in console tab via
+// `playwright-cli eval-file`. The Auth0 access token is read from localStorage
+// in-page and never leaves the browser / is never printed.
+
+const exec = require('sliccy:exec');
+const fs   = require('fs');
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const CONSOLE_HOST = 'console.clickhouse.cloud';
+const CP  = 'https://control-plane-internal.clickhouse.cloud'; // control-plane
+const CA  = 'https://console-api-internal.clickhouse.cloud';   // console-api
+
+// console-api /.api/metrics time-series metric names (aggregation node_chart_max,
+// times in SECONDS). Discovered from the console bundle.
+const CONSOLE_METRICS = [
+  'resident_memory_without_page_cache', 'server_usage_cores',
+  'cluster_size_active_replicas', 'allocated_memory', 'recommendation_desired_memory',
+  'allocated_cpu', 'merges_finished', 'merges_failed', 'current_merges',
+  'created_mutations', 'current_mutations', 'disk_storage', 'selected_bytes',
+  'inserted_bytes', 'select_query', 'insert_query', 'successful_all_query',
+  'failed_all_query', 'selected_rows', 'inserted_rows', 'ingress_data_transfer',
+  'egress_data_transfer', 'attached_databases', 'attached_tables',
+  'total_parts_of_merge_tree_tables',
+];
+
+// control-plane /api/metrics/queryMetrics batch types.
+const INSTANCE_METRIC_TYPES = [
+  'S3_STORAGE_USAGE', 'ALLOCATED_MEMORY', 'ALLOCATED_MEMORY_NODE', 'MEMORY_USAGE',
+  'MEMORY_USAGE_MAX', 'MEMORY_TRACKED_BYTES', 'ALLOCATED_CPU_NODE', 'CPU_USAGE',
+  'CPU_USAGE_MAX', 'CPU_WAIT', 'OS_USER_CPU_USAGE_NORMALIZED',
+  'OS_KERNEL_CPU_USAGE_NORMALIZED', 'CGROUP_USER_CPU_USAGE', 'CGROUP_KERNEL_CPU_USAGE',
+  'QUERIES_PER_SECOND', 'SELECTED_BYTES_PER_SEC', 'S3_READ_WAIT',
+  'S3_READ_ERRORS_PER_SEC', 'READ_FROM_DISK_BYTES_PER_SEC', 'READ_FROM_FS_BYTES_PER_SEC',
+  'READ_FROM_S3_BYTES_PER_SECOND', 'S3_DISK_WRITE_REQ_PER_SEC', 'S3_DISK_READ_REQ_PER_SEC',
+  'NETWORK_RECEIVE_BYTES_PER_SEC', 'NETWORK_SEND_BYTES_PER_SEC',
+  'CONCURENT_TCP_CONNECTIONS', 'CONCURENT_MYSQL_CONNECTIONS', 'CONCURENT_HTTP_CONNECTIONS',
+];
+const TIME_PERIODS = ['LAST_15_MINUTES', 'LAST_HOUR', 'LAST_DAY', 'LAST_WEEK', 'LAST_MONTH', 'LAST_YEAR'];
+
+// Bytes-valued instance metric types (for human formatting).
+const BYTE_TYPES = new Set([
+  'S3_STORAGE_USAGE', 'ALLOCATED_MEMORY', 'ALLOCATED_MEMORY_NODE', 'MEMORY_USAGE',
+  'MEMORY_USAGE_MAX', 'MEMORY_TRACKED_BYTES', 'SELECTED_BYTES_PER_SEC',
+  'READ_FROM_DISK_BYTES_PER_SEC', 'READ_FROM_FS_BYTES_PER_SEC',
+  'READ_FROM_S3_BYTES_PER_SECOND', 'NETWORK_RECEIVE_BYTES_PER_SEC', 'NETWORK_SEND_BYTES_PER_SEC',
+]);
+
+// ─── Tab management ────────────────────────────────────────────────────────────
+
+let _tabId = null;
+
+// Probe a tab: does it hold a live control-plane-web Auth0 access token?
+async function tabHasToken(tabId) {
+  const probe = '(() => { try { const k = Object.keys(localStorage).find(k => k.startsWith("@@auth0spajs@@") && k.includes("control-plane-web")); return k && JSON.parse(localStorage.getItem(k)).body.access_token ? "yes" : "no"; } catch (e) { return "no"; } })()';
+  const tmp = '/shared/.chc_probe_' + Date.now() + '_' + Math.floor(Math.random() * 1e6) + '.js';
+  await fs.writeFile(tmp, probe);
+  let r;
+  try { r = await exec('playwright-cli eval-file ' + tmp + ' --tab=' + tabId); }
+  finally { await fs.rm(tmp).catch(function () {}); }
+  return r.exitCode === 0 && /yes/.test(r.stdout || '');
+}
+
+async function findTab() {
+  const list = await exec('playwright-cli tab-list');
+  const stdout = list.stdout || '';
+  if (_tabId && stdout.includes(_tabId)) return _tabId;
+  _tabId = null;
+
+  // Collect every open console.clickhouse.cloud tab.
+  const re = new RegExp('\\[([A-F0-9]+)\\]\\s+https?://[^\\s]*' + CONSOLE_HOST.replace(/\./g, '\\.'), 'g');
+  const candidates = [];
+  let m = re.exec(stdout);
+  while (m !== null) {
+    candidates.push(m[1]);
+    m = re.exec(stdout);
+  }
+
+  if (!candidates.length) {
+    console.error('No logged-in ClickHouse Cloud console tab found.');
+    console.error('Open https://' + CONSOLE_HOST + ' and sign in, then retry.');
+    process.exit(1);
+  }
+  // Prefer a tab that actually carries a live token (tabs can be mid-reload).
+  for (const c of candidates) {
+    if (await tabHasToken(c)) { _tabId = c; return _tabId; }
+  }
+  // Fall back to the first candidate; apiCall surfaces a clear no-token error.
+  _tabId = candidates[0];
+  return _tabId;
+}
+
+// ─── Page-context API call (token stays in the browser) ─────────────────────────
+
+async function apiCall(method, url, body, ctype) {
+  const tabId = await findTab();
+  const bodyJson = body == null ? null : (typeof body === 'string' ? body : JSON.stringify(body));
+  const code = [
+    '(async () => {',
+    '  const key = Object.keys(localStorage).find(k => k.startsWith("@@auth0spajs@@") && k.includes("control-plane-web"));',
+    '  if (!key) return JSON.stringify({ __error: "no-token" });',
+    '  let tok; try { tok = JSON.parse(localStorage.getItem(key)).body.access_token; } catch (e) {}',
+    '  if (!tok) return JSON.stringify({ __error: "no-token" });',
+    '  const h = { "authorization": "Bearer " + tok };',
+    '  const bodyStr = ' + JSON.stringify(bodyJson) + ';',
+    '  if (bodyStr != null) h["content-type"] = ' + JSON.stringify(ctype || 'text/plain;charset=UTF-8') + ';',
+    '  const opts = { method: ' + JSON.stringify(method) + ', credentials: "include", headers: h };',
+    '  if (bodyStr != null) opts.body = bodyStr;',
+    '  try {',
+    '    const r = await fetch(' + JSON.stringify(url) + ', opts);',
+    '    const t = await r.text();',
+    '    return JSON.stringify({ status: r.status, body: t });',
+    '  } catch (e) { return JSON.stringify({ __error: "fetch-failed", detail: String(e) }); }',
+    '})()',
+  ].join('\n');
+
+  const tmp = '/shared/.chc_eval_' + Date.now() + '_' + Math.floor(Math.random() * 1e6) + '.js';
+  await fs.writeFile(tmp, code);
+  let result;
+  try {
+    result = await exec('playwright-cli eval-file ' + tmp + ' --tab=' + tabId);
+  } finally {
+    await fs.rm(tmp).catch(function () {});
+  }
+  if (result.exitCode !== 0) {
+    throw new Error('page-context eval failed: ' + (result.stderr || result.stdout || 'unknown'));
+  }
+  let parsed;
+  try { parsed = JSON.parse(result.stdout.trim()); }
+  catch (e) { throw new Error('Could not parse eval output: ' + result.stdout.slice(0, 300)); }
+
+  if (parsed.__error === 'no-token') {
+    console.error('Console session token not found. Sign in at https://' + CONSOLE_HOST + ' and retry.');
+    process.exit(1);
+  }
+  if (parsed.__error) throw new Error('API call error: ' + parsed.__error + ' ' + (parsed.detail || ''));
+
+  if (parsed.status === 401 || parsed.status === 403) {
+    console.error('Unauthorized (' + parsed.status + '). Console session may have expired — re-open ' +
+      'https://' + CONSOLE_HOST + ' and retry.');
+    process.exit(1);
+  }
+  if (parsed.status >= 400) {
+    throw new Error('HTTP ' + parsed.status + ': ' + String(parsed.body).slice(0, 300));
+  }
+  let json;
+  try { json = JSON.parse(parsed.body); }
+  catch (e) { return parsed.body; }
+  return json;
+}
+
+// RPC helpers (control-plane appends ?<action> and echoes rpcAction in the body)
+function rpc(base, action, extra) {
+  return apiCall('POST', base + '?' + action, Object.assign({ rpcAction: action }, extra || {}));
+}
+
+// ─── Arg parsing ─────────────────────────────────────────────────────────────
+
+function parseArgs(args) {
+  const opts = {};
+  const pos = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a.startsWith('--')) {
+      const eq = a.indexOf('=');
+      if (eq !== -1) opts[a.slice(2, eq)] = a.slice(eq + 1);
+      else {
+        const next = args[i + 1];
+        if (next !== undefined && !next.startsWith('--')) { opts[a.slice(2)] = next; i++; }
+        else opts[a.slice(2)] = true;
+      }
+    } else pos.push(a);
+  }
+  return { opts, pos };
+}
+
+// ─── Formatting ────────────────────────────────────────────────────────────────
+
+function money(n) { return '$' + Number(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }); }
+function num(n, d) { return Number(n).toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: d == null ? 3 : d }); }
+function bytes(n) {
+  if (n == null) return '-';
+  const u = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+  let v = Number(n), i = 0;
+  while (v >= 1024 && i < u.length - 1) { v /= 1024; i++; }
+  return v.toFixed(v >= 100 || i === 0 ? 0 : 2) + ' ' + u[i];
+}
+function pad(s, w) { s = String(s); return s.length >= w ? s : s + ' '.repeat(w - s.length); }
+function table(rows, cols) {
+  const widths = cols.map(c => Math.max(c.label.length, ...rows.map(r => String(c.get(r) == null ? '-' : c.get(r)).length)));
+  const line = cols.map((c, i) => pad(c.label, widths[i])).join('  ');
+  console.log(line);
+  console.log(cols.map((c, i) => '-'.repeat(widths[i])).join('  '));
+  for (const r of rows) console.log(cols.map((c, i) => pad(c.get(r) == null ? '-' : c.get(r), widths[i])).join('  '));
+}
+
+// ─── Org resolution ─────────────────────────────────────────────────────────────
+
+async function listOrgs() {
+  const res = await rpc(CP + '/api/organization', 'list');
+  // response: { <orgId>: { id, name, ... }, ... }
+  return Object.values(res).map(o => ({ id: o.id, name: o.name, tier: o.tier || o.organizationTier }));
+}
+
+async function resolveOrg(opts) {
+  if (opts.org) return opts.org;
+  const orgs = await listOrgs();
+  if (orgs.length === 1) return orgs[0].id;
+  if (orgs.length === 0) { console.error('No organizations found for this account.'); process.exit(1); }
+  console.error('Multiple organizations — specify --org=<id>:');
+  for (const o of orgs) console.error('  ' + o.id + '  ' + o.name);
+  process.exit(1);
+}
+
+// ─── Commands ─────────────────────────────────────────────────────────────────
+
+async function cmdOrgs(opts) {
+  const orgs = await listOrgs();
+  if (opts.json) { console.log(JSON.stringify(orgs, null, 2)); return; }
+  table(orgs, [
+    { label: 'ID', get: r => r.id },
+    { label: 'NAME', get: r => r.name },
+    { label: 'TIER', get: r => r.tier || '-' },
+  ]);
+}
+
+async function listInstances(orgId) {
+  const res = await rpc(CP + '/api/instance', 'list', { organizationId: orgId });
+  return (res && res.instances) || [];
+}
+
+function replicaSummary(i) {
+  const min = i.minReplicas, max = i.maxReplicas;
+  return min === max ? String(min) : min + '-' + max;
+}
+function memSummary(i) {
+  const min = i.minAutoScalingReplicaMemory, max = i.maxAutoScalingReplicaMemory;
+  if (min == null && max == null) return '-';
+  return (min === max ? String(min) : min + '-' + max) + ' GB';
+}
+
+async function cmdServices(opts) {
+  const orgId = await resolveOrg(opts);
+  const insts = await listInstances(orgId);
+  if (opts.json) { console.log(JSON.stringify(insts, null, 2)); return; }
+  if (!insts.length) { console.log('No services in org ' + orgId); return; }
+  table(insts, [
+    { label: 'NAME', get: r => r.name },
+    { label: 'ID', get: r => r.id },
+    { label: 'STATE', get: r => r.state },
+    { label: 'TIER', get: r => r.instanceTier || '-' },
+    { label: 'REGION', get: r => r.regionId },
+    { label: 'VERSION', get: r => r.clickhouseVersion },
+    { label: 'REPLICAS', get: r => replicaSummary(r) },
+    { label: 'MEM/REPLICA', get: r => memSummary(r) },
+    { label: 'IDLE', get: r => (r.enableIdleScaling ? (r.idleTimeoutMinutes + 'm') : 'off') },
+  ]);
+  console.log('\nReplicas shown as min-max (autoscaling range). MEM/REPLICA is per-replica RAM range.');
+}
+
+async function cmdService(pos, opts) {
+  const svcId = pos[0];
+  if (!svcId) { console.error('Usage: clickhouse-cloud service <serviceId> [--org=ID]'); process.exit(1); }
+  const orgId = await resolveOrg(opts);
+  const insts = await listInstances(orgId);
+  const inst = insts.find(i => i.id === svcId);
+  if (!inst) { console.error('Service ' + svcId + ' not found in org ' + orgId); process.exit(1); }
+  if (opts.json) { console.log(JSON.stringify(inst, null, 2)); return; }
+  const fields = [
+    ['Name', inst.name], ['ID', inst.id], ['State', inst.state], ['Tier', inst.instanceTier],
+    ['Provider', inst.cloudProvider], ['Region', inst.regionId], ['Version', inst.clickhouseVersion],
+    ['Replicas (min-max)', replicaSummary(inst)], ['Memory/replica', memSummary(inst)],
+    ['Min required memory', (inst.minRequiredMemoryGb != null ? inst.minRequiredMemoryGb + ' GB' : '-')],
+    ['Idle scaling', inst.enableIdleScaling ? ('on (' + inst.idleTimeoutMinutes + ' min)') : 'off'],
+    ['Autoscaling mode', inst.autoscalingMode || '-'],
+    ['Release channel', inst.releaseChannel || '-'],
+    ['Endpoint', inst.endpoints && inst.endpoints.https ? inst.endpoints.https.hostname : '-'],
+  ];
+  const w = Math.max(...fields.map(f => f[0].length));
+  for (const [k, v] of fields) console.log(pad(k, w) + '  ' + (v == null ? '-' : v));
+}
+
+// Recursively collect all { key: { metricValue, cost } } line items from a report node.
+function collectLineItems(node, out) {
+  if (!node || typeof node !== 'object') return;
+  for (const [k, v] of Object.entries(node)) {
+    if (v && typeof v === 'object' && 'cost' in v && 'metricValue' in v) {
+      out[k] = { metricValue: (out[k] ? out[k].metricValue : 0) + v.metricValue, cost: (out[k] ? out[k].cost : 0) + v.cost };
+    }
+  }
+}
+
+async function cmdCost(opts) {
+  const orgId = await resolveOrg(opts);
+  const period = opts.period || 'BILL_DATE';
+  const res = await rpc(CP + '/api/billing', 'getUsageReport', { organizationId: orgId, usagePeriod: { type: period } });
+  const report = res.report || res;
+  if (opts.json) { console.log(JSON.stringify(report, null, 2)); return; }
+
+  console.log('ClickHouse Cloud usage report');
+  console.log('Org:      ' + report.organizationId);
+  console.log('Period:   ' + report.startDate + '  ->  ' + report.endDateInclusive + '  (' + period + ')');
+  console.log('Currency: ' + report.currency);
+  console.log('');
+
+  const svcRows = [];
+  let grandTotal = 0;
+  for (const dw of (report.dataWarehouseReports || [])) {
+    const items = {};
+    collectLineItems(dw, items);                    // storage line items live on the warehouse
+    collectLineItems(dw.totalInstanceReport, items); // compute/transfer aggregated across instances
+    let dwTotal = 0;
+    for (const k of Object.keys(items)) dwTotal += items[k].cost;
+    grandTotal += dwTotal;
+    svcRows.push({ name: dw.name, provider: dw.cloudProvider, region: dw.region, tier: dw.organizationTier, total: dwTotal, items });
+  }
+
+  table(svcRows, [
+    { label: 'SERVICE', get: r => r.name },
+    { label: 'TIER', get: r => r.tier },
+    { label: 'REGION', get: r => r.region },
+    { label: 'COST', get: r => money(r.total) },
+  ]);
+  console.log('');
+  console.log('TOTAL: ' + money(grandTotal) + ' ' + report.currency + ' (period to date)');
+
+  // Per-service line-item detail
+  for (const s of svcRows) {
+    const entries = Object.entries(s.items).filter(([, v]) => v.cost > 0 || v.metricValue > 0);
+    if (!entries.length) continue;
+    console.log('\n' + s.name + ' — line items:');
+    const rows = entries.sort((a, b) => b[1].cost - a[1].cost).map(([k, v]) => ({ k, v }));
+    table(rows, [
+      { label: 'LINE ITEM', get: r => r.k },
+      { label: 'USAGE', get: r => num(r.v.metricValue) },
+      { label: 'COST', get: r => money(r.v.cost) },
+    ]);
+  }
+}
+
+// ── Utilization ──
+
+function seriesStats(values) {
+  const nn = values.filter(v => v != null && !isNaN(v));
+  if (!nn.length) return { points: values.length, nonNull: 0, min: null, max: null, avg: null, latest: null };
+  return {
+    points: values.length, nonNull: nn.length,
+    min: Math.min(...nn), max: Math.max(...nn),
+    avg: nn.reduce((a, b) => a + b, 0) / nn.length,
+    latest: nn[nn.length - 1],
+  };
+}
+
+// queryMetrics data shape: batch[].data = [ [ {node, data:[[tsMs,val],...]}, ... ] ]
+function flattenQueryMetrics(data) {
+  const vals = [];
+  const walk = (x) => {
+    if (Array.isArray(x)) {
+      if (x.length === 2 && typeof x[0] === 'number') vals.push(x[1]);
+      else { for (const el of x) walk(el); }
+    } else if (x && x.data) walk(x.data);
+  };
+  walk(data);
+  return vals;
+}
+
+async function cmdMetrics(pos, opts) {
+  const svcId = pos[0];
+  if (!svcId) { console.error('Usage: clickhouse-cloud metrics <serviceId> [--type TYPE | --metric NAME] [--period LAST_DAY] [--org ID]'); process.exit(1); }
+
+  // Console time-series endpoint (--metric)
+  if (opts.metric) {
+    const metric = opts.metric === true ? 'disk_storage' : opts.metric;
+    const now = Math.floor(Date.now() / 1000);
+    const endTime = opts.to ? parseInt(opts.to) : now;
+    const startTime = opts.from ? parseInt(opts.from) : (endTime - 86400);
+    const aggregationPeriod = opts.step ? parseInt(opts.step) : 3600;
+    const aggregation = opts.agg || 'node_chart_max';
+    const res = await apiCall('POST', CA + '/.api/metrics',
+      { query: { aggregation, aggregationPeriod, endTime, metric, startTime }, serviceId: svcId },
+      'text/plain;charset=UTF-8');
+    const m = res.metrics || {};
+    if (opts.json) { console.log(JSON.stringify(res, null, 2)); return; }
+    console.log('Console metric: ' + metric + '  service ' + svcId);
+    console.log('Window: ' + new Date(startTime * 1000).toISOString() + '  ->  ' + new Date(endTime * 1000).toISOString());
+    const series = m.series || [];
+    if (!series.length) { console.log('No data points (service may be idle / scaled to zero).'); return; }
+    for (const s of series) {
+      const st = seriesStats((s.values || []).map(p => p.y));
+      console.log('  ' + (s.name || 'series') + ': min ' + num(st.min) + '  max ' + num(st.max) + '  avg ' + num(st.avg) + '  latest ' + num(st.latest) + '  (' + st.nonNull + '/' + st.points + ' pts)');
+    }
+    return;
+  }
+
+  // control-plane queryMetrics batch (--type, default a curated set)
+  const orgId = await resolveOrg(opts);
+  const period = opts.period || 'LAST_DAY';
+  if (TIME_PERIODS.indexOf(period) === -1) { console.error('Invalid --period. Valid: ' + TIME_PERIODS.join(', ')); process.exit(1); }
+  let types;
+  if (opts.type) types = [opts.type === true ? 'CPU_USAGE_MAX' : opts.type];
+  else types = ['CPU_USAGE_MAX', 'MEMORY_USAGE_MAX', 'ALLOCATED_MEMORY', 'S3_STORAGE_USAGE', 'QUERIES_PER_SECOND'];
+
+  const res = await apiCall('POST', CP + '/api/metrics/queryMetrics',
+    { organizationId: orgId, instanceId: svcId, batch: types.map(t => ({ type: t, timePeriod: period })) });
+  if (opts.json) { console.log(JSON.stringify(res, null, 2)); return; }
+
+  console.log('Utilization for service ' + svcId + '  (' + period + ')\n');
+  const rows = (res.batch || []).map(item => {
+    const st = seriesStats(flattenQueryMetrics(item.data));
+    const fmt = BYTE_TYPES.has(item.type) ? bytes : (v => v == null ? '-' : num(v));
+    return { type: item.type, min: fmt(st.min), max: fmt(st.max), avg: fmt(st.avg), latest: fmt(st.latest), n: st.nonNull + '/' + st.points };
+  });
+  table(rows, [
+    { label: 'METRIC', get: r => r.type },
+    { label: 'MIN', get: r => r.min },
+    { label: 'MAX', get: r => r.max },
+    { label: 'AVG', get: r => r.avg },
+    { label: 'LATEST', get: r => r.latest },
+    { label: 'POINTS', get: r => r.n },
+  ]);
+}
+
+async function cmdApi(pos, opts) {
+  const method = (pos[0] || 'GET').toUpperCase();
+  const url = pos[1];
+  if (!url) { console.error('Usage: clickhouse-cloud api <METHOD> <URL> [--body=JSON] [--ctype=...]'); process.exit(1); }
+  const body = opts.body === true ? null : (opts.body || null);
+  const res = await apiCall(method, url, body, opts.ctype === true ? undefined : opts.ctype);
+  console.log(typeof res === 'string' ? res : JSON.stringify(res, null, 2));
+}
+
+function showHelp() {
+  console.log('clickhouse-cloud — ClickHouse Cloud cost & utilization reporting\n');
+  console.log('(Console/control-plane API — for SQL queries use the `klickhaus` skill.)\n');
+  console.log('Commands:');
+  console.log('  orgs                             List organizations');
+  console.log('  services [--org ID]              List services (state, tier, replicas, memory, idle)');
+  console.log('  service <svcId> [--org ID]       Full detail for one service');
+  console.log('  cost [--org ID] [--period P]     Usage/billing report: per-service cost + line items');
+  console.log('  metrics <svcId> [FLAGS]          Utilization summary (min/max/avg/latest)');
+  console.log('  api <METHOD> <URL> [--body=..]   Raw authenticated passthrough\n');
+  console.log('Global flags:');
+  console.log('  --org=ID       Organization id (auto-detected if you have exactly one)');
+  console.log('  --json         Emit raw JSON instead of a formatted table\n');
+  console.log('cost flags:');
+  console.log('  --period=P     BILL_DATE (default). Billing usage period type.\n');
+  console.log('metrics flags:');
+  console.log('  --type=TYPE    control-plane instance metric (default: a curated batch)');
+  console.log('  --period=P     ' + TIME_PERIODS.join(', ') + ' (default LAST_DAY)');
+  console.log('  --metric=NAME  console time-series metric (e.g. disk_storage); times in seconds');
+  console.log('  --from=SEC --to=SEC --step=SEC   window for --metric (unix seconds)');
+  console.log('  --agg=AGG      console aggregation (default node_chart_max)\n');
+  console.log('  instance metric types: ' + INSTANCE_METRIC_TYPES.slice(0, 8).join(', ') + ', ...');
+  console.log('  console metrics:       ' + CONSOLE_METRICS.slice(0, 8).join(', ') + ', ...');
+  console.log('  (see references/endpoints.md for the full lists)\n');
+  console.log('Examples:');
+  console.log('  clickhouse-cloud cost');
+  console.log('  clickhouse-cloud services');
+  console.log('  clickhouse-cloud metrics 6f3c51d6-c282-421a-a46d-54fc08d4ce99 --period=LAST_WEEK');
+  console.log('  clickhouse-cloud metrics <svc> --type=S3_STORAGE_USAGE --period=LAST_MONTH');
+  console.log('  clickhouse-cloud metrics <svc> --metric=disk_storage');
+}
+
+// ─── Main ──────────────────────────────────────────────────────────────────────
+
+const raw = process.argv.slice(2);
+const cmd = raw[0];
+const { opts, pos } = parseArgs(raw.slice(1));
+
+if (!cmd || cmd === 'help' || cmd === '--help' || cmd === '-h') { showHelp(); process.exit(cmd ? 0 : 1); }
+
+try {
+  switch (cmd) {
+    case 'orgs':     await cmdOrgs(opts); break;
+    case 'services': await cmdServices(opts); break;
+    case 'service':  await cmdService(pos, opts); break;
+    case 'cost':     await cmdCost(opts); break;
+    case 'metrics':  await cmdMetrics(pos, opts); break;
+    case 'usage':    await cmdCost(opts); break;
+    case 'api':      await cmdApi(pos, opts); break;
+    default:
+      console.error('Unknown command: ' + cmd);
+      showHelp();
+      process.exit(1);
+  }
+} catch (e) {
+  console.error('Error: ' + (e && e.message ? e.message : e));
+  process.exit(1);
+}

--- a/skills/clickhouse-cloud/scripts/clickhouse-cloud.jsh
+++ b/skills/clickhouse-cloud/scripts/clickhouse-cloud.jsh
@@ -22,6 +22,24 @@ const CONSOLE_HOST = 'console.clickhouse.cloud';
 const CP  = 'https://control-plane-internal.clickhouse.cloud'; // control-plane
 const CA  = 'https://console-api-internal.clickhouse.cloud';   // console-api
 
+// The live Auth0 bearer token is attached to every request, so requests must
+// only ever go to trusted ClickHouse Cloud API hosts — never an arbitrary URL
+// (which could exfiltrate the token). `api` and all callers validate against this.
+const ALLOWED_HOSTS = new Set([
+  'control-plane-internal.clickhouse.cloud',
+  'console-api-internal.clickhouse.cloud',
+]);
+
+function assertAllowedUrl(url) {
+  let host;
+  try { host = new URL(url).host; } catch (e) { host = null; }
+  if (!host || !ALLOWED_HOSTS.has(host)) {
+    console.error('Refusing to send the bearer token to a non-ClickHouse host: ' + url);
+    console.error('Allowed hosts: ' + [...ALLOWED_HOSTS].join(', '));
+    process.exit(1);
+  }
+}
+
 // console-api /.api/metrics time-series metric names (aggregation node_chart_max,
 // times in SECONDS). Discovered from the console bundle.
 const CONSOLE_METRICS = [
@@ -104,6 +122,7 @@ async function findTab() {
 // ─── Page-context API call (token stays in the browser) ─────────────────────────
 
 async function apiCall(method, url, body, ctype) {
+  assertAllowedUrl(url);
   const tabId = await findTab();
   const bodyJson = body == null ? null : (typeof body === 'string' ? body : JSON.stringify(body));
   const code = [
@@ -291,14 +310,34 @@ async function cmdService(pos, opts) {
   for (const [k, v] of fields) console.log(pad(k, w) + '  ' + (v == null ? '-' : v));
 }
 
-// Recursively collect all { key: { metricValue, cost } } line items from a report node.
+// Collect { key: { metricValue, cost } } line items from a report node.
+// Recurses into nested aggregate objects (e.g. totalClickpipeReport) so their
+// line items are captured, but does NOT descend into arrays of sub-reports
+// (instanceReports / clickpipeReports) — those are already rolled up into the
+// totalInstanceReport we pass in, so recursing would double-count.
 function collectLineItems(node, out) {
-  if (!node || typeof node !== 'object') return;
+  if (!node || typeof node !== 'object' || Array.isArray(node)) return;
   for (const [k, v] of Object.entries(node)) {
-    if (v && typeof v === 'object' && 'cost' in v && 'metricValue' in v) {
+    if (!v || typeof v !== 'object') continue;
+    if ('cost' in v && 'metricValue' in v) {
       out[k] = { metricValue: (out[k] ? out[k].metricValue : 0) + v.metricValue, cost: (out[k] ? out[k].cost : 0) + v.cost };
+    } else if (!Array.isArray(v)) {
+      collectLineItems(v, out); // nested aggregate (e.g. totalClickpipeReport)
     }
   }
+}
+
+// Sum every { cost } leaf under a node (deep) — used for authoritative totals.
+function sumCosts(node) {
+  if (!node || typeof node !== 'object') return 0;
+  let total = 0;
+  for (const v of Object.values(node)) {
+    if (v && typeof v === 'object') {
+      if (typeof v.cost === 'number') total += v.cost;
+      else total += sumCosts(v);
+    }
+  }
+  return total;
 }
 
 async function cmdCost(opts) {
@@ -315,15 +354,24 @@ async function cmdCost(opts) {
   console.log('');
 
   const svcRows = [];
-  let grandTotal = 0;
   for (const dw of (report.dataWarehouseReports || [])) {
+    // One recursive pass over the warehouse node captures storage line items
+    // (direct children) plus everything under totalInstanceReport
+    // (compute/transfer/clickpipes). The per-instance instanceReports array is
+    // skipped by collectLineItems, so nothing is double-counted.
     const items = {};
-    collectLineItems(dw, items);                    // storage line items live on the warehouse
-    collectLineItems(dw.totalInstanceReport, items); // compute/transfer aggregated across instances
+    collectLineItems(dw, items);
     let dwTotal = 0;
     for (const k of Object.keys(items)) dwTotal += items[k].cost;
-    grandTotal += dwTotal;
     svcRows.push({ name: dw.name, provider: dw.cloudProvider, region: dw.region, tier: dw.organizationTier, total: dwTotal, items });
+  }
+  // Managed Postgres instances bill separately from data warehouses.
+  for (const pg of (report.pgInstanceReports || [])) {
+    const items = {};
+    collectLineItems(pg, items);
+    let pgTotal = 0;
+    for (const k of Object.keys(items)) pgTotal += items[k].cost;
+    svcRows.push({ name: (pg.name || 'Postgres') + ' (pg)', provider: pg.cloudProvider, region: pg.region, tier: pg.organizationTier, total: pgTotal, items });
   }
 
   table(svcRows, [
@@ -333,6 +381,10 @@ async function cmdCost(opts) {
     { label: 'COST', get: r => money(r.total) },
   ]);
   console.log('');
+  // Authoritative org-wide total: the API's own totalUsageReport if present,
+  // otherwise the sum of the per-service rows above.
+  const rowSum = svcRows.reduce((a, r) => a + r.total, 0);
+  const grandTotal = report.totalUsageReport ? sumCosts(report.totalUsageReport) : rowSum;
   console.log('TOTAL: ' + money(grandTotal) + ' ' + report.currency + ' (period to date)');
 
   // Per-service line-item detail
@@ -351,28 +403,40 @@ async function cmdCost(opts) {
 
 // ── Utilization ──
 
-function seriesStats(values) {
-  const nn = values.filter(v => v != null && !isNaN(v));
-  if (!nn.length) return { points: values.length, nonNull: 0, min: null, max: null, avg: null, latest: null };
+// Accepts an array of [timestamp, value] points (timestamp may be null for the
+// console time-series, which is already time-ordered). min/max/avg use every
+// non-null value; `latest` is the value at the newest timestamp (so for
+// multi-node series it reflects the most recent sample, not the last-listed node).
+function seriesStats(points) {
+  const nn = points.filter(p => p[1] != null && !isNaN(p[1]));
+  if (!nn.length) return { points: points.length, nonNull: 0, min: null, max: null, avg: null, latest: null };
+  const vals = nn.map(p => p[1]);
+  let latestPt = nn[0];
+  for (const p of nn) {
+    if (p[0] == null || latestPt[0] == null) latestPt = p; // no ts → assume input order
+    else if (p[0] >= latestPt[0]) latestPt = p;
+  }
   return {
-    points: values.length, nonNull: nn.length,
-    min: Math.min(...nn), max: Math.max(...nn),
-    avg: nn.reduce((a, b) => a + b, 0) / nn.length,
-    latest: nn[nn.length - 1],
+    points: points.length, nonNull: nn.length,
+    min: Math.min(...vals), max: Math.max(...vals),
+    avg: vals.reduce((a, b) => a + b, 0) / vals.length,
+    latest: latestPt[1],
   };
 }
 
 // queryMetrics data shape: batch[].data = [ [ {node, data:[[tsMs,val],...]}, ... ] ]
+// Returns [tsMs, value] pairs across all nodes so seriesStats can pick the
+// value at the newest timestamp rather than the last-appended node's tail.
 function flattenQueryMetrics(data) {
-  const vals = [];
+  const pts = [];
   const walk = (x) => {
     if (Array.isArray(x)) {
-      if (x.length === 2 && typeof x[0] === 'number') vals.push(x[1]);
+      if (x.length === 2 && typeof x[0] === 'number') pts.push([x[0], x[1]]);
       else { for (const el of x) walk(el); }
     } else if (x && x.data) walk(x.data);
   };
   walk(data);
-  return vals;
+  return pts;
 }
 
 async function cmdMetrics(pos, opts) {
@@ -397,7 +461,7 @@ async function cmdMetrics(pos, opts) {
     const series = m.series || [];
     if (!series.length) { console.log('No data points (service may be idle / scaled to zero).'); return; }
     for (const s of series) {
-      const st = seriesStats((s.values || []).map(p => p.y));
+      const st = seriesStats((s.values || []).map(p => [p.x, p.y]));
       console.log('  ' + (s.name || 'series') + ': min ' + num(st.min) + '  max ' + num(st.max) + '  avg ' + num(st.avg) + '  latest ' + num(st.latest) + '  (' + st.nonNull + '/' + st.points + ' pts)');
     }
     return;

--- a/skills/clickhouse-cloud/scripts/clickhouse-cloud.jsh
+++ b/skills/clickhouse-cloud/scripts/clickhouse-cloud.jsh
@@ -21,6 +21,7 @@ const fs   = require('fs');
 const CONSOLE_HOST = 'console.clickhouse.cloud';
 const CP  = 'https://control-plane-internal.clickhouse.cloud'; // control-plane
 const CA  = 'https://console-api-internal.clickhouse.cloud';   // console-api
+const QUERIES = 'https://queries.clickhouse.cloud';            // SQL-console query proxy
 
 // The live Auth0 bearer token is attached to every request, so requests must
 // only ever go to trusted ClickHouse Cloud API hosts — never an arbitrary URL
@@ -28,6 +29,7 @@ const CA  = 'https://console-api-internal.clickhouse.cloud';   // console-api
 const ALLOWED_HOSTS = new Set([
   'control-plane-internal.clickhouse.cloud',
   'console-api-internal.clickhouse.cloud',
+  'queries.clickhouse.cloud',
 ]);
 
 function assertAllowedUrl(url) {
@@ -504,15 +506,82 @@ async function cmdApi(pos, opts) {
   console.log(typeof res === 'string' ? res : JSON.stringify(res, null, 2));
 }
 
+// ─── SQL query (SQL-console query proxy, session-authenticated) ─────────────────
+// Runs SQL against a service via the same endpoint the Cloud SQL console uses
+// (queries.clickhouse.cloud), signed with the in-page Auth0 token — so no separate
+// database username/password is needed, unlike a direct native/HTTP connection.
+
+async function resolveService(opts) {
+  const explicit = (typeof opts.service === 'string' && opts.service) ||
+                   (typeof opts.instance === 'string' && opts.instance) || null;
+  if (explicit) return explicit;
+  const orgId = await resolveOrg(opts);
+  const insts = await listInstances(orgId);
+  if (insts.length === 1) return insts[0].id;
+  if (insts.length === 0) { console.error('No services in this org. Specify --service=<id>.'); process.exit(1); }
+  console.error('Multiple services — specify --service=<id>:');
+  for (const i of insts) console.error('  ' + i.id + '  ' + i.name);
+  process.exit(1);
+}
+
+function fmtCell(v) {
+  if (v == null) return '';
+  if (typeof v === 'object') return JSON.stringify(v);
+  return String(v);
+}
+
+// Parse the streaming JSONEachRowWithProgress body into { meta, rows, exception }.
+function parseRowStream(body) {
+  const out = { meta: [], rows: [], exception: null };
+  for (const ln of String(body).split('\n')) {
+    if (!ln.trim()) continue;
+    let o; try { o = JSON.parse(ln); } catch (e) { continue; }
+    if (o.exception) out.exception = o.exception;
+    else if (o.meta) out.meta = o.meta;
+    else if (o.row) out.rows.push(o.row);
+    // {progress:{...}} lines are ignored
+  }
+  return out;
+}
+
+async function cmdQuery(pos, opts) {
+  let sql = pos.join(' ').trim();
+  if (typeof opts.file === 'string' && opts.file) sql = (await fs.readFile(opts.file, 'utf8')).trim();
+  if (!sql) {
+    console.error('Usage: clickhouse-cloud query "<SQL>" [--service=ID] [--org=ID] [--database=default] [--json|--tsv]');
+    console.error('   or: clickhouse-cloud query --file=query.sql [--service=ID]');
+    process.exit(1);
+  }
+  const svcId = await resolveService(opts);
+  const database = (typeof opts.database === 'string' && opts.database) || 'default';
+  const runId = 'liveQueries:' + Date.now().toString(36) + Math.random().toString(36).slice(2, 10);
+  const url = QUERIES + '/service/' + encodeURIComponent(svcId) +
+    '/run?enable_http_compression=1&format=JSONEachRowWithProgress&request_timeout=3600000';
+  const raw = await apiCall('POST', url, JSON.stringify({ runId, sql, database }), 'text/plain;charset=UTF-8');
+  const res = parseRowStream(typeof raw === 'string' ? raw : JSON.stringify(raw));
+  if (res.exception) { console.error('ClickHouse: ' + res.exception); process.exit(1); }
+  if (opts.json) { console.log(JSON.stringify(res.rows, null, 2)); return; }
+  if (!res.meta.length && !res.rows.length) { console.log('(no rows)'); return; }
+  const cols = res.meta.length ? res.meta.map(m => m.name) : Object.keys(res.rows[0] || {});
+  if (opts.tsv) {
+    console.log(cols.join('\t'));
+    for (const r of res.rows) console.log(cols.map(c => fmtCell(r[c])).join('\t'));
+    return;
+  }
+  table(res.rows, cols.map(c => ({ label: c, get: r => fmtCell(r[c]) })));
+  console.log('\n' + res.rows.length + ' row(s).');
+}
+
 function showHelp() {
   console.log('clickhouse-cloud — ClickHouse Cloud cost & utilization reporting\n');
-  console.log('(Console/control-plane API — for SQL queries use the `klickhaus` skill.)\n');
+  console.log('(Console/control-plane API. Also runs SQL via the Cloud SQL-console proxy —\n see `query` below; the `klickhaus` skill remains the dedicated CDN-logs workflow.)\n');
   console.log('Commands:');
   console.log('  orgs                             List organizations');
   console.log('  services [--org ID]              List services (state, tier, replicas, memory, idle)');
   console.log('  service <svcId> [--org ID]       Full detail for one service');
   console.log('  cost [--org ID] [--period P]     Usage/billing report: per-service cost + line items');
   console.log('  metrics <svcId> [FLAGS]          Utilization summary (min/max/avg/latest)');
+  console.log('  query "<SQL>" [FLAGS]            Run SQL against a service (session-auth, no DB password)');
   console.log('  api <METHOD> <URL> [--body=..]   Raw authenticated passthrough\n');
   console.log('Global flags:');
   console.log('  --org=ID       Organization id (auto-detected if you have exactly one)');
@@ -528,12 +597,19 @@ function showHelp() {
   console.log('  instance metric types: ' + INSTANCE_METRIC_TYPES.slice(0, 8).join(', ') + ', ...');
   console.log('  console metrics:       ' + CONSOLE_METRICS.slice(0, 8).join(', ') + ', ...');
   console.log('  (see references/endpoints.md for the full lists)\n');
+  console.log('query flags:');
+  console.log('  --service=ID   service to run against (auto-detected if the org has exactly one)');
+  console.log('  --database=DB  default database (default: default)');
+  console.log('  --file=PATH    read SQL from a file instead of the argument');
+  console.log('  --json | --tsv output as JSON array / TSV instead of a table\n');
   console.log('Examples:');
   console.log('  clickhouse-cloud cost');
   console.log('  clickhouse-cloud services');
   console.log('  clickhouse-cloud metrics 6f3c51d6-c282-421a-a46d-54fc08d4ce99 --period=LAST_WEEK');
   console.log('  clickhouse-cloud metrics <svc> --type=S3_STORAGE_USAGE --period=LAST_MONTH');
   console.log('  clickhouse-cloud metrics <svc> --metric=disk_storage');
+  console.log('  clickhouse-cloud query "SELECT count() FROM system.query_log" --service=<svc>');
+  console.log('  clickhouse-cloud query --file=q.sql --json');
 }
 
 // ─── Main ──────────────────────────────────────────────────────────────────────
@@ -552,6 +628,8 @@ try {
     case 'cost':     await cmdCost(opts); break;
     case 'metrics':  await cmdMetrics(pos, opts); break;
     case 'usage':    await cmdCost(opts); break;
+    case 'query':    await cmdQuery(pos, opts); break;
+    case 'sql':      await cmdQuery(pos, opts); break;
     case 'api':      await cmdApi(pos, opts); break;
     default:
       console.error('Unknown command: ' + cmd);


### PR DESCRIPTION
## What this adds

A new SLICC skill **`clickhouse-cloud`** for **cost and utilization reporting** on ClickHouse Cloud via the management console / control-plane API. It complements the existing `klickhaus` skill, which runs SQL against a ClickHouse service's data plane — this skill covers the *cloud console* (billing, infrastructure, metrics), not SQL.

### Command surface (`scripts/clickhouse-cloud.jsh`)
- `orgs` — list organizations.
- `services [--org ID]` — service inventory: state, tier, region, version, replica range, per-replica memory, idle-scaling.
- `service <svcId>` — full detail for one service.
- `cost [--org ID] [--period]` — usage/billing report via `getUsageReport`: per-service cost table, grand total, and per-line-item breakdown (compute unit hours, storage TB-months for tables + backups, public/inter-region data transfer, ClickPipes).
- `metrics <svcId> [--type TYPE | --metric NAME] [--period]` — utilization summary (min/max/avg/latest). Default source is the control-plane `queryMetrics` batch (CPU, memory, S3 storage, QPS, connections, …); `--metric` switches to the console-api time-series endpoint.
- `api <METHOD> <URL> [--body=..]` — raw authenticated passthrough.
- Global `--org`, `--json`.

## Auth model (no secrets stored or committed)

The ClickHouse Cloud internal APIs require **both** an `Authorization: Bearer <JWT>` (Auth0 access token) **and** an `Origin: https://console.clickhouse.cloud` header, so a direct fetch is CORS/401-rejected. Instead, every call runs as a **page-context fetch inside the user's signed-in `console.clickhouse.cloud` browser tab** (via `playwright-cli eval-file`). The Auth0 token is read from `localStorage` in-page and used only there — it is **never printed, stored, or committed**. No `.config`, token, or captured HAR data is included.

## Provenance

Reverse-engineered from the ClickHouse Cloud console using the `secret-sauce` workflow: endpoint surface discovered via the app's resource timing + JS bundle (rpcActions, metric enums, URL builders), then validated with live read-only calls. `references/endpoints.md` documents the full endpoint surface, cost line-item keys, instance metric types, console metric names, and response schemas.

Live-tested read-only against a real org/service: `cost` returns the usage report with a per-service total; `services` shows replica/memory config; `metrics` returns CPU/memory/S3-storage/QPS summaries. No auth errors.

Please do not squash — the per-file commit history is intentional.
