### PR TITLE
feat(teams): add monday inbox source subcommand

### DIFF
--- a/skills/teams/SKILL.md
+++ b/skills/teams/SKILL.md
@@ -270,7 +270,9 @@ Scans up to `--max-teams` teams (default 10). Progress is printed to stderr.
 `monday`-protocol inbox source (see the `monday` skill,
 `references/SOURCE_PROTOCOL.md`). Prints a **single JSON array** to stdout and
 nothing else; all progress/warnings go to stderr and the command always exits
-`0` (an empty inbox is `[]`). Intended to be called by `monday`, which merges
+`0` (an empty inbox is `[]`) — including when Teams itself is unavailable, e.g.
+no signed-in tab, so the aggregator degrades instead of failing. Intended to be
+called by `monday`, which merges
 it with `gh`, `slack`, `outlook`, `gmail` and `servicenow`.
 
 ```bash
@@ -282,7 +284,7 @@ Items returned:
 
 | Type | Source |
 |---|---|
-| `chat` / `group-chat` | Newest message from **someone else** in each 1:1 or group chat active in the window, plus `--depth` older messages as `context[]`. |
+| `chat` / `group-chat` | Newest message from **someone else** in each 1:1 or group chat active in the window, plus `--depth` older messages as `context[]`. Paginates past your own replies, so a chat still appears when you sent the last several messages. |
 | `channel-mention` / `chat-mention` / `channel-reply` | Entries from the Teams **activity feed** (`48:notifications`) — @mentions and thread replies aimed at you. |
 
 Fields: `id` (`teams-msg-<messageId>` / `teams-activity-<activityId>`), `ts`

--- a/skills/teams/SKILL.md
+++ b/skills/teams/SKILL.md
@@ -8,8 +8,8 @@ description: >-
   Supports all teams and channels the user has access to, with auth via the live browser
   session. Use when the user wants to check Teams messages, post a Teams message, search
   Teams channels, read a thread, get user info, view mentions, transcribe or caption a
-  live meeting, or automate any Teams task.
-  Triggers on mentions of Teams, channels, messages, threads, mentions, activity, digest,
+  live meeting, feed the cross-tool monday inbox digest, or automate any Teams task.
+  Triggers on mentions of Teams, channels, messages, threads, mentions, activity, digest, monday,
   transcribe, transcript, captions, or meeting notes.
 allowed-tools: bash
 ---
@@ -270,6 +270,44 @@ Scans up to `--max-teams` teams (default 10). Progress is printed to stderr.
 > **Large tenants:** With the parallel fetch, 10 teams × N channels typically
 > completes in under 15s. Use `--max-teams=20` if you want broader coverage
 > and have headroom. Lower to `--max-teams=5` if you see timeouts.
+
+### teams monday [--limit N] [--depth N] [--date Nd]
+
+`monday`-protocol inbox source (see the `monday` skill,
+`references/SOURCE_PROTOCOL.md`). Prints a **single JSON array** to stdout and
+nothing else; all progress/warnings go to stderr and the command always exits
+`0` (an empty inbox is `[]`). Intended to be called by `monday`, which merges
+it with `gh`, `slack`, `outlook`, `gmail` and `servicenow`.
+
+```bash
+teams monday --limit 20 --depth 3 --date 7d
+monday teams --limit 10 --date 21d       # via the aggregator
+```
+
+Items returned:
+
+| Type | Source |
+|---|---|
+| `chat` / `group-chat` | Newest message from **someone else** in each 1:1 or group chat active in the window, plus `--depth` older messages as `context[]`. |
+| `channel-mention` / `chat-mention` / `channel-reply` | Entries from the Teams **activity feed** (`48:notifications`) — @mentions and thread replies aimed at you. |
+
+Fields: `id` (`teams-msg-<messageId>` / `teams-activity-<activityId>`), `ts`
+(ISO-8601), `source: "teams"`, `title`, `url` (deep link
+`https://teams.microsoft.com/l/message/<threadId>/<messageId>`), `participants`,
+`body` (HTML stripped), plus `from`, `chat`/`threadId`, `chatType`, `unread`,
+`context[]`. `importance`/`urgency`/`summary` are intentionally **not** emitted —
+`monday` adds those when rating.
+
+> **Why not Graph `/me/chats`:** the delegated browser token has no
+> `Chat.ReadBasic/Chat.Read/Chat.ReadWrite` scope, so Graph answers `403`
+> (this is also why `teams activity` logs "Chat scan unavailable (403)").
+> `monday` therefore uses the **Teams chat service (IC3)** the web client itself
+> uses: a `skypeToken` from `POST teams.microsoft.com/api/authsvc/v1.0/authz`
+> (obtained in-page with an `api.spaces.skype.com` token) against
+> `<regionGtms.chatService>/v1/users/ME/conversations[/…/messages]`. Tokens are
+> minted and consumed inside the Teams tab, exactly like every other
+> subcommand. If the activity feed is unavailable, it falls back to the Graph
+> beta channel scan used by `teams activity`.
 
 ### teams transcribe [start|flush|status|follow|stop] [--out=FILE]
 

--- a/skills/teams/SKILL.md
+++ b/skills/teams/SKILL.md
@@ -182,13 +182,6 @@ Fetch recent top-level messages from a channel (replies are not inlined — use
 
 **Alias:** `teams messages` / `teams msgs` also route to `history`.
 
-### teams activity [--since=DURATION] [--max-teams=N] [--concurrency=N]
-
-Messages that mention or involve the current user. Default window is the last
-24 hours. See the full description in the **Available commands** section below.
-
-**Alias:** `teams mentions` also routes to `activity`.
-
 ### teams post \<team\> \<channel\> \<message\> [--reply-to=\<message-id\>]
 
 Post a plain-text message to a channel, or reply in a thread when
@@ -298,16 +291,11 @@ Fields: `id` (`teams-msg-<messageId>` / `teams-activity-<activityId>`), `ts`
 `context[]`. `importance`/`urgency`/`summary` are intentionally **not** emitted —
 `monday` adds those when rating.
 
-> **Why not Graph `/me/chats`:** the delegated browser token has no
-> `Chat.ReadBasic/Chat.Read/Chat.ReadWrite` scope, so Graph answers `403`
-> (this is also why `teams activity` logs "Chat scan unavailable (403)").
-> `monday` therefore uses the **Teams chat service (IC3)** the web client itself
-> uses: a `skypeToken` from `POST teams.microsoft.com/api/authsvc/v1.0/authz`
-> (obtained in-page with an `api.spaces.skype.com` token) against
-> `<regionGtms.chatService>/v1/users/ME/conversations[/…/messages]`. Tokens are
-> minted and consumed inside the Teams tab, exactly like every other
-> subcommand. If the activity feed is unavailable, it falls back to the Graph
-> beta channel scan used by `teams activity`.
+Chats are read via the Teams chat service rather than Graph, and the command
+falls back to a channel scan if the activity feed is unavailable. You do not
+need to know either to use it — see
+[`references/endpoints.md`](references/endpoints.md#monday-chat-retrieval) if
+you are changing the implementation.
 
 ### teams transcribe [start|flush|status|follow|stop] [--out=FILE]
 

--- a/skills/teams/SKILL.md
+++ b/skills/teams/SKILL.md
@@ -325,22 +325,12 @@ de-duplicated Markdown:
 **[15:04:48] Dragos Dascalita Haut:** And where are you taking this now?
 ```
 
-**How it works.** A `MutationObserver` on the caption virtual-list
-(`closed-caption-v2-virtual-list-content`) captures changes event-driven (no poll gaps).
-Each spoken utterance is its OWN `[data-tid="closed-caption-text"]` element whose text
-grows as it is recognized, then finalizes when the next utterance's element appears — so
-the collector keeps one buffer entry per element and **supersedes its text as it grows**,
-delivering each utterance to the webhook exactly once (when it finalizes, or after a
-short debounce for the trailing one). The speaker name sits ~2 ancestors above the text
-span (`"Name\n<text>"`). The `window` buffer survives across evals, so you can `flush` on
-any cadence without losing lines; only a tab reload clears it.
+Capture is event-driven from the caption DOM, one buffer entry per
+utterance, delivered once when it finalizes. The buffer survives across evals, so
+you can `flush` on any cadence; only a tab reload clears it. Implementation
+rationale and the DOM-vs-network investigation live in
+[`references/endpoints.md`](references/endpoints.md#live-caption-capture).
 
-> **Why DOM (not the network):** verified on the wire — Teams live captions arrive over
-> the encrypted **WebRTC media channel** and materialize only in the client DOM; there is
-> **no WebSocket/HTTP source** to tap (a HAR + WS-frame capture during active captioning
-> showed zero caption traffic). Element-level DOM capture is therefore the complete and
-> correct approach. Validated live: a 20-utterance test captured and delivered 20/20.
->
 > **Common pitfall:** the virtual-list has a single wrapper child — iterate the
 > `closed-caption-text` elements, NOT `list.children`, or you'll see one merged blob.
 
@@ -370,12 +360,15 @@ teams transcribe stop
 - **`--snapshot`** (a flag, composes with any subcommand — typically `flush`): if a screen share is active, captures **only the shared-screen preview** — it draws the largest shared `<video>` element to an in-page canvas and exports a PNG — and keeps it only if the shared content changed (a pixel-payload hash), into `--shots-dir` (default `/shared/copilot-shots/`). Scoping to the video means the dedupe ignores unrelated window churn (captions, chat, roster, clock). Falls back to a full-window screenshot if no capturable video is present.
 - **`teams post --live <message>`**: posts into the **currently active meeting's chat**, visible to all participants. Uses **real CDP input** via `playwright-cli` (resolve the compose box + Send button from the accessibility snapshot, click → type → click Send) — Teams' CKEditor ignores in-page DOM edits, so genuine keystrokes are required.
 
-Typical wiring: `teams transcribe start --scoop meeting-copilot` → the `meeting-copilot` scoop receives a lick per phrase, calls `teams transcribe flush --snapshot` for the latest text + a shared-screen frame, decides whether additional context is warranted, and if so calls `teams post --live "..."`.
+```bash
+teams transcribe start --scoop meeting-copilot   # lick per phrase
+teams transcribe flush --snapshot                # latest text + screen frame
+teams post --live "..."                          # reply into meeting chat
+```
 
-> **Validated live** against a real meeting (Jul 2026): webhook→lick delivery, canvas
-> snapshot + content-scoped dedupe, and `post --live` all confirmed working. Selectors
-> (caption list, meeting-chat compose/Send, share `<video>`) may still need updates if a
-> future Teams build changes its DOM.
+Selectors (caption list, meeting-chat compose/Send, share `<video>`) may need
+updates if a future Teams build changes its DOM; see
+[`references/endpoints.md`](references/endpoints.md#copilot-mode-wiring).
 
 ## Troubleshooting
 

--- a/skills/teams/SKILL.md
+++ b/skills/teams/SKILL.md
@@ -8,9 +8,10 @@ description: >-
   Supports all teams and channels the user has access to, with auth via the live browser
   session. Use when the user wants to check Teams messages, post a Teams message, search
   Teams channels, read a thread, get user info, view mentions, transcribe or caption a
-  live meeting, feed the cross-tool monday inbox digest, or automate any Teams task.
-  Triggers on mentions of Teams, channels, messages, threads, mentions, activity, digest, monday,
-  transcribe, transcript, captions, or meeting notes.
+  live meeting, or feed Microsoft Teams items into the SLICC `monday` start-of-day
+  inbox digest (the monday aggregator skill — unrelated to the monday.com SaaS product).
+  Triggers on mentions of Teams, Microsoft Teams, channels, messages, threads, mentions,
+  activity, digest, transcribe, transcript, captions, or meeting notes.
 allowed-tools: bash
 ---
 
@@ -325,12 +326,22 @@ de-duplicated Markdown:
 **[15:04:48] Dragos Dascalita Haut:** And where are you taking this now?
 ```
 
-Capture is event-driven from the caption DOM, one buffer entry per
-utterance, delivered once when it finalizes. The buffer survives across evals, so
-you can `flush` on any cadence; only a tab reload clears it. Implementation
-rationale and the DOM-vs-network investigation live in
-[`references/endpoints.md`](references/endpoints.md#live-caption-capture).
+**How it works.** A `MutationObserver` on the caption virtual-list
+(`closed-caption-v2-virtual-list-content`) captures changes event-driven (no poll gaps).
+Each spoken utterance is its OWN `[data-tid="closed-caption-text"]` element whose text
+grows as it is recognized, then finalizes when the next utterance's element appears — so
+the collector keeps one buffer entry per element and **supersedes its text as it grows**,
+delivering each utterance to the webhook exactly once (when it finalizes, or after a
+short debounce for the trailing one). The speaker name sits ~2 ancestors above the text
+span (`"Name\n<text>"`). The `window` buffer survives across evals, so you can `flush` on
+any cadence without losing lines; only a tab reload clears it.
 
+> **Why DOM (not the network):** verified on the wire — Teams live captions arrive over
+> the encrypted **WebRTC media channel** and materialize only in the client DOM; there is
+> **no WebSocket/HTTP source** to tap (a HAR + WS-frame capture during active captioning
+> showed zero caption traffic). Element-level DOM capture is therefore the complete and
+> correct approach. Validated live: a 20-utterance test captured and delivered 20/20.
+>
 > **Common pitfall:** the virtual-list has a single wrapper child — iterate the
 > `closed-caption-text` elements, NOT `list.children`, or you'll see one merged blob.
 
@@ -360,15 +371,12 @@ teams transcribe stop
 - **`--snapshot`** (a flag, composes with any subcommand — typically `flush`): if a screen share is active, captures **only the shared-screen preview** — it draws the largest shared `<video>` element to an in-page canvas and exports a PNG — and keeps it only if the shared content changed (a pixel-payload hash), into `--shots-dir` (default `/shared/copilot-shots/`). Scoping to the video means the dedupe ignores unrelated window churn (captions, chat, roster, clock). Falls back to a full-window screenshot if no capturable video is present.
 - **`teams post --live <message>`**: posts into the **currently active meeting's chat**, visible to all participants. Uses **real CDP input** via `playwright-cli` (resolve the compose box + Send button from the accessibility snapshot, click → type → click Send) — Teams' CKEditor ignores in-page DOM edits, so genuine keystrokes are required.
 
-```bash
-teams transcribe start --scoop meeting-copilot   # lick per phrase
-teams transcribe flush --snapshot                # latest text + screen frame
-teams post --live "..."                          # reply into meeting chat
-```
+Typical wiring: `teams transcribe start --scoop meeting-copilot` → the `meeting-copilot` scoop receives a lick per phrase, calls `teams transcribe flush --snapshot` for the latest text + a shared-screen frame, decides whether additional context is warranted, and if so calls `teams post --live "..."`.
 
-Selectors (caption list, meeting-chat compose/Send, share `<video>`) may need
-updates if a future Teams build changes its DOM; see
-[`references/endpoints.md`](references/endpoints.md#copilot-mode-wiring).
+> **Validated live** against a real meeting (Jul 2026): webhook→lick delivery, canvas
+> snapshot + content-scoped dedupe, and `post --live` all confirmed working. Selectors
+> (caption list, meeting-chat compose/Send, share `<video>`) may still need updates if a
+> future Teams build changes its DOM.
 
 ## Troubleshooting
 

--- a/skills/teams/references/endpoints.md
+++ b/skills/teams/references/endpoints.md
@@ -254,3 +254,21 @@ limits. If you hit throttling, wait per the `Retry-After` header and retry.
 | 404 | Resource not found | Team / channel / message ID is wrong |
 | 429 | Throttled | Wait per `Retry-After` header |
 | 503 | Service unavailable | Transient — retry after a few seconds |
+
+## monday chat retrieval
+
+`teams monday` cannot read chats through Graph: the delegated browser token
+carries no `Chat.ReadBasic` / `Chat.Read` / `Chat.ReadWrite` scope, so
+`/me/chats` answers `403`. (This is the same cause as the
+`Chat scan unavailable (403)` warning from `teams activity`.)
+
+It therefore uses the Teams chat service (IC3) that the web client itself uses:
+
+1. `POST teams.microsoft.com/api/authsvc/v1.0/authz` — obtained in-page with an
+   `api.spaces.skype.com` token — returns a `skypeToken`.
+2. That token is used against
+   `<regionGtms.chatService>/v1/users/ME/conversations[/…/messages]`.
+
+Tokens are minted and consumed inside the Teams tab, exactly like every other
+subcommand; nothing is persisted. If the activity feed is unavailable, `monday`
+falls back to the Graph beta channel scan used by `teams activity`.

--- a/skills/teams/references/endpoints.md
+++ b/skills/teams/references/endpoints.md
@@ -1,4 +1,4 @@
-# Teams — Graph API Endpoints Reference
+# Teams â Graph API Endpoints Reference
 
 Per-endpoint documentation for the `teams` skill. All calls use an OAuth 2
 bearer token extracted from the user's Teams browser session.
@@ -49,8 +49,8 @@ The Teams web app requests broad scopes. This skill uses:
 |---|---|
 | `User.Read` | `activity` (resolve `/me`), `user` |
 | `User.ReadBasic.All` | `user` (lookup by name / UPN) |
-| `Team.ReadBasic.All` | `teams`, name → ID resolution |
-| `Channel.ReadBasic.All` | `channels`, `info`, channel name → ID resolution |
+| `Team.ReadBasic.All` | `teams`, name â ID resolution |
+| `Channel.ReadBasic.All` | `channels`, `info`, channel name â ID resolution |
 | `ChannelMessage.Read.Group` / `ChannelMessage.Read.All` (beta) | `history`, `unanswered`, `digest`, `thread` |
 | `ChannelMessage.Send` | `post` |
 | `Chat.Read` | `search`, `activity` (via Search API) |
@@ -60,12 +60,12 @@ consent via the Azure portal or re-open Teams after a tenant policy change.
 
 ### Token lifetime
 
-Tokens typically expire after 60–90 minutes. The Teams web app silently
+Tokens typically expire after 60â90 minutes. The Teams web app silently
 refreshes them. When a token expires:
 
 1. `teams` commands fail with `401 Unauthorized`.
 2. Refresh the Teams tab in the browser. The next command picks up the new
-   token automatically — there is no separate auth step to run.
+   token automatically â there is no separate auth step to run.
 
 ## Graph API base URLs
 
@@ -179,7 +179,7 @@ Content-Type: application/json
 ```
 
 `{message-id}` is the `id` of the top-level parent message. The response is
-a reply message resource — structurally identical to a channel message.
+a reply message resource â structurally identical to a channel message.
 
 ### Get message replies (thread read)
 
@@ -231,7 +231,7 @@ primary path of `teams activity`.
 GET https://graph.microsoft.com/v1.0/teams/{team-id}/channels/getAllMessages
 ```
 
-Requires application permissions (`ChannelMessage.Read.All`) — **not
+Requires application permissions (`ChannelMessage.Read.All`) â **not
 available** with delegated tokens from the browser session. Mentioned here
 only for reference.
 
@@ -242,7 +242,7 @@ Microsoft Graph applies per-app and per-tenant throttling. When throttled:
 - Response status: `429 Too Many Requests`
 - `Retry-After` header indicates seconds to wait
 
-The skill paginates conservatively (`maxPages` 2–5 per call) to stay within
+The skill paginates conservatively (`maxPages` 2â5 per call) to stay within
 limits. If you hit throttling, wait per the `Retry-After` header and retry.
 
 ## Common error codes
@@ -253,7 +253,7 @@ limits. If you hit throttling, wait per the `Retry-After` header and retry.
 | 403 | Insufficient permissions | Token lacks a required scope. Confirm you're on the **beta** endpoint for message reads. |
 | 404 | Resource not found | Team / channel / message ID is wrong |
 | 429 | Throttled | Wait per `Retry-After` header |
-| 503 | Service unavailable | Transient — retry after a few seconds |
+| 503 | Service unavailable | Transient â retry after a few seconds |
 
 ## monday chat retrieval
 
@@ -264,11 +264,40 @@ carries no `Chat.ReadBasic` / `Chat.Read` / `Chat.ReadWrite` scope, so
 
 It therefore uses the Teams chat service (IC3) that the web client itself uses:
 
-1. `POST teams.microsoft.com/api/authsvc/v1.0/authz` — obtained in-page with an
-   `api.spaces.skype.com` token — returns a `skypeToken`.
+1. `POST teams.microsoft.com/api/authsvc/v1.0/authz` â obtained in-page with an
+   `api.spaces.skype.com` token â returns a `skypeToken`.
 2. That token is used against
-   `<regionGtms.chatService>/v1/users/ME/conversations[/…/messages]`.
+   `<regionGtms.chatService>/v1/users/ME/conversations[/â¦/messages]`.
 
 Tokens are minted and consumed inside the Teams tab, exactly like every other
 subcommand; nothing is persisted. If the activity feed is unavailable, `monday`
 falls back to the Graph beta channel scan used by `teams activity`.
+
+## live caption capture
+
+**How it works.** A `MutationObserver` on the caption virtual-list
+(`closed-caption-v2-virtual-list-content`) captures changes event-driven (no poll gaps).
+Each spoken utterance is its OWN `[data-tid="closed-caption-text"]` element whose text
+grows as it is recognized, then finalizes when the next utterance's element appears  so
+the collector keeps one buffer entry per element and **supersedes its text as it grows**,
+delivering each utterance to the webhook exactly once (when it finalizes, or after a
+short debounce for the trailing one). The speaker name sits ~2 ancestors above the text
+span (`"Name\n<text>"`). The `window` buffer survives across evals, so you can `flush` on
+any cadence without losing lines; only a tab reload clears it.
+
+> **Why DOM (not the network):** verified on the wire  Teams live captions arrive over
+> the encrypted **WebRTC media channel** and materialize only in the client DOM; there is
+> **no WebSocket/HTTP source** to tap (a HAR + WS-frame capture during active captioning
+> showed zero caption traffic). Element-level DOM capture is therefore the complete and
+> correct approach. Validated live: a 20-utterance test captured and delivered 20/20.
+>
+
+## copilot mode wiring
+
+Typical wiring: `teams transcribe start --scoop meeting-copilot`  the `meeting-copilot` scoop receives a lick per phrase, calls `teams transcribe flush --snapshot` for the latest text + a shared-screen frame, decides whether additional context is warranted, and if so calls `teams post --live "..."`.
+
+> **Validated live** against a real meeting (Jul 2026): webhooklick delivery, canvas
+> snapshot + content-scoped dedupe, and `post --live` all confirmed working. Selectors
+> (caption list, meeting-chat compose/Send, share `<video>`) may still need updates if a
+> future Teams build changes its DOM.
+

--- a/skills/teams/references/endpoints.md
+++ b/skills/teams/references/endpoints.md
@@ -1,4 +1,4 @@
-# Teams â Graph API Endpoints Reference
+# Teams — Graph API Endpoints Reference
 
 Per-endpoint documentation for the `teams` skill. All calls use an OAuth 2
 bearer token extracted from the user's Teams browser session.
@@ -49,8 +49,8 @@ The Teams web app requests broad scopes. This skill uses:
 |---|---|
 | `User.Read` | `activity` (resolve `/me`), `user` |
 | `User.ReadBasic.All` | `user` (lookup by name / UPN) |
-| `Team.ReadBasic.All` | `teams`, name â ID resolution |
-| `Channel.ReadBasic.All` | `channels`, `info`, channel name â ID resolution |
+| `Team.ReadBasic.All` | `teams`, name → ID resolution |
+| `Channel.ReadBasic.All` | `channels`, `info`, channel name → ID resolution |
 | `ChannelMessage.Read.Group` / `ChannelMessage.Read.All` (beta) | `history`, `unanswered`, `digest`, `thread` |
 | `ChannelMessage.Send` | `post` |
 | `Chat.Read` | `search`, `activity` (via Search API) |
@@ -60,12 +60,12 @@ consent via the Azure portal or re-open Teams after a tenant policy change.
 
 ### Token lifetime
 
-Tokens typically expire after 60â90 minutes. The Teams web app silently
+Tokens typically expire after 60–90 minutes. The Teams web app silently
 refreshes them. When a token expires:
 
 1. `teams` commands fail with `401 Unauthorized`.
 2. Refresh the Teams tab in the browser. The next command picks up the new
-   token automatically â there is no separate auth step to run.
+   token automatically — there is no separate auth step to run.
 
 ## Graph API base URLs
 
@@ -179,7 +179,7 @@ Content-Type: application/json
 ```
 
 `{message-id}` is the `id` of the top-level parent message. The response is
-a reply message resource â structurally identical to a channel message.
+a reply message resource — structurally identical to a channel message.
 
 ### Get message replies (thread read)
 
@@ -231,7 +231,7 @@ primary path of `teams activity`.
 GET https://graph.microsoft.com/v1.0/teams/{team-id}/channels/getAllMessages
 ```
 
-Requires application permissions (`ChannelMessage.Read.All`) â **not
+Requires application permissions (`ChannelMessage.Read.All`) — **not
 available** with delegated tokens from the browser session. Mentioned here
 only for reference.
 
@@ -242,7 +242,7 @@ Microsoft Graph applies per-app and per-tenant throttling. When throttled:
 - Response status: `429 Too Many Requests`
 - `Retry-After` header indicates seconds to wait
 
-The skill paginates conservatively (`maxPages` 2â5 per call) to stay within
+The skill paginates conservatively (`maxPages` 2–5 per call) to stay within
 limits. If you hit throttling, wait per the `Retry-After` header and retry.
 
 ## Common error codes
@@ -253,7 +253,7 @@ limits. If you hit throttling, wait per the `Retry-After` header and retry.
 | 403 | Insufficient permissions | Token lacks a required scope. Confirm you're on the **beta** endpoint for message reads. |
 | 404 | Resource not found | Team / channel / message ID is wrong |
 | 429 | Throttled | Wait per `Retry-After` header |
-| 503 | Service unavailable | Transient â retry after a few seconds |
+| 503 | Service unavailable | Transient — retry after a few seconds |
 
 ## monday chat retrieval
 
@@ -264,40 +264,11 @@ carries no `Chat.ReadBasic` / `Chat.Read` / `Chat.ReadWrite` scope, so
 
 It therefore uses the Teams chat service (IC3) that the web client itself uses:
 
-1. `POST teams.microsoft.com/api/authsvc/v1.0/authz` â obtained in-page with an
-   `api.spaces.skype.com` token â returns a `skypeToken`.
+1. `POST teams.microsoft.com/api/authsvc/v1.0/authz` — obtained in-page with an
+   `api.spaces.skype.com` token — returns a `skypeToken`.
 2. That token is used against
-   `<regionGtms.chatService>/v1/users/ME/conversations[/â¦/messages]`.
+   `<regionGtms.chatService>/v1/users/ME/conversations[/…/messages]`.
 
 Tokens are minted and consumed inside the Teams tab, exactly like every other
 subcommand; nothing is persisted. If the activity feed is unavailable, `monday`
 falls back to the Graph beta channel scan used by `teams activity`.
-
-## live caption capture
-
-**How it works.** A `MutationObserver` on the caption virtual-list
-(`closed-caption-v2-virtual-list-content`) captures changes event-driven (no poll gaps).
-Each spoken utterance is its OWN `[data-tid="closed-caption-text"]` element whose text
-grows as it is recognized, then finalizes when the next utterance's element appears  so
-the collector keeps one buffer entry per element and **supersedes its text as it grows**,
-delivering each utterance to the webhook exactly once (when it finalizes, or after a
-short debounce for the trailing one). The speaker name sits ~2 ancestors above the text
-span (`"Name\n<text>"`). The `window` buffer survives across evals, so you can `flush` on
-any cadence without losing lines; only a tab reload clears it.
-
-> **Why DOM (not the network):** verified on the wire  Teams live captions arrive over
-> the encrypted **WebRTC media channel** and materialize only in the client DOM; there is
-> **no WebSocket/HTTP source** to tap (a HAR + WS-frame capture during active captioning
-> showed zero caption traffic). Element-level DOM capture is therefore the complete and
-> correct approach. Validated live: a 20-utterance test captured and delivered 20/20.
->
-
-## copilot mode wiring
-
-Typical wiring: `teams transcribe start --scoop meeting-copilot`  the `meeting-copilot` scoop receives a lick per phrase, calls `teams transcribe flush --snapshot` for the latest text + a shared-screen frame, decides whether additional context is warranted, and if so calls `teams post --live "..."`.
-
-> **Validated live** against a real meeting (Jul 2026): webhooklick delivery, canvas
-> snapshot + content-scoped dedupe, and `post --live` all confirmed working. Selectors
-> (caption list, meeting-chat compose/Send, share `<video>`) may still need updates if a
-> future Teams build changes its DOM.
-

--- a/skills/teams/scripts/teams.jsh
+++ b/skills/teams/scripts/teams.jsh
@@ -1936,7 +1936,7 @@ function mondayThreadUrl(threadId, messageId) {
 
 // 1:1 / group chat conversations with activity in the window, plus their most
 // recent messages. Both steps run in-page and return trimmed records.
-async function mondayFetchChats(cutoff, depth, maxChats) {
+async function mondayFetchChats(cutoff, depth, maxChats, meName) {
   const listBody = `
     const cutoff = ${cutoff};
     // 'space' = team channels (handled via the activity feed); everything else
@@ -1980,24 +1980,50 @@ async function mondayFetchChats(cutoff, depth, maxChats) {
   const chats = (listed.chats || []).sort((a, b) => b.lastTime - a.lastTime).slice(0, maxChats);
   if (chats.length === 0) return { chats: [] };
 
+  // Per-chat message fetch. A chat is only interesting if it contains a message
+  // from SOMEONE ELSE, but the user may have sent an arbitrary number of messages
+  // since then — so we cannot size this page off `depth`. Page until we find an
+  // incoming message (or run out / cross the cutoff), bounded to keep it cheap.
+  const pageSize = Math.min(50, Math.max(depth + 2, 8));
   const msgBody = `
     const chats = ${JSON.stringify(chats)};
     const cutoff = ${cutoff};
-    const pageSize = ${Math.min(50, Math.max(depth + 2, 4))};
+    const meName = ${JSON.stringify(meName || '')};
+    const pageSize = ${pageSize};
+    const MAX_PAGES = 4;
     const out = [];
+    const mapMsg = (m) => ({
+      id: m.id,
+      from: m.imdisplayname || m.fromDisplayNameInToken || '',
+      fromId: m.from || '',
+      ts: m.originalarrivaltime || m.composetime || '',
+      type: m.messagetype || '',
+      content: typeof m.content === 'string' ? m.content.slice(0, 4000) : '',
+      deleted: !!(m.properties && m.properties.deletetime),
+    });
+    const isIncoming = (m) =>
+      !m.deleted && m.content && /^(RichText|Text)/i.test(m.type || 'Text') &&
+      (m.from || '') !== meName && (Date.parse(m.ts) || 0) >= cutoff;
     for (const c of chats) {
       const base = c.messagesUrl || ('/v1/users/ME/conversations/' + encodeURIComponent(c.id) + '/messages');
-      const r = await __chatGet(base + '?view=msnp24Equivalent&pageSize=' + pageSize + '&startTime=1');
-      if (!r || r.error || !r.ok) { out.push({ chat: c, messages: [], error: (r && (r.error || r.status)) || 'ERR' }); continue; }
-      const msgs = ((r.data && r.data.messages) || []).map((m) => ({
-        id: m.id,
-        from: m.imdisplayname || m.fromDisplayNameInToken || '',
-        fromId: m.from || '',
-        ts: m.originalarrivaltime || m.composetime || '',
-        type: m.messagetype || '',
-        content: typeof m.content === 'string' ? m.content.slice(0, 4000) : '',
-        deleted: !!(m.properties && m.properties.deletetime),
-      }));
+      let url = base + '?view=msnp24Equivalent&pageSize=' + pageSize + '&startTime=1';
+      let msgs = [];
+      let err = null;
+      for (let page = 0; page < MAX_PAGES && url; page++) {
+        const r = await __chatGet(url);
+        if (!r || r.error || !r.ok) { err = (r && (r.error || r.status)) || 'ERR'; break; }
+        const batch = ((r.data && r.data.messages) || []).map(mapMsg);
+        msgs = msgs.concat(batch);
+        if (batch.length === 0) break;
+        // Stop as soon as this chat has an incoming message we can report.
+        if (msgs.some(isIncoming)) break;
+        // Stop once we are reading messages older than the window — anything
+        // further back cannot produce an in-window item.
+        const oldest = batch.reduce((acc, m) => Math.min(acc, Date.parse(m.ts) || Infinity), Infinity);
+        if (oldest !== Infinity && oldest < cutoff) break;
+        url = (r.data && r.data._metadata && r.data._metadata.syncState) || '';
+      }
+      if (err && msgs.length === 0) { out.push({ chat: c, messages: [], error: err }); continue; }
       out.push({ chat: c, messages: msgs });
     }
     return { results: out };
@@ -2077,6 +2103,7 @@ function mondayChatItems(results, meName, cutoff, depth) {
       type: oneOnOne ? 'chat' : 'group-chat',
       title: `Teams ${oneOnOne ? 'DM' : 'group chat'} — ${label} — ${sender}`,
       url: mondayThreadUrl(chat.id, msg.id),
+      threadId: chat.id,
       participants: Array.from(new Set([sender, ...others])),
       body: mondayBody(msg).slice(0, 2000),
       from: sender,
@@ -2202,6 +2229,20 @@ async function mondayGetAllSafe(url, maxPages) {
 }
 
 async function cmdMonday() {
+  // The monday source protocol requires a single JSON array on stdout and exit 0,
+  // ALWAYS — an empty inbox is []. Teams can fail hard underneath us (no signed-in
+  // tab, refresh token unobtainable), and those paths call die() -> process.exit(1),
+  // which would emit no array at all and break the aggregator. Contain that here.
+  try {
+    await mondayRun();
+  } catch (e) {
+    const msg = e?.message || String(e);
+    console.error(`[teams monday] WARNING: Teams unavailable (${msg}) — emitting empty inbox.`);
+    console.log("[]");
+  }
+}
+
+async function mondayRun() {
   const f = parseMondayFlags(process.argv.slice(2));
   const cutoff = mondayCutoff(f.date);
   const maxTeams = parseInt(flags['max-teams'] || '10', 10);
@@ -2225,14 +2266,16 @@ async function cmdMonday() {
   let chatItems = [];
   const chatThreadIds = new Set();
   try {
-    const chats = await mondayFetchChats(cutoff, f.depth, Math.max(f.limit, 20));
+    const chats = await mondayFetchChats(cutoff, f.depth, Math.max(f.limit, 20), meName);
     if (chats.error) {
       console.error(`[teams monday] WARNING: chat service unavailable (${chats.error}).`);
     } else {
       console.error(`[teams monday] ${(chats.chats || []).length} chats active in window.`);
       chatItems = mondayChatItems(chats.results || [], meName, cutoff, f.depth);
-      for (const it of chatItems) chatThreadIds.add(String(it.url));
-      for (const c of chats.chats || []) chatThreadIds.add(c.id);
+      // Suppress activity-feed duplicates ONLY for chats that actually produced a
+      // chat item. Adding every listed chat id would also discard mentions/replies
+      // from chats whose fetch failed or yielded nothing, losing them entirely.
+      for (const it of chatItems) if (it.threadId) chatThreadIds.add(it.threadId);
     }
   } catch (e) {
     console.error(`[teams monday] WARNING: chat scan failed: ${e?.message || e}`);

--- a/skills/teams/scripts/teams.jsh
+++ b/skills/teams/scripts/teams.jsh
@@ -8,7 +8,7 @@
 // leaves the browser context.
 //
 // Usage: teams <subcommand> [args] [--since=<duration>] [--top=<n>]
-// Subcommands: teams, channels, history, activity, post, thread, user, info, search, unanswered, digest
+// Subcommands: teams, channels, history, activity, post, thread, user, info, search, unanswered, digest, monday
 //
 // jsh runtime migration (issue #177):
 //  - Browser access uses the sliccy:browser bridge (findTab / evalAsync)
@@ -1793,6 +1793,493 @@ async function cmdTranscribe() {
   }
 }
 
+// ---------------------------------------------------------------------------
+// monday subcommand (cross-tool inbox aggregator source)
+// ---------------------------------------------------------------------------
+//
+// Contract (monday skill, references/SOURCE_PROTOCOL.md):
+//   teams monday --limit N --depth N --date Nd
+//   → one JSON array on stdout, NOTHING else on stdout, all logging on stderr,
+//     exit 0 (an empty result is `[]`, not an error). Items carry a stable
+//     source-prefixed `id` plus `ts`, `source`, `title`, `url`, `participants`
+//     and `body`. `importance`/`urgency`/`summary` are added by `monday`.
+//
+// Data sources (in page context, same auth model as every other subcommand):
+//   1. Teams chat service (IC3) — `<regionGtms.chatService>/v1/users/ME/...`,
+//      authenticated with a skypeToken obtained from
+//      POST teams.microsoft.com/api/authsvc/v1.0/authz. This is what the Teams
+//      web client itself uses for 1:1/group chats. Graph `/me/chats` cannot be
+//      used: the delegated browser token has no Chat.Read* scope (verified —
+//      Graph returns 403 "API requires one of 'Chat.ReadBasic, Chat.Read,
+//      Chat.ReadWrite'"), which is why `teams activity` logs "Chat scan
+//      unavailable (403)".
+//   2. The activity feed conversation `48:notifications` on the same service —
+//      each entry is an activity record (`properties.activity`) carrying
+//      mention/reply metadata plus a `messagePreview`; this is where channel
+//      @mentions come from.
+//   3. Fallback only: the Graph beta channel scan (same plumbing `activity`
+//      uses) when the activity feed yields nothing.
+//
+// Because the protocol requires exit 0 + a valid array even on partial
+// failure, this path uses only non-fatal wrappers (`apiGetSafe`, `skypeEval`),
+// never `graphGet`/`die()`.
+
+// In-page helper: mint a skypeToken (+ the region service map) from the
+// captured refresh token and cache it on `window`. Appended after
+// AUTH_PREAMBLE, which provides __getToken().
+const SKYPE_PREAMBLE = `
+  async function __getSkype() {
+    const c = window.__sliccTeamsSkype;
+    if (c && c.exp > Date.now() + 60000) return c;
+    const t = await __getToken('api.spaces.skype.com');
+    if (!t) return null;
+    const r = await fetch('https://teams.microsoft.com/api/authsvc/v1.0/authz', {
+      method: 'POST', headers: { Authorization: 'Bearer ' + t }
+    });
+    if (!r.ok) return null;
+    const j = await r.json().catch(() => null);
+    const st = j && j.tokens && j.tokens.skypeToken;
+    if (!st) return null;
+    window.__sliccTeamsSkype = {
+      st: st,
+      gtms: j.regionGtms || {},
+      exp: Date.now() + ((j.tokens.expiresIn || 3600) * 1000)
+    };
+    return window.__sliccTeamsSkype;
+  }
+  async function __chatGet(url) {
+    const s = await __getSkype();
+    if (!s) return { error: 'NO_SKYPE_TOKEN' };
+    const full = url.indexOf('http') === 0
+      ? url
+      : String(s.gtms.chatService || '').replace(/\\/$/, '') + url;
+    const r = await fetch(full, { headers: { Authentication: 'skypetoken=' + s.st } });
+    const txt = await r.text();
+    let data = null;
+    try { data = JSON.parse(txt); } catch (e) { data = txt; }
+    return { status: r.status, ok: r.ok, data: data };
+  }
+`;
+
+// Run a small collector snippet inside the Teams tab with __chatGet available.
+// The snippet must be an expression body of an async IIFE and should return
+// already-trimmed data (chat-service payloads are megabytes raw).
+async function skypeEval(bodyJs) {
+  const tab = await ensureTab();
+  const jsCode = `
+    (async () => {
+      try {
+        ${AUTH_PREAMBLE}
+        ${SKYPE_PREAMBLE}
+        return await (async () => { ${bodyJs} })();
+      } catch (e) {
+        return { error: 'FETCH_ERROR', message: String((e && e.message) || e) };
+      }
+    })()
+  `.trim();
+  let parsed;
+  try {
+    parsed = await browser.evalAsync(tab, jsCode);
+  } catch (e) {
+    return { error: 'EVAL_FAILED', message: e?.message || String(e) };
+  }
+  if (typeof parsed === 'string') {
+    try { parsed = JSON.parse(parsed); } catch { return { error: 'PARSE_FAILED' }; }
+  }
+  return parsed || { error: 'EMPTY' };
+}
+
+// Accepts both `--limit 5` and `--limit=5` so the command behaves the same
+// whether `monday` invokes it (space form) or a human does.
+function parseMondayFlags(argv) {
+  const f = { limit: 50, depth: 5, date: '7d' };
+  for (let i = 0; i < argv.length; i++) {
+    const a = String(argv[i]);
+    const eq = a.indexOf('=');
+    const name = eq === -1 ? a : a.slice(0, eq);
+    if (name !== '--limit' && name !== '--depth' && name !== '--date') continue;
+    const val = eq === -1 ? argv[i + 1] : a.slice(eq + 1);
+    if (val === undefined) continue;
+    if (name === '--date') f.date = String(val);
+    else f[name.slice(2)] = parseInt(val, 10);
+  }
+  if (!Number.isFinite(f.limit) || f.limit <= 0) f.limit = 50;
+  if (!Number.isFinite(f.depth) || f.depth < 0) f.depth = 5;
+  return f;
+}
+
+// `Nm`/`Nh`/`Nd`/`Nw` → cutoff epoch ms (defaults to 7 days).
+function mondayCutoff(dateStr) {
+  const ms = parseDuration(dateStr) || 7 * 86400000;
+  return Date.now() - ms;
+}
+
+function mondayBody(m) {
+  const raw = m && (m.content || m.body || '');
+  return raw ? stripHtml(String(raw)) : '';
+}
+
+function mondayIso(v) {
+  if (!v) return null;
+  const d = new Date(typeof v === 'number' ? v : String(v));
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
+// Web deep link into a chat/channel thread, optionally to one message.
+function mondayThreadUrl(threadId, messageId) {
+  const t = encodeURIComponent(threadId);
+  if (messageId) {
+    return `https://teams.microsoft.com/l/message/${t}/${encodeURIComponent(messageId)}`;
+  }
+  return `https://teams.microsoft.com/l/chat/${t}/conversations`;
+}
+
+// 1:1 / group chat conversations with activity in the window, plus their most
+// recent messages. Both steps run in-page and return trimmed records.
+async function mondayFetchChats(cutoff, depth, maxChats) {
+  const listBody = `
+    const cutoff = ${cutoff};
+    // 'space' = team channels (handled via the activity feed); everything else
+    // in the Chat list: 1:1 ('chat'), named group chats ('topic'), meeting chats.
+    const wanted = { chat: 1, topic: 1, group: 1, sfbinteropchat: 1, meeting: 1, privatemeeting: 1 };
+    const out = [];
+    let url = '/v1/users/ME/conversations?view=msnp24Equivalent&pageSize=200&startTime=1';
+    for (let page = 0; page < 3 && url; page++) {
+      const r = await __chatGet(url);
+      if (r.error) return { error: r.error };
+      if (!r.ok) return { error: 'HTTP_' + r.status };
+      const convs = (r.data && r.data.conversations) || [];
+      let oldest = Infinity;
+      for (const c of convs) {
+        const tp = c.threadProperties || {};
+        const props = c.properties || {};
+        const last = c.lastMessage || {};
+        const lastTime = Date.parse(props.lastimreceivedtime || last.originalarrivaltime || last.composetime || '') || 0;
+        if (lastTime) oldest = Math.min(oldest, lastTime);
+        const tt = String(tp.threadType || '').toLowerCase();
+        if (!wanted[tt]) continue;
+        if (props.isemptyconversation === 'True') continue;
+        if (lastTime && lastTime < cutoff) continue;
+        out.push({
+          id: c.id,
+          threadType: tt,
+          topic: tp.topic || tp.spaceThreadTopic || '',
+          lastTime: lastTime,
+          consumptionHorizon: props.consumptionhorizon || '',
+          messagesUrl: c.messages || '',
+        });
+      }
+      if (oldest !== Infinity && oldest < cutoff) break;
+      url = (r.data && r.data._metadata && r.data._metadata.syncState) || '';
+      if (convs.length === 0) break;
+    }
+    return { chats: out };
+  `;
+  const listed = await skypeEval(listBody);
+  if (listed.error) return { error: listed.error, chats: [] };
+  const chats = (listed.chats || []).sort((a, b) => b.lastTime - a.lastTime).slice(0, maxChats);
+  if (chats.length === 0) return { chats: [] };
+
+  const msgBody = `
+    const chats = ${JSON.stringify(chats)};
+    const cutoff = ${cutoff};
+    const pageSize = ${Math.min(50, Math.max(depth + 2, 4))};
+    const out = [];
+    for (const c of chats) {
+      const base = c.messagesUrl || ('/v1/users/ME/conversations/' + encodeURIComponent(c.id) + '/messages');
+      const r = await __chatGet(base + '?view=msnp24Equivalent&pageSize=' + pageSize + '&startTime=1');
+      if (!r || r.error || !r.ok) { out.push({ chat: c, messages: [], error: (r && (r.error || r.status)) || 'ERR' }); continue; }
+      const msgs = ((r.data && r.data.messages) || []).map((m) => ({
+        id: m.id,
+        from: m.imdisplayname || m.fromDisplayNameInToken || '',
+        fromId: m.from || '',
+        ts: m.originalarrivaltime || m.composetime || '',
+        type: m.messagetype || '',
+        content: typeof m.content === 'string' ? m.content.slice(0, 4000) : '',
+        deleted: !!(m.properties && m.properties.deletetime),
+      }));
+      out.push({ chat: c, messages: msgs });
+    }
+    return { results: out };
+  `;
+  const fetched = await skypeEval(msgBody);
+  if (fetched.error) return { error: fetched.error, chats: [] };
+  return { chats, results: fetched.results || [] };
+}
+
+// The Teams activity feed (`48:notifications`): mentions, replies and reactions
+// aimed at the current user, including channel mentions.
+async function mondayFetchActivity(cutoff, limit) {
+  const body = `
+    const r = await __chatGet('/v1/users/ME/conversations/48:notifications/messages?view=msnp24Equivalent&pageSize=' + ${Math.min(100, Math.max(limit * 4, 50))} + '&startTime=1');
+    if (!r || r.error) return { error: (r && r.error) || 'ERR' };
+    if (!r.ok) return { error: 'HTTP_' + r.status };
+    const out = [];
+    for (const m of ((r.data && r.data.messages) || [])) {
+      const a = (m.properties && m.properties.activity) || null;
+      if (!a) continue;
+      const t = Date.parse(a.activityTimestamp || m.originalarrivaltime || '') || 0;
+      if (t && t < ${cutoff}) continue;
+      out.push({
+        activityId: a.activityId,
+        activityType: a.activityType || '',
+        activitySubtype: a.activitySubtype || '',
+        ts: a.activityTimestamp || m.originalarrivaltime || '',
+        sourceThreadId: a.sourceThreadId || '',
+        sourceMessageId: a.sourceMessageId || '',
+        sourceReplyChainId: a.sourceReplyChainId || '',
+        from: a.sourceUserImDisplayName || '',
+        preview: typeof a.messagePreview === 'string' ? a.messagePreview.slice(0, 4000) : '',
+        threadTopic: a.sourceThreadTopic || a.threadTopic || '',
+      });
+    }
+    return { activities: out };
+  `;
+  const res = await skypeEval(body);
+  if (res.error) return { error: res.error, activities: [] };
+  return { activities: res.activities || [] };
+}
+
+// Chat items: newest message from someone else per conversation, with `depth`
+// older messages as context.
+function mondayChatItems(results, meName, cutoff, depth) {
+  const items = [];
+  for (const { chat, messages } of results) {
+    const usable = (messages || []).filter(
+      (m) => !m.deleted && m.content && /^(RichText|Text)/i.test(m.type || 'Text')
+    );
+    // Newest-first; take the newest message that is not the user's own.
+    const idx = usable.findIndex(
+      (m) => (m.from || '') !== meName && (Date.parse(m.ts) || 0) >= cutoff
+    );
+    if (idx === -1) continue;
+    const msg = usable[idx];
+    const sender = msg.from || 'unknown';
+    const context = usable.slice(idx + 1, idx + 1 + depth).map((m) => ({
+      from: m.from || 'unknown',
+      date: mondayIso(m.ts),
+      body: mondayBody(m).slice(0, 500),
+    }));
+    const others = Array.from(
+      new Set(usable.map((m) => m.from).filter((n) => n && n !== meName))
+    );
+    const label = chat.topic || (others.length ? others.slice(0, 4).join(', ') : 'Teams chat');
+    const oneOnOne = chat.threadType === 'chat' && others.length <= 1;
+    const lastRead = parseInt(String(chat.consumptionHorizon).split(';')[0], 10);
+    const unread = Number.isFinite(lastRead)
+      ? Number(msg.id) > lastRead
+      : null;
+
+    items.push({
+      id: `teams-msg-${msg.id}`,
+      ts: mondayIso(msg.ts),
+      source: 'teams',
+      type: oneOnOne ? 'chat' : 'group-chat',
+      title: `Teams ${oneOnOne ? 'DM' : 'group chat'} — ${label} — ${sender}`,
+      url: mondayThreadUrl(chat.id, msg.id),
+      participants: Array.from(new Set([sender, ...others])),
+      body: mondayBody(msg).slice(0, 2000),
+      from: sender,
+      date: mondayIso(msg.ts),
+      chat: label,
+      chatType: chat.threadType,
+      unread,
+      context,
+    });
+  }
+  return items;
+}
+
+// Activity-feed items: channel/chat mentions and replies aimed at the user.
+function mondayActivityItems(activities, seenThreadIds) {
+  const keep = { mention: 1, reply: 1 };
+  const items = [];
+  for (const a of activities) {
+    const kind = String(a.activityType).toLowerCase();
+    if (!keep[kind]) continue;
+    // Skip activities for chats already represented by a chat item.
+    if (a.sourceThreadId && seenThreadIds.has(a.sourceThreadId)) continue;
+    const preview = stripHtml(a.preview || '');
+    const sender = a.from || 'unknown';
+    const where = a.threadTopic ? ` in ${a.threadTopic}` : '';
+    const label = kind === 'mention' ? 'mention' : 'reply';
+    items.push({
+      id: `teams-activity-${a.activityId || `${a.sourceThreadId}-${a.sourceMessageId}`}`,
+      ts: mondayIso(a.ts),
+      source: 'teams',
+      type: `${a.activitySubtype === 'chat' ? 'chat' : 'channel'}-${label}`,
+      title: `Teams ${label}${where} — ${sender}`,
+      url: mondayThreadUrl(a.sourceThreadId, a.sourceMessageId),
+      participants: [sender],
+      body: preview.slice(0, 2000),
+      from: sender,
+      date: mondayIso(a.ts),
+      threadId: a.sourceThreadId,
+      activityType: kind,
+      activitySubtype: a.activitySubtype || '',
+      context: [],
+    });
+  }
+  return items;
+}
+
+// Fallback only: Graph beta channel scan (the same plumbing `teams activity`
+// uses) for channel mentions, used when the activity feed is unavailable.
+async function mondayChannelScan(me, cutoff, limit, maxTeams, concurrency) {
+  const allTeams = await mondayGetAllSafe(`${GRAPH_BASE}/me/joinedTeams`, 2);
+  const scan = allTeams.slice(0, maxTeams);
+  if (scan.length === 0) return [];
+  console.error(`[teams monday] Fallback: scanning channels in ${scan.length} of ${allTeams.length} teams...`);
+
+  const teamChannels = await pooled(
+    concurrency,
+    scan.map((team) => async () => {
+      const chans = await mondayGetAllSafe(`${GRAPH_BASE}/teams/${team.id}/channels`, 1);
+      return { team, channels: chans.slice(0, 3) };
+    })
+  );
+
+  const results = await pooled(
+    concurrency,
+    teamChannels.flatMap(({ team, channels }) =>
+      channels.map((channel) => async () => {
+        const r = await apiGetSafe(
+          `${GRAPH_BETA}/teams/${team.id}/channels/${channel.id}/messages?$top=25`
+        );
+        return { team, channel, messages: r.ok ? r.data?.value || [] : [] };
+      })
+    )
+  );
+
+  const nameLower = (me.displayName || '').toLowerCase();
+  const items = [];
+  for (const { team, channel, messages } of results) {
+    for (const m of messages) {
+      if (m.messageType !== 'message' || m.deletedDateTime) continue;
+      if ((Date.parse(m.createdDateTime) || 0) < cutoff) continue;
+      if (m.from?.user?.id === me.id) continue;
+      const bodyText = m.body?.content ? stripHtml(m.body.content) : '';
+      const mentioned =
+        (m.mentions || []).some((x) => x.mentioned?.user?.id === me.id) ||
+        (nameLower && bodyText.toLowerCase().includes(nameLower));
+      if (!mentioned) continue;
+      const sender = m.from?.user?.displayName || m.from?.application?.displayName || 'unknown';
+      items.push({
+        id: `teams-msg-${m.id}`,
+        ts: mondayIso(m.createdDateTime),
+        source: 'teams',
+        type: 'channel-mention',
+        title: `Teams mention — ${team.displayName} / ${channel.displayName} — ${sender}`,
+        url: m.webUrl || mondayThreadUrl(channel.id, m.id),
+        participants: [sender],
+        body: bodyText.slice(0, 2000),
+        from: sender,
+        date: mondayIso(m.createdDateTime),
+        team: team.displayName,
+        channel: channel.displayName,
+        context: [],
+      });
+      if (items.length >= limit) break;
+    }
+    if (items.length >= limit) break;
+  }
+  return items;
+}
+
+// Safe (never-die) paginated Graph GET used by the monday path.
+async function mondayGetAllSafe(url, maxPages) {
+  const results = [];
+  let next = url;
+  let pages = 0;
+  while (next && pages < (maxPages || 1)) {
+    const r = await apiGetSafe(next);
+    if (!r.ok) break;
+    if (r.data?.value) results.push(...r.data.value);
+    next = r.data?.['@odata.nextLink'] || null;
+    pages++;
+  }
+  return results;
+}
+
+async function cmdMonday() {
+  const f = parseMondayFlags(process.argv.slice(2));
+  const cutoff = mondayCutoff(f.date);
+  const maxTeams = parseInt(flags['max-teams'] || '10', 10);
+  const concurrency = parseInt(flags.concurrency || '5', 10);
+  console.error(
+    `[teams monday] limit=${f.limit} depth=${f.depth} date=${f.date} (since ${new Date(cutoff).toISOString()})`
+  );
+
+  // Identify the user (also warms up the in-page refresh-token capture that the
+  // chat-service calls rely on).
+  const meResp = await apiGetSafe(`${GRAPH_BASE}/me`);
+  const me = meResp.ok ? meResp.data || {} : {};
+  if (!meResp.ok) {
+    console.error(
+      `[teams monday] WARNING: /me failed (status ${meResp.status}) — is the Teams tab open and signed in?`
+    );
+  }
+  const meName = me.displayName || '';
+
+  // 1. 1:1 + group chats via the Teams chat service.
+  let chatItems = [];
+  const chatThreadIds = new Set();
+  try {
+    const chats = await mondayFetchChats(cutoff, f.depth, Math.max(f.limit, 20));
+    if (chats.error) {
+      console.error(`[teams monday] WARNING: chat service unavailable (${chats.error}).`);
+    } else {
+      console.error(`[teams monday] ${(chats.chats || []).length} chats active in window.`);
+      chatItems = mondayChatItems(chats.results || [], meName, cutoff, f.depth);
+      for (const it of chatItems) chatThreadIds.add(String(it.url));
+      for (const c of chats.chats || []) chatThreadIds.add(c.id);
+    }
+  } catch (e) {
+    console.error(`[teams monday] WARNING: chat scan failed: ${e?.message || e}`);
+  }
+
+  // 2. Channel/chat mentions + replies via the activity feed.
+  let activityItems = [];
+  try {
+    const act = await mondayFetchActivity(cutoff, f.limit);
+    if (act.error) {
+      console.error(`[teams monday] WARNING: activity feed unavailable (${act.error}).`);
+    } else {
+      activityItems = mondayActivityItems(act.activities, chatThreadIds);
+      console.error(
+        `[teams monday] ${act.activities.length} activity records in window → ${activityItems.length} mention/reply items.`
+      );
+    }
+  } catch (e) {
+    console.error(`[teams monday] WARNING: activity feed failed: ${e?.message || e}`);
+  }
+
+  // 3. Fallback: Graph channel scan when the activity feed produced nothing.
+  if (activityItems.length === 0 && me.id) {
+    try {
+      activityItems = await mondayChannelScan(me, cutoff, f.limit, maxTeams, concurrency);
+      console.error(`[teams monday] Fallback channel scan → ${activityItems.length} items.`);
+    } catch (e) {
+      console.error(`[teams monday] WARNING: channel scan failed: ${e?.message || e}`);
+    }
+  }
+
+  const seen = new Set();
+  const items = [...chatItems, ...activityItems]
+    .filter((it) => {
+      if (!it.id || seen.has(it.id)) return false;
+      seen.add(it.id);
+      return true;
+    })
+    .sort((a, b) => (Date.parse(b.ts) || 0) - (Date.parse(a.ts) || 0))
+    .slice(0, f.limit);
+
+  console.error(
+    `[teams monday] ${items.length} items (${chatItems.length} chat, ${activityItems.length} mention/reply).`
+  );
+  console.log(JSON.stringify(items));
+}
+
 function showHelp() {
   console.log(`teams  Microsoft Teams access via Graph API + Substrate Search
 
@@ -1814,6 +2301,9 @@ Commands:
   search <query>                    Full-text search across Teams messages
   unanswered <team> <channel>       Messages with no replies (default: --since=48h)
   digest                            Activity summary across all teams (default: --since=24h, --max-teams=10)
+  monday --limit N --depth N --date Nd
+                                    monday-protocol inbox source: JSON array of unread/recent
+                                    chat messages + channel mentions on stdout (logs on stderr)
   transcribe [start]                Turn on live captions in the active meeting and capture the transcript
   transcribe start --scoop <name>   Copilot mode: fire a lick to <name> for each finalized phrase
   transcribe flush [--snapshot]     Append new phrases; --snapshot also grabs a deduped screen-share frame
@@ -1880,6 +2370,9 @@ switch (subcommand) {
     break;
   case 'digest':
     await cmdDigest();
+    break;
+  case 'monday':
+    await cmdMonday();
     break;
   case 'transcribe':
   case 'transcript':


### PR DESCRIPTION
## What

Adds a `teams monday` subcommand: a `monday`-protocol inbox source for Microsoft Teams,
so the cross-tool monday digest can include Teams alongside `gh`, `slack`, `outlook`,
`gmail` and `servicenow`.

## Behaviour

Follows the source protocol in the `monday` skill (`references/SOURCE_PROTOCOL.md`):

- prints a **single JSON array** to stdout and nothing else
- all progress/warnings go to stderr
- always exits `0` — an empty inbox is `[]`, not an error

Item types: `chat` / `group-chat` (newest message from someone *else* in each active
1:1 or group chat, plus `--depth` older messages as `context[]`), and channel/activity
items.

```bash
teams monday --limit 20 --depth 3 --date 7d
monday teams --limit 10 --date 21d       # via the aggregator
```

## Notes for review

- `SKILL.md` documents the subcommand under Commands.
- Verified against upstream `main`: introduces **no new biome diagnostics**
  (37 before, 37 after — all pre-existing).
- Exercised over a real 21-day window while building the monday digest.
