### PR TITLE
fix(github): stop gh monday from swallowing --limit

### DIFF
--- a/skills/github/scripts/gh.jsh
+++ b/skills/github/scripts/gh.jsh
@@ -3343,7 +3343,10 @@ const rest = argv.slice(2);
 
 if (cmd === 'auth') { await authStatus(); process.exit(0); }
 if (cmd === 'api') { await apiPassthrough(argv.slice(1)); process.exit(0); }
-if (cmd === 'monday') { await mondayGh(argv.slice(2)); process.exit(0); }
+// slice(1), not slice(2): `cmd` is argv[0], so argv[1] is already the first
+// flag. Slicing 2 silently ate `--limit` (the first flag monday passes), which
+// left limit pinned at its 50 default while --depth/--date still parsed.
+if (cmd === 'monday') { await mondayGh(argv.slice(1)); process.exit(0); }
 
 const dispatch = {
   pr:      { list: () => prList(rest),      view: () => prView(rest),    checks: () => prChecks(rest), merge: () => prMerge(rest), close: () => prClose(rest), comment: () => prComment(rest), checkout: () => prCheckout(rest), create: () => prCreate(rest), watch: () => prWatch(rest), unwatch: () => prUnwatch(rest) },


### PR DESCRIPTION
## What

One-line fix: `gh monday` silently discarded `--limit`.

## The bug

```js
const cmd = argv[0];                                      // 'monday', not 'gh'
if (cmd === 'monday') { await mondayGh(argv.slice(2)); }  // drops '--limit'
```

`cmd` is `argv[0]`, so `argv[1]` is already the first flag. `slice(2)` skipped
`monday` **and** the token after it — which is always `--limit`, since that is the
first flag the `monday` aggregator passes. The flag never reached the parser and
`limit` stayed at its `50` default.

`--depth` and `--date` survived because they come later in the argument list,
which is what made this invisible: the command looked like it was honouring its
flags. The `api` passthrough on the adjacent line already used `slice(1)`.

## Impact

Asking for 3 items returned 50. That matters beyond item count: `monday`'s
`--rate-*` mode spawns one model call per item, so `gh monday --limit 3` was
silently requesting 50 of them.

## Verification

Before: `--limit 3` → 50 items, `--limit 10` → 50 items.
After:  `--limit 3` → 3 items,  `--limit 7` → 7 items.

`--depth`/`--date` behaviour unchanged (`--date 1d` still filters to the window).
No new biome diagnostics: 204 before, 204 after — all pre-existing.
