### PR TITLE
feat(monday): bound rating cost, stop writing per-item prompt files

### DIFF
--- a/skills/monday/SKILL.md
+++ b/skills/monday/SKILL.md
@@ -42,9 +42,9 @@ The `monday` command executes the following steps in order:
 
 1. **Discover sources** — with no positional args, run `which [cmd]` for each name in `KNOWN_COMMANDS` and keep those found on PATH; otherwise use the names supplied as positional args.
 2. **Invoke in parallel** — call `[cmd] monday --limit N --depth N --date Nd` for every discovered source concurrently.
-3. **Collect and validate JSON** — sources that exit non-zero, emit empty output, or return invalid JSON are logged to stderr and dropped; aggregation continues with the rest.
+3. **Collect and validate JSON** — sources that exit non-zero, emit empty output, or return invalid JSON are logged to stderr and dropped; aggregation continues with the rest. Each source is also truncated to `--limit`, so a source that ignores the flag cannot inflate the run.
 4. **Deduplicate by `id`** — merge arrays in argument order; the first occurrence of an `id` wins. (Precedence rules: [`references/SOURCE_PROTOCOL.md`](references/SOURCE_PROTOCOL.md).)
-5. **Optionally rate** — if any `--rate-*` flag is set, submit each item to the rating agent (model: `--rate-model`; optional context: `--rate-context`) to assign `importance`, `urgency`, and `summary` fields. Rating failures fall back to the unrated item; aggregation still completes.
+5. **Optionally rate** — if any `--rate-*` flag is set, submit each item to the rating agent (model: `--rate-model`; optional context: `--rate-context`) to assign `importance`, `urgency`, and `summary` fields. Agents run through a bounded worker pool (`--rate-concurrency`) and no more than `--rate-max` items are rated. Rating failures fall back to the unrated item; aggregation still completes.
 6. **Sort and output** — if rated, sort by `urgency × importance` descending (ties broken by `ts` descending); otherwise sort by `ts` descending. Write the final JSON array to stdout.
 
 ## Flags
@@ -59,10 +59,29 @@ The `monday` command executes the following steps in order:
 | `--rate-summary N` | off | Generate a ~N-character summary per item |
 | `--rate-model NAME` | `claude-haiku-4-5` | Model used by the rating agent |
 | `--rate-context PATH` | none | Read-only knowledge-base path the rating agent can grep |
+| `--rate-concurrency N` | `4` | Parallel rating agents (bounded worker pool) |
+| `--rate-max N` | `60` | Refuse to rate more than N items; the rest pass through unrated |
 
 Positional args (`gh`, `slack`, `teams`, `outlook`, `gmail`, `servicenow`) select
 which sources to invoke. With no positional args, `monday` runs `which <cmd>` on
 the known source list and uses whichever are found on PATH.
+
+`linkedin` and `tiktok` implement the protocol but are **not** auto-discovered,
+because they swamp a work triage run with personal notifications. Name them
+explicitly to opt in (`monday gh tiktok`).
+
+### Rating is one model call per item
+
+Each rated item costs one `agent` invocation, so cost and wall time scale with
+the merged item count — not with the number of sources. Two guard rails keep a
+run bounded: `--rate-concurrency` caps how many run at once, and `--rate-max`
+caps how many are rated at all (excess items pass through unrated rather than
+silently launching hundreds of calls). Start with a small `--limit` and one
+source, then widen:
+
+```bash
+monday gh --limit 5 --date 1d --rate-importance 9-1 --rate-urgency 8-1
+```
 
 ## Source protocol
 
@@ -109,6 +128,8 @@ found on `PATH`:
 | `"<cmd>" returned non-array JSON` | Source printed an object, or logged to stdout | Sources must print a JSON **array** to stdout and send logs to stderr |
 | Duplicates collapsed unexpectedly | Two sources share an item `id` | First source in argument order wins — reorder positional args to set precedence |
 | Empty `[]` output | Window too narrow or `--limit` too low | Widen `--date` (e.g. `14d`) or raise `--limit` |
+| `NOTE: "<cmd>" returned N items for --limit K` | The source ignored `--limit`; `monday` truncated it | Harmless, but the source has a bug worth fixing — it also inflates rating cost |
+| Rating never finishes / floods approval prompts | Too many items, or an old build writing one scratch file per item | Lower `--limit`, lower `--rate-max`, or reduce `--rate-concurrency`. Current builds pass prompts as arguments and write nothing |
 
 Confirm a single source satisfies the protocol before aggregating:
 `gh monday --limit 5 --date 3d | jq 'type, length'` should print `"array"` and a

--- a/skills/monday/scripts/monday.jsh
+++ b/skills/monday/scripts/monday.jsh
@@ -10,10 +10,10 @@
 //
 // With no positional args, auto-discovers monday-compatible commands on PATH.
 
-// Runtime bridges: the jsh runtime no longer injects `exec`/`fs` as bare
-// globals; obtain them explicitly. `exec` is callable directly.
+// Runtime bridge: the jsh runtime no longer injects `exec` as a bare global;
+// obtain it explicitly. `exec` is callable directly.
+// (No `fs` import: rating passes prompts as argv, so this script writes nothing.)
 const exec = require('sliccy:exec');
-const fs = require('fs');
 
 // Single POSIX-shell-quote a value for safe interpolation into an exec()
 // command line (exec runs through the jsh shell bridge).
@@ -70,6 +70,43 @@ function parseArgs(args) {
 
 const { subcommands, flags } = parseArgs(args);
 
+// ─── Help ────────────────────────────────────────────────────────────────────
+
+if (flags.help || flags.h) {
+  console.log(`monday — aggregate and rank inbox items across tools
+
+USAGE
+  monday [source...] [flags]
+
+  With no sources, auto-discovers monday-compatible commands on PATH.
+  Sources: gh, slack, teams, outlook, gmail, servicenow, linkedin, tiktok
+
+FLAGS
+  --limit N              Max items per source (default 50). Enforced by monday
+                         even if a source ignores it.
+  --depth N              Thread/comment depth per item (default 5)
+  --date Nd              Time window, e.g. 3d, 2w (default 7d)
+
+RATING (each rated item costs one model call — start small)
+  --rate-importance HI-LO   Rate importance, e.g. 9-1
+  --rate-urgency HI-LO      Rate urgency, e.g. 8-1
+  --rate-summary N          ~N-character summary per item
+  --rate-model NAME         Model for rating (default claude-haiku-4-5)
+  --rate-context PATH       Read-only knowledge base the rater may grep
+  --rate-concurrency N      Parallel rating agents (default 4)
+  --rate-max N              Refuse to rate more than N items (default 60)
+
+OUTPUT
+  JSON array on stdout; progress and warnings on stderr. Sorted by
+  urgency x importance when rated, else by timestamp descending.
+
+EXAMPLES
+  monday gh --limit 5 --date 1d
+  monday slack teams --limit 10 --date 3d
+  monday gh --limit 5 --rate-importance 9-1 --rate-urgency 8-1`);
+  process.exit(0);
+}
+
 // ─── Flag Defaults ───────────────────────────────────────────────────────────
 
 const limit = flags['limit'] || '50';
@@ -82,12 +119,21 @@ const rateUrgency    = flags['rate-urgency']    || null;   // e.g. "9-2"
 const rateSummary    = flags['rate-summary']     || null;   // e.g. "1000"
 const rateModel      = flags['rate-model']       || 'claude-haiku-4-5';
 const rateContext    = flags['rate-context']      || null;  // e.g. "/workspace/kb"
+const rateConcurrency = flags['rate-concurrency'] || '4';   // parallel rating agents
+const rateMax        = flags['rate-max']          || '60';  // hard ceiling on rated items
 
 const hasRating = !!(rateImportance || rateUrgency || rateSummary);
 
 // ─── Known Monday-Compatible Commands ────────────────────────────────────────
 
-const KNOWN_COMMANDS = ['gh', 'slack', 'teams', 'outlook', 'gmail', 'servicenow'];  // 'monday' itself intentionally excluded
+// Work sources, auto-discovered when no positional args are given.
+// 'monday' itself intentionally excluded.
+const KNOWN_COMMANDS = ['gh', 'slack', 'teams', 'outlook', 'gmail', 'servicenow'];
+
+// Protocol-compatible but personal/high-noise: these implement `<cmd> monday` yet
+// are NOT auto-discovered, because a work triage run drowns in them (one 21-day run
+// pulled 25 TikTok notifications and zero work items). Name them explicitly to opt in.
+const OPT_IN_COMMANDS = ['linkedin', 'tiktok'];
 
 /**
  * Discover which known commands are available on PATH.
@@ -132,6 +178,17 @@ async function invokeSource(cmd) {
     if (!Array.isArray(parsed)) {
       console.error(`[monday] WARNING: "${cmd}" returned non-array JSON`);
       return [];
+    }
+    // Enforce --limit ourselves. It is documented as "max items per source", but a
+    // source that ignores the flag would otherwise silently inflate the run — and
+    // when rating is on, every extra item costs one more agent invocation. Trust
+    // the contract, verify the result.
+    const cap = parseInt(limit, 10);
+    if (Number.isFinite(cap) && cap > 0 && parsed.length > cap) {
+      console.error(
+        `[monday] NOTE: "${cmd}" returned ${parsed.length} items for --limit ${cap}; truncating.`
+      );
+      return parsed.slice(0, cap);
     }
     return parsed;
   } catch (e) {
@@ -225,11 +282,11 @@ async function rateItem(item) {
   const prompt = buildRatingPrompt(item);
 
   // Build the agent command
-  let cmd = `agent --model ${rateModel}`;
+  let cmd = `agent --model ${escapeShellArg(rateModel)}`;
 
   // Set read-only paths if rate-context is provided
   if (rateContext) {
-    cmd += ` --read-only ${rateContext},/workspace/`;
+    cmd += ` --read-only ${escapeShellArg(`${rateContext},/workspace/`)}`;
   }
 
   // CWD, allowed commands, and the prompt
@@ -237,15 +294,13 @@ async function rateItem(item) {
   const allowedCmds = rateContext ? 'grep,rg,cat,find,ls' : 'true';
   cmd += ` . ${allowedCmds}`;
 
-  // Escape the prompt for shell: use a temp file to avoid quoting issues
-  const tmpFile = `/tmp/monday-prompt-${item.id.replace(/[^a-zA-Z0-9_-]/g, '_')}-${Date.now()}.txt`;
-  await fs.writeFile(tmpFile, prompt);
-
-  const fullCmd = `${cmd} "$(cat ${tmpFile})"`;
+  // Pass the prompt as a single quoted argv, NOT via a temp file. `agent` takes the
+  // prompt as its third positional argument, so a file buys nothing — and writing
+  // one scratch file per item is actively harmful: in a sandbox that gates writes,
+  // each write raises its own approval request (a 147-item run produced 128 of them
+  // and never finished). No filesystem writes here means nothing to approve.
+  const fullCmd = `${cmd} ${escapeShellArg(prompt)}`;
   const result = await exec(fullCmd);
-
-  // Clean up temp file
-  await exec(`rm -f ${escapeShellArg(tmpFile)}`);
 
   if (result.exitCode !== 0) {
     console.error(`[monday] WARNING: rating agent failed for item ${item.id}`);
@@ -280,11 +335,36 @@ async function rateItem(item) {
 }
 
 /**
- * Rate all items in parallel.
+ * Rate all items with BOUNDED concurrency.
+ *
+ * A plain Promise.all over the merged list spawns one agent per item all at once —
+ * 147 items meant 147 simultaneous model calls, which is how a triage run wedged
+ * itself. A small worker pool keeps the run steady and interruptible while still
+ * being much faster than serial.
  */
 async function rateAllItems(items) {
-  console.error(`[monday] rating ${items.length} items with model=${rateModel}...`);
-  return Promise.all(items.map(rateItem));
+  const workers = Math.max(1, parseInt(rateConcurrency, 10) || 1);
+  console.error(
+    `[monday] rating ${items.length} items with model=${rateModel} (concurrency ${workers})...`
+  );
+
+  const out = new Array(items.length);
+  let next = 0;
+  let done = 0;
+
+  async function worker() {
+    while (next < items.length) {
+      const i = next++;
+      out[i] = await rateItem(items[i]);
+      done++;
+      if (done % 10 === 0 || done === items.length) {
+        console.error(`[monday]   rated ${done}/${items.length}`);
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(workers, items.length) }, worker));
+  return out;
 }
 
 // ─── Sorting ─────────────────────────────────────────────────────────────────
@@ -322,6 +402,16 @@ async function main() {
       return;
     }
     console.error(`[monday] discovered: ${commands.join(', ')}`);
+    const optIn = await Promise.all(
+      OPT_IN_COMMANDS.map(async (c) => {
+        const r = await exec(`which ${escapeShellArg(c)} 2>/dev/null`);
+        return r.exitCode === 0 ? c : null;
+      })
+    );
+    const available = optIn.filter(Boolean);
+    if (available.length) {
+      console.error(`[monday] not included (name explicitly to opt in): ${available.join(', ')}`);
+    }
   }
 
   // 2. Invoke all sources in parallel
@@ -333,7 +423,22 @@ async function main() {
 
   // 4. Rate if any --rate-* flags are present
   if (hasRating && items.length > 0) {
-    items = await rateAllItems(items);
+    // Guard rail: rating is one model call per item, so an unexpectedly large merge
+    // is expensive and slow. Rate the newest N and pass the rest through unrated
+    // rather than silently launching hundreds of calls.
+    const cap = Math.max(1, parseInt(rateMax, 10) || 1);
+    if (items.length > cap) {
+      console.error(
+        `[monday] WARNING: ${items.length} items exceeds --rate-max ${cap}. ` +
+        `Rating the ${cap} newest; the rest pass through unrated. ` +
+        `Raise --rate-max or lower --limit.`
+      );
+      const byNewest = sortItems(items, false);
+      const rated = await rateAllItems(byNewest.slice(0, cap));
+      items = [...rated, ...byNewest.slice(cap)];
+    } else {
+      items = await rateAllItems(items);
+    }
   }
 
   // 5. Sort

--- a/skills/monday/scripts/monday.jsh
+++ b/skills/monday/scripts/monday.jsh
@@ -426,8 +426,17 @@ async function main() {
     // Guard rail: rating is one model call per item, so an unexpectedly large merge
     // is expensive and slow. Rate the newest N and pass the rest through unrated
     // rather than silently launching hundreds of calls.
-    const cap = Math.max(1, parseInt(rateMax, 10) || 1);
-    if (items.length > cap) {
+    //
+    // `--rate-max 0` must mean ZERO calls, so clamp at 0 rather than 1 — an
+    // explicit cap of zero that still spent one paid call would be a lie. A
+    // non-numeric value falls back to the documented default instead of 1.
+    const parsedMax = parseInt(rateMax, 10);
+    const cap = Number.isFinite(parsedMax) ? Math.max(0, parsedMax) : 60;
+    if (cap === 0) {
+      console.error(
+        '[monday] --rate-max 0: rating disabled, all items pass through unrated.'
+      );
+    } else if (items.length > cap) {
       console.error(
         `[monday] WARNING: ${items.length} items exceeds --rate-max ${cap}. ` +
         `Rating the ${cap} newest; the rest pass through unrated. ` +


### PR DESCRIPTION
## What

Makes `monday`'s rating path bounded and side-effect-free, and adds a `--help`.

## Why

`monday --rate-*` was unusable on a real inbox. A 147-item run raised **128
separate sudo approval prompts**, stalled at 257 scratch files, and never produced
output. Two independent causes:

**1. One scratch file per item, for no reason.** Rating wrote
`/tmp/monday-prompt-<id>-<ts>.txt` per item and then ran `agent ... "$(cat file)"`.
But `agent` takes the prompt as its third positional argument, and its `--help`
states *"`/tmp/` is always writable — no flag toggles it."* The file bought
nothing, and in a sandbox that gates writes each one raised its own approval
request. Prompts are now passed as a single quoted argv, so **the script writes
nothing at all** and there is nothing to approve.

**2. Unbounded fan-out.** `Promise.all(items.map(rateItem))` spawned one agent per
item simultaneously — 147 concurrent model calls. Replaced with a small worker
pool.

## Changes

- **No filesystem writes** in the rating path (prompt passed as argv). The `fs`
  import is gone.
- `--rate-concurrency N` (default 4) — bounded worker pool, with progress on stderr.
- `--rate-max N` (default 60) — refuses to rate more than N items; the newest N are
  rated and the rest pass through unrated rather than silently launching hundreds
  of calls.
- **`--limit` is now enforced by `monday` itself**, per source. It is documented as
  "max items per source", but a source that ignored it would inflate the run — and
  under `--rate-*` every extra item is another model call. Truncation is logged.
- `--help` (the skill had none).
- `--rate-model` / `--rate-context` are now shell-quoted.
- `linkedin` and `tiktok` implement the protocol but are **not** auto-discovered:
  one 21-day run pulled 25 TikTok notifications and zero work items. They are
  listed as opt-in and advertised on stderr, so they remain discoverable.

## Verification

- 2 items rated in 6.6s; **0 files** in `/tmp` afterwards, 0 approval prompts.
- 4 real `gh` items rated and ranked correctly (renovate PRs scored 2).
- `--rate-max 3` on 12 items: exactly 3 rated, 9 passed through unrated.
- A stub source returning 12 items for `--limit 3` is truncated to 3, with a NOTE
  on stderr.
- Multi-source dedup and ts-descending sort unchanged; `--help` exits 0.
- Biome: 5 diagnostics before → **4** after (removed the now-unused `fs`).

## Note for review

`--limit` enforcement is the one behaviour change beyond the rating path. It is
deliberate: a misbehaving source should not be able to inflate cost. Happy to
split it out if you would rather keep this PR strictly to the rating fix.
