### PR TITLE
feat(slack): surface thread parent ts in history output

### DIFF
--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -205,7 +205,10 @@ than retrying the same `message_ts`.
 
 ### slack history \<channel_id\> [--limit=N]
 
-Fetch recent messages from a channel. Default limit is 20.
+Fetch recent messages from a channel. Default limit is 20. Threaded messages are
+tagged with the parent timestamp, e.g. `[3 replies · ts=1774539502.747989]`, so you
+can copy that `ts` straight into `slack thread` / `slack post --thread_ts` without
+having to open the message in the Slack UI to find its permalink.
 
 ### slack post \<channel_or_user_id\> \<message\>
 
@@ -231,7 +234,8 @@ member count, and purpose.
 
 ### slack thread \<channel_id\> \<thread_ts\> [--limit=N]
 
-Read thread replies. Provide the channel ID and the thread's parent timestamp.
+Read thread replies. Provide the channel ID and the thread's parent timestamp
+(shown as `ts=…` on the `[N replies]` marker in `slack history` output).
 Default limit is 50. Messages that carry files/images show an extra line per
 attachment with its name, type, dimensions, and file id, plus a ready-to-run
 `slack download <file_id>` hint — so screenshots shared in a thread are visible

--- a/skills/slack/scripts/slack.jsh
+++ b/skills/slack/scripts/slack.jsh
@@ -273,7 +273,7 @@ function formatMessage(msg) {
   const name = msg.user_profile?.display_name || msg.user_profile?.real_name || msg.user || 'unknown';
   const time = formatTimestamp(msg.ts);
   const text = msg.text || '';
-  const thread = msg.reply_count ? ` [${msg.reply_count} replies]` : '';
+  const thread = msg.reply_count ? ` [${msg.reply_count} replies · ts=${msg.ts}]` : '';
   let out = `[${time}] ${name}: ${text}${thread}`;
   // Surface file/image attachments so threads with screenshots are legible and
   // the file id is available for `slack download <file_id>`.


### PR DESCRIPTION
## What
Show the message timestamp on threaded parents in `slack history` output:

```
[3 replies · ts=1774539502.747989]
```

## Why
The `slack thread <channel> <thread_ts>` and `slack post --thread_ts=<ts>` commands both require a message timestamp, but `history` output previously never exposed one. To read a thread you had to open the message in the Slack UI and dig the `ts` out of its permalink. Now you can copy it straight from the `history` listing.

## Changes
- `scripts/slack.jsh`: one-line change in `formatMessage` — append `· ts=${msg.ts}` to the existing `[N replies]` marker (only shown on threaded parents, so non-threaded output is unchanged).
- `SKILL.md`: document the marker under the `history` and `thread` command sections.

No behavior change beyond the extra tag; no new deps.