### PR TITLE
feat(monday+github): category triage taxonomy, effort/ROI ranking, budget/focus backpressure, dip renderer, rate-model validation

### DIFF
--- a/skills/github/scripts/gh.jsh
+++ b/skills/github/scripts/gh.jsh
@@ -2500,6 +2500,27 @@ async function mondayGh(args) {
     username = user.login;
   } catch {}
 
+  // Normalize GitHub's own state into the protocol-standard disposition flags the
+  // aggregator's signal guard reads (so `monday` stays source-agnostic):
+  //   resolved          — merged/closed → FYI
+  //   not_ready         — draft or CI pending/failing → hold for later
+  //   awaiting_you      — your review/action is requested → actionable now
+  //   waiting_on_others — you authored it and it's now on others (review/merge)
+  function ghNormalize(m) {
+    const resolved = m.merged === true || m.state === 'closed';
+    if (resolved) return { resolved: true };
+    const asked = ['review_requested', 'mention', 'assign', 'assigned'].includes(m.relationship);
+    if (asked) return { awaiting_you: true };
+    const notReady = m.draft === true || m.awaiting_checks === true;
+    if (m.authored_by_you === true && m.state === 'open') {
+      if (notReady) return { not_ready: true };            // blocked on your CI / still a draft
+      if (m.mergeable_state === 'clean') return { awaiting_you: true }; // green + approved → you merge
+      return { waiting_on_others: true };                  // waiting on reviewers/merge
+    }
+    return notReady ? { not_ready: true } : {};
+  }
+  const withNormalized = (m) => ({ ...m, ...ghNormalize(m) });
+
   const items = [];
   const seen = new Set();
 
@@ -2509,10 +2530,12 @@ async function mondayGh(args) {
   // own rating instructions.
   const GH_RATING_HINT = [
     'This is a GitHub item. `meta.viewer` is the reader\'s own username.',
-    '`meta.authored_by_you: true` means the reader opened this PR/issue (they are likely waiting on others or on a merge).',
-    '`meta.relationship` (review_requested, assignee, mention, author, subscribed, ...) says what is expected of the reader — weight items where they are personally on the hook (review requested, assigned, directly mentioned, or authored-and-ready) above things they merely subscribe to.',
-    'If `meta.merged` is true or `meta.state` is "closed", the item is already done — category MUST be `fyi`.',
-    'If `meta.awaiting_checks` is true (a PR whose CI is pending or failing) or `meta.draft` is true, it is not ready to act on yet — keep urgency low; acting now would be premature. `meta.checks` is passing/pending/failing and `meta.ready_to_merge: true` means clean and green.',
+    'The item carries normalized disposition flags — trust them:',
+    '`meta.resolved: true` → it is merged/closed, already done → category MUST be `fyi`.',
+    '`meta.awaiting_you: true` → the reader\'s review or action is requested (review_requested / assigned / mentioned, or their own PR is green and ready to merge) → this is a real to-do (confirm/review/respond/act).',
+    '`meta.waiting_on_others: true` → the reader has done their part and is now waiting on other people (their open PR awaiting review/merge, a question awaiting a reply) → category `waiting`: they may want to chase or nudge, but there is nothing for them to build.',
+    '`meta.not_ready: true` → a PR that is a draft or whose CI is pending/failing → not ready to act on yet; keep urgency low.',
+    'Otherwise use `meta.relationship` and the content to judge how much the reader is personally on the hook.',
   ].join(' ');
 
   function addItem(item) {
@@ -2625,7 +2648,7 @@ async function mondayGh(args) {
         ts: n.updated_at,
         body,
         participants: [],
-        meta: {
+        meta: withNormalized({
           reason: n.reason,
           unread: n.unread,
           viewer: username,
@@ -2634,7 +2657,7 @@ async function mondayGh(args) {
           relationship: n.reason,
           authored_by_you: n.reason === 'author',
           ...signals,
-        },
+        }),
       });
     }
   } catch {}
@@ -2660,7 +2683,7 @@ async function mondayGh(args) {
         ts: pr.updated_at,
         body,
         participants: [pr.user.login, ...(pr.assignees || []).map(a => a.login)].filter((v, i, a) => a.indexOf(v) === i),
-        meta: {
+        meta: withNormalized({
           state: pr.state,
           draft: pr.draft || false,
           viewer: username,
@@ -2670,7 +2693,7 @@ async function mondayGh(args) {
           // Checks readiness so a review request that's still red/pending on CI
           // can be held out of the "now" slice.
           ...(await subjectSignals(repoUrl, pr.number, 'pr')),
-        },
+        }),
       });
     }
   } catch {}
@@ -2696,14 +2719,14 @@ async function mondayGh(args) {
         ts: issue.updated_at,
         body,
         participants: [issue.user.login, ...(issue.assignees || []).map(a => a.login)].filter((v, i, a) => a.indexOf(v) === i),
-        meta: {
+        meta: withNormalized({
           state: issue.state,
           labels: (issue.labels || []).map(l => l.name),
           viewer: username,
           author: issue.user.login,
           relationship: 'assignee',
           authored_by_you: issue.user.login === username,
-        },
+        }),
       });
     }
   } catch {}

--- a/skills/github/scripts/gh.jsh
+++ b/skills/github/scripts/gh.jsh
@@ -2559,7 +2559,15 @@ async function mondayGh(args) {
         ts: n.updated_at,
         body,
         participants: [],
-        meta: { reason: n.reason, unread: n.unread },
+        meta: {
+          reason: n.reason,
+          unread: n.unread,
+          viewer: username,
+          // Your relationship to the thread, straight from the notification
+          // reason (author, review_requested, mention, assign, comment, ...).
+          relationship: n.reason,
+          authored_by_you: n.reason === 'author',
+        },
       });
     }
   } catch {}
@@ -2584,7 +2592,14 @@ async function mondayGh(args) {
         ts: pr.updated_at,
         body,
         participants: [pr.user.login, ...(pr.assignees || []).map(a => a.login)].filter((v, i, a) => a.indexOf(v) === i),
-        meta: { state: pr.state, draft: pr.draft || false },
+        meta: {
+          state: pr.state,
+          draft: pr.draft || false,
+          viewer: username,
+          author: pr.user.login,
+          relationship: 'review_requested',
+          authored_by_you: pr.user.login === username,
+        },
       });
     }
   } catch {}
@@ -2609,7 +2624,14 @@ async function mondayGh(args) {
         ts: issue.updated_at,
         body,
         participants: [issue.user.login, ...(issue.assignees || []).map(a => a.login)].filter((v, i, a) => a.indexOf(v) === i),
-        meta: { state: issue.state, labels: (issue.labels || []).map(l => l.name) },
+        meta: {
+          state: issue.state,
+          labels: (issue.labels || []).map(l => l.name),
+          viewer: username,
+          author: issue.user.login,
+          relationship: 'assignee',
+          authored_by_you: issue.user.login === username,
+        },
       });
     }
   } catch {}

--- a/skills/github/scripts/gh.jsh
+++ b/skills/github/scripts/gh.jsh
@@ -2524,6 +2524,54 @@ async function mondayGh(args) {
     }
   }
 
+  // Helper: derive a normalized checks state for a commit sha.
+  // 'passing' | 'pending' | 'failing' | 'none' | null (unknown/error).
+  async function checksFor(repo, sha) {
+    if (!sha) return null;
+    try {
+      const runs = await api.get(`/repos/${repo}/commits/${sha}/check-runs`);
+      const cr = (runs && runs.check_runs) || [];
+      if (cr.length) {
+        if (cr.some(r => r.status !== 'completed')) return 'pending';
+        if (cr.some(r => ['failure', 'timed_out', 'cancelled', 'action_required', 'stale'].includes(r.conclusion))) return 'failing';
+        return 'passing';
+      }
+      // Fall back to the legacy combined status API for repos not using checks.
+      const st = await api.get(`/repos/${repo}/commits/${sha}/status`);
+      if (st && st.total_count > 0) {
+        return st.state === 'success' ? 'passing' : st.state === 'pending' ? 'pending' : 'failing';
+      }
+      return 'none';
+    } catch { return null; }
+  }
+
+  // Helper: fetch the real state/merged/draft/checks for a PR or issue subject.
+  // Notifications alone don't carry this, so merged PRs and CI-pending PRs would
+  // otherwise look like fresh to-dos. One extra call per subject (plus one for
+  // checks on open PRs) — bounded by --limit.
+  async function subjectSignals(repo, num, type) {
+    const m = {};
+    if (!repo || !num) return m;
+    try {
+      if (type === 'pr') {
+        const pr = await api.get(`/repos/${repo}/pulls/${num}`);
+        m.state = pr.state;                        // 'open' | 'closed'
+        m.merged = !!pr.merged;
+        m.draft = !!pr.draft;
+        m.mergeable_state = pr.mergeable_state || null;
+        if (!m.merged && pr.state === 'open') {
+          m.checks = await checksFor(repo, pr.head && pr.head.sha);
+          m.awaiting_checks = m.checks === 'pending' || m.checks === 'failing';
+          m.ready_to_merge = m.mergeable_state === 'clean' && m.checks === 'passing';
+        }
+      } else if (type === 'issue') {
+        const iss = await api.get(`/repos/${repo}/issues/${num}`);
+        m.state = iss.state;                       // 'open' | 'closed'
+      }
+    } catch { /* enrichment is best-effort */ }
+    return m;
+  }
+
   // 1. Notifications
   try {
     const notifs = await api.get('/notifications', {
@@ -2549,6 +2597,11 @@ async function mondayGh(args) {
       const body = (num && depth > 0)
         ? await fetchThread(repo, num, type, baseBody, depth)
         : baseBody;
+      // Enrich with real subject state so merged/closed items don't look like
+      // open to-dos and CI-pending PRs can be held out of the "now" slice.
+      const signals = (type === 'pr' || type === 'issue')
+        ? await subjectSignals(repo, num, type)
+        : {};
       addItem({
         id: `gh-notif-${n.id}`,
         source: 'gh',
@@ -2567,6 +2620,7 @@ async function mondayGh(args) {
           // reason (author, review_requested, mention, assign, comment, ...).
           relationship: n.reason,
           authored_by_you: n.reason === 'author',
+          ...signals,
         },
       });
     }
@@ -2599,6 +2653,9 @@ async function mondayGh(args) {
           author: pr.user.login,
           relationship: 'review_requested',
           authored_by_you: pr.user.login === username,
+          // Checks readiness so a review request that's still red/pending on CI
+          // can be held out of the "now" slice.
+          ...(await subjectSignals(repoUrl, pr.number, 'pr')),
         },
       });
     }

--- a/skills/github/scripts/gh.jsh
+++ b/skills/github/scripts/gh.jsh
@@ -2503,6 +2503,18 @@ async function mondayGh(args) {
   const items = [];
   const seen = new Set();
 
+  // Source-owned rating guidance, carried to the rater via the item's
+  // `rating_hint` field (part of the monday protocol). Keeping GitHub's field
+  // semantics here — not in the generic aggregator — lets each tool manage its
+  // own rating instructions.
+  const GH_RATING_HINT = [
+    'This is a GitHub item. `meta.viewer` is the reader\'s own username.',
+    '`meta.authored_by_you: true` means the reader opened this PR/issue (they are likely waiting on others or on a merge).',
+    '`meta.relationship` (review_requested, assignee, mention, author, subscribed, ...) says what is expected of the reader — weight items where they are personally on the hook (review requested, assigned, directly mentioned, or authored-and-ready) above things they merely subscribe to.',
+    'If `meta.merged` is true or `meta.state` is "closed", the item is already done — category MUST be `fyi`.',
+    'If `meta.awaiting_checks` is true (a PR whose CI is pending or failing) or `meta.draft` is true, it is not ready to act on yet — keep urgency low; acting now would be premature. `meta.checks` is passing/pending/failing and `meta.ready_to_merge: true` means clean and green.',
+  ].join(' ');
+
   function addItem(item) {
     if (seen.has(item.id)) return;
     seen.add(item.id);
@@ -2605,6 +2617,7 @@ async function mondayGh(args) {
       addItem({
         id: `gh-notif-${n.id}`,
         source: 'gh',
+        rating_hint: GH_RATING_HINT,
         type,
         title: n.subject.title,
         subtitle: num ? `${repo} #${num}` : repo,
@@ -2639,6 +2652,7 @@ async function mondayGh(args) {
       addItem({
         id: `gh-pr-${pr.id}`,
         source: 'gh',
+        rating_hint: GH_RATING_HINT,
         type: 'pr',
         title: pr.title,
         subtitle: `${repoUrl} #${pr.number}`,
@@ -2674,6 +2688,7 @@ async function mondayGh(args) {
       addItem({
         id: `gh-issue-${issue.id}`,
         source: 'gh',
+        rating_hint: GH_RATING_HINT,
         type: 'issue',
         title: issue.title,
         subtitle: `${repoUrl} #${issue.number}`,

--- a/skills/monday/SKILL.md
+++ b/skills/monday/SKILL.md
@@ -36,7 +36,7 @@ monday gh slack --limit 20 --date 3d
 monday --rate-importance 9-1 --rate-urgency 8-1 --rate-summary 500
 
 # Rate with a specific model and a knowledge-base context directory
-monday gh --rate-importance 8-3 --rate-model haiku --rate-context /workspace/kb
+monday gh --rate-importance 8-3 --rate-model us.anthropic.claude-haiku --rate-context /workspace/kb
 
 # Estimate effort and rank by quick wins first (impact per minute)
 monday gh --rate-importance 9-1 --rate-urgency 8-1 --rate-effort --sort roi
@@ -72,7 +72,7 @@ The `monday` command executes the following steps in order:
 | `--rate-urgency HI-LO` | off | Rate each item's urgency on a HI..LO integer scale |
 | `--rate-summary N` | off | Generate a ~N-character summary per item |
 | `--rate-effort` | off | Estimate `effort_minutes` per item plus a `quick`/`short`/`deep` band. Powers `--sort roi` and `--budget`. |
-| `--rate-model NAME` | cheapest model | Rating model. Accepts an exact id from `models` or a unique case-insensitive substring (e.g. `haiku`, `us.anthropic.claude-haiku`). Validated against the live `models` catalog before any call — a typo or ambiguous fragment fails fast (exit 1) instead of running. When omitted, the cheapest haiku-class model is auto-selected. |
+| `--rate-model NAME` | cheapest model | Rating model. Accepts an exact id from `models` or a unique case-insensitive substring (e.g. `us.anthropic.claude-haiku`). Validated against the live `models` catalog before any call — a typo or ambiguous fragment fails fast (exit 1) instead of running. When omitted, the cheapest haiku-class model is auto-selected. |
 | `--rate-context PATH` | none | Read-only knowledge-base path the rating agent can grep |
 | `--rate-concurrency N` | `4` | Parallel rating agents (bounded worker pool) |
 | `--rate-max N` | `60` | Refuse to rate more than N items; the rest pass through unrated |

--- a/skills/monday/SKILL.md
+++ b/skills/monday/SKILL.md
@@ -56,9 +56,9 @@ The `monday` command executes the following steps in order:
 2. **Invoke in parallel** — call `[cmd] monday --limit N --depth N --date Nd` for every discovered source concurrently.
 3. **Collect and validate JSON** — sources that exit non-zero, emit empty output, or return invalid JSON are logged to stderr and dropped; aggregation continues with the rest. Each source is also truncated to `--limit`, so a source that ignores the flag cannot inflate the run.
 4. **Deduplicate by `id`** — merge arrays in argument order; the first occurrence of an `id` wins. (Precedence rules: [`references/SOURCE_PROTOCOL.md`](references/SOURCE_PROTOCOL.md).)
-5. **Optionally rate** — if any `--rate-*` flag is set, submit each item to the rating agent to assign `importance`, `urgency`, `summary`, a `category` (`fyi` \| `confirm` \| `review` \| `respond` \| `act` — what the item asks of you), a derived `actionable` flag (`category !== 'fyi'`), and — with `--rate-effort` — an `effort_minutes` estimate plus a coarse `effort_band` (`quick`/`short`/`deep`). Agents run through a bounded worker pool (`--rate-concurrency`) and no more than `--rate-max` items are rated. Rating failures fall back to the unrated item; aggregation still completes.
+5. **Optionally rate** — if any `--rate-*` flag is set, submit each item to the rating agent to assign `importance`, `urgency`, `summary`, a `category` (`fyi` \| `confirm` \| `review` \| `respond` \| `act` \| `waiting` — what the item asks of you; `waiting` = you've done your part and are chasing others), a derived `actionable` flag (true unless `fyi` or `waiting`), and — with `--rate-effort` — an `effort_minutes` estimate plus a coarse `effort_band` (`quick`/`short`/`deep`). Agents run through a bounded worker pool (`--rate-concurrency`) and no more than `--rate-max` items are rated. Rating failures fall back to the unrated item; aggregation still completes.
 6. **Sort** — order by `--sort`: `roi` (impact per minute — the default when `--rate-effort` is on), `value` (importance × urgency), or `newest`. Unrated runs always fall back to `ts` descending.
-7. **Plan (backpressure)** — split actionable to-dos from informational **FYI** items (merged PRs, closed issues, notifications). If `--focus N` or `--budget DURATION` is set, promote a doable slice of to-dos to a `now` bucket and hold the rest as `later`; FYI items go to a separate `fyi` bucket that never consumes the time budget. Each item gets a `bucket` field and a one-line plan summary prints to stderr. The goal is a doable slice, not a wall (see [Backpressure](#backpressure-a-plan-not-a-wall) and [Presentation](#presentation-render-as-a-dip-not-a-wall)).
+7. **Plan (backpressure)** — split to-dos from **FYI** (merged/closed/notifications) and from **waiting** (you're chasing others). If `--focus N` or `--budget DURATION` is set, promote a doable slice of to-dos to a `now` bucket and hold the rest as `later`; `waiting` items go to a `followup` bucket (chase/nudge, not counted against your budget) and FYI to a `fyi` bucket. Each item gets a `bucket` field and a one-line plan summary prints to stderr. The goal is a doable slice, not a wall (see [Backpressure](#backpressure-a-plan-not-a-wall) and [Presentation](#presentation-render-as-a-dip-not-a-wall)).
 8. **Output** — write the final JSON array to stdout.
 
 ## Flags
@@ -365,9 +365,9 @@ A single JSON array on stdout. Sorting and rating augmentation follow pipeline s
 ]
 ```
 
-`category` (`fyi`/`confirm`/`review`/`respond`/`act`) and its derived
+`category` (`fyi`/`confirm`/`review`/`respond`/`act`/`waiting`) and its derived
 `actionable` flag appear on every rated item; `effort_minutes` / `effort_band`
-appear only with `--rate-effort`; `bucket` (`now` | `later` | `fyi`) appears
+appear only with `--rate-effort`; `bucket` (`now` | `later` | `followup` | `fyi`) appears
 once a plan is active. Without those flags the output is unchanged from the
 plain rated shape (`importance` / `urgency` / `summary`).
 

--- a/skills/monday/SKILL.md
+++ b/skills/monday/SKILL.md
@@ -200,14 +200,24 @@ field from monday's output — the same ones the dip's Done / Later buttons send
 back via `slicc.lick`, so the presentation loop can call `monday done <id>`
 directly.
 
-**Signal trust.** Sources may tag items with relationship metadata
-(`meta.authored_by_you`, `meta.relationship` = `review_requested` / `mention` /
-`assign`, `meta.state`). When present, `monday` trusts these over the rater: an
-item you were asked to review, or authored and left open, stays **actionable**
-even if the rater guessed `fyi` (it is retagged `category: review` and marked
-`reclassified_by_signal`). Merged/closed items are never resurfaced. Disable the
-override with `--no-trust-signals`. The `github` source populates these fields
-for notifications, review requests, and assigned issues.
+**Signal trust.** Sources may tag items with relationship and state metadata
+(`meta.authored_by_you`, `meta.relationship`, `meta.state`, `meta.merged`,
+`meta.draft`, `meta.checks`, `meta.awaiting_checks`). When present, `monday`
+trusts these over the rater:
+
+- **Already merged / closed** → forced to `fyi` (never a to-do), no matter what
+  the rater guessed from stale notification text.
+- **Asked to review / mentioned / assigned, or authored and still open** → kept
+  **actionable** even if the rater guessed `fyi` (retagged `category: review`,
+  marked `reclassified_by_signal`).
+- **A PR still red or pending on CI (`awaiting_checks`) or a draft** → held out
+  of the `now` bucket (into `later`) even if it ranks high — it isn't ready to
+  act on yet.
+
+Disable the override with `--no-trust-signals`. The `github` source populates
+these fields by fetching each PR/issue's real state and CI status (notifications
+alone don't carry it), so merged PRs and CI-pending PRs are classified correctly
+instead of surfacing as fresh top-of-list to-dos.
 
 
 

--- a/skills/monday/SKILL.md
+++ b/skills/monday/SKILL.md
@@ -89,8 +89,9 @@ The `monday` command executes the following steps in order:
 |---------|--------|
 | `monday done <id>...` | Mark handled — hidden from all future runs |
 | `monday ignore <id>...` | Never show these items again |
-| `monday restore <id>...` (alias `unignore`) | Undo a done/ignore |
-| `monday ignored` (alias `list-ignored`) | Print the done/ignore list (JSON on stdout) |
+| `monday mute <id>...` | Silence forever (alias of ignore) |
+| `monday restore <id>...` (aliases `unignore`, `unmute`) | Undo a done/ignore/mute |
+| `monday ignored` (aliases `list-ignored`, `muted`) | Print the silenced list (JSON on stdout) |
 | `monday cache-clear` (alias `forget-cache`) | Wipe the rating cache |
 
 
@@ -188,7 +189,8 @@ never resurfaces:
 ```bash
 monday done   gh-notif-24826743046      # handled it
 monday ignore gh-notif-24826743046      # never show me this again
-monday ignored                          # list what's suppressed (JSON on stdout)
+monday mute   gh-notif-24826743046      # silence forever (alias of ignore)
+monday ignored                          # list what's silenced (JSON on stdout)
 monday restore gh-notif-24826743046     # bring it back
 ```
 

--- a/skills/monday/SKILL.md
+++ b/skills/monday/SKILL.md
@@ -79,6 +79,20 @@ The `monday` command executes the following steps in order:
 | `--sort MODE` | `roi` if `--rate-effort` else `value` | Ranking: `roi` (impact per minute — best bang-for-buck first), `value` (importance × urgency), or `newest` (timestamp) |
 | `--focus N` | off | Promote only the top N to-dos to the `now` bucket; the rest become `later` |
 | `--budget DURATION` | off | Pack the highest-ranked to-dos that fit a time box (`90m`, `2h`, `1h30m`) into `now`; needs `--rate-effort` |
+| `--no-cache` | off | Don't reuse or write cached ratings this run |
+| `--include-ignored` | off | Show items on the done/ignore list anyway |
+| `--no-trust-signals` | off | Don't override the rater from source relationship metadata |
+
+**Management subcommands** (persist state under `$MONDAY_HOME` / `~/.monday`):
+
+| Command | Effect |
+|---------|--------|
+| `monday done <id>...` | Mark handled — hidden from all future runs |
+| `monday ignore <id>...` | Never show these items again |
+| `monday restore <id>...` (alias `unignore`) | Undo a done/ignore |
+| `monday ignored` (alias `list-ignored`) | Print the done/ignore list (JSON on stdout) |
+| `monday cache-clear` (alias `forget-cache`) | Wipe the rating cache |
+
 
 Positional args (`gh`, `slack`, `teams`, `outlook`, `gmail`, `servicenow`) select
 which sources to invoke. With no positional args, `monday` runs `which <cmd>` on
@@ -155,6 +169,45 @@ When a rated run is large (>12 items) and neither knob is set, `monday` nudges
 you toward them on stderr rather than silently dumping the backlog. The default
 output is unchanged and fully backward-compatible — `bucket` only appears once
 you opt into a plan.
+
+## State: rating cache, done/ignore list, and signal trust
+
+`monday` keeps a little persistent state under `$MONDAY_HOME` (default
+`~/.monday`, or `/shared/monday` when there is no home dir):
+
+**Rating cache** (`rating-cache.json`). Every rating is cached, keyed by the
+item's content **and** the rating parameters and model. A rerun only pays for
+new or changed items — an unchanged inbox re-rates for free. The key includes
+the importance/urgency scales, summary length, effort flag, context path, and
+resolved model, so changing any of them correctly invalidates. Bypass with
+`--no-cache`; wipe with `monday cache-clear`.
+
+**Done / ignore list** (`suppress.json`). Dismiss an item permanently so it
+never resurfaces:
+
+```bash
+monday done   gh-notif-24826743046      # handled it
+monday ignore gh-notif-24826743046      # never show me this again
+monday ignored                          # list what's suppressed (JSON on stdout)
+monday restore gh-notif-24826743046     # bring it back
+```
+
+Suppressed items are filtered right after merge (before rating, so they cost
+nothing). `--include-ignored` shows them anyway. The ids are the stable `id`
+field from monday's output — the same ones the dip's Done / Later buttons send
+back via `slicc.lick`, so the presentation loop can call `monday done <id>`
+directly.
+
+**Signal trust.** Sources may tag items with relationship metadata
+(`meta.authored_by_you`, `meta.relationship` = `review_requested` / `mention` /
+`assign`, `meta.state`). When present, `monday` trusts these over the rater: an
+item you were asked to review, or authored and left open, stays **actionable**
+even if the rater guessed `fyi` (it is retagged `category: review` and marked
+`reclassified_by_signal`). Merged/closed items are never resurfaced. Disable the
+override with `--no-trust-signals`. The `github` source populates these fields
+for notifications, review requests, and assigned issues.
+
+
 
 ## Presentation: render as a dip, not a wall
 

--- a/skills/monday/SKILL.md
+++ b/skills/monday/SKILL.md
@@ -5,10 +5,13 @@ description: >-
   Outlook, GitHub, ServiceNow) into a single ranked list. Acts as a dispatcher: each
   source skill exposes a `[cmd] monday` sub-command that returns JSON items, and the
   `monday` command merges, deduplicates, optionally rates with an AI model
-  (importance times urgency), and sorts them. Use when the user asks "what should I
-  work on", "Monday morning triage", "what needs my attention", "show me my inbox",
-  "rank my todos", "what's urgent across all my tools", or for weekly/daily triage
-  across email, chat, tickets, and pull requests.
+  (importance times urgency, and optionally effort in minutes), sorts by value or
+  ROI (impact per minute), and can build a doable "now" plan under a time budget or
+  top-N focus so a big inbox becomes a plan of attack rather than an overwhelming
+  wall. Use when the user asks "what should I work on", "Monday morning triage",
+  "what needs my attention", "show me my inbox", "rank my todos", "what's urgent
+  across all my tools", "build me a plan", "what can I clear in 90 minutes", or for
+  weekly/daily triage across email, chat, tickets, and pull requests.
 allowed-tools: bash
 ---
 
@@ -34,6 +37,15 @@ monday --rate-importance 9-1 --rate-urgency 8-1 --rate-summary 500
 
 # Rate with a specific model and a knowledge-base context directory
 monday gh --rate-importance 8-3 --rate-model haiku --rate-context /workspace/kb
+
+# Estimate effort and rank by quick wins first (impact per minute)
+monday gh --rate-importance 9-1 --rate-urgency 8-1 --rate-effort --sort roi
+
+# Backpressure: turn a big inbox into a doable 90-minute plan
+monday --rate-importance 9-1 --rate-urgency 8-1 --rate-effort --budget 90m
+
+# Or just the top 5 as "now", everything else ranked as "later"
+monday --rate-importance 9-1 --rate-urgency 8-1 --focus 5
 ```
 
 ## Aggregation pipeline
@@ -44,8 +56,10 @@ The `monday` command executes the following steps in order:
 2. **Invoke in parallel** — call `[cmd] monday --limit N --depth N --date Nd` for every discovered source concurrently.
 3. **Collect and validate JSON** — sources that exit non-zero, emit empty output, or return invalid JSON are logged to stderr and dropped; aggregation continues with the rest. Each source is also truncated to `--limit`, so a source that ignores the flag cannot inflate the run.
 4. **Deduplicate by `id`** — merge arrays in argument order; the first occurrence of an `id` wins. (Precedence rules: [`references/SOURCE_PROTOCOL.md`](references/SOURCE_PROTOCOL.md).)
-5. **Optionally rate** — if any `--rate-*` flag is set, submit each item to the rating agent (model: `--rate-model`; optional context: `--rate-context`) to assign `importance`, `urgency`, and `summary` fields. Agents run through a bounded worker pool (`--rate-concurrency`) and no more than `--rate-max` items are rated. Rating failures fall back to the unrated item; aggregation still completes.
-6. **Sort and output** — if rated, sort by `urgency × importance` descending (ties broken by `ts` descending); otherwise sort by `ts` descending. Write the final JSON array to stdout.
+5. **Optionally rate** — if any `--rate-*` flag is set, submit each item to the rating agent (model: `--rate-model`; optional context: `--rate-context`) to assign `importance`, `urgency`, `summary`, and — with `--rate-effort` — an `effort_minutes` estimate plus a coarse `effort_band` (`quick`/`short`/`deep`). Agents run through a bounded worker pool (`--rate-concurrency`) and no more than `--rate-max` items are rated. Rating failures fall back to the unrated item; aggregation still completes.
+6. **Sort** — order by `--sort`: `value` (importance × urgency, the default), `roi` (impact per minute — quick wins first; needs `--rate-effort`), or `newest` (timestamp). Unrated runs always fall back to `ts` descending.
+7. **Plan (backpressure)** — if `--focus N` or `--budget DURATION` is set, split the sorted list into a `now` bucket and a `later` bucket, tag each item with a `bucket` field, and emit `now` items first. A one-line plan summary goes to stderr. The goal is a doable slice, not a wall (see [Backpressure](#backpressure-a-plan-not-a-wall)).
+8. **Output** — write the final JSON array to stdout.
 
 ## Flags
 
@@ -57,10 +71,14 @@ The `monday` command executes the following steps in order:
 | `--rate-importance HI-LO` | off | Rate each item's importance on a HI..LO integer scale |
 | `--rate-urgency HI-LO` | off | Rate each item's urgency on a HI..LO integer scale |
 | `--rate-summary N` | off | Generate a ~N-character summary per item |
+| `--rate-effort` | off | Estimate `effort_minutes` per item plus a `quick`/`short`/`deep` band. Powers `--sort roi` and `--budget`. |
 | `--rate-model NAME` | cheapest model | Rating model. Accepts an exact id from `models` or a unique case-insensitive substring (e.g. `haiku`, `us.anthropic.claude-haiku`). Validated against the live `models` catalog before any call — a typo or ambiguous fragment fails fast (exit 1) instead of running. When omitted, the cheapest haiku-class model is auto-selected. |
 | `--rate-context PATH` | none | Read-only knowledge-base path the rating agent can grep |
 | `--rate-concurrency N` | `4` | Parallel rating agents (bounded worker pool) |
 | `--rate-max N` | `60` | Refuse to rate more than N items; the rest pass through unrated |
+| `--sort MODE` | `value` | Ranking: `value` (importance × urgency), `roi` (impact per minute; needs `--rate-effort`), or `newest` (timestamp) |
+| `--focus N` | off | Mark only the top N items as the `now` bucket; the rest become `later` |
+| `--budget DURATION` | off | Pack the highest-ranked items that fit a time box (`90m`, `2h`, `1h30m`) into `now`; needs `--rate-effort` |
 
 Positional args (`gh`, `slack`, `teams`, `outlook`, `gmail`, `servicenow`) select
 which sources to invoke. With no positional args, `monday` runs `which <cmd>` on
@@ -93,6 +111,76 @@ resolving against `models --json` ourselves and handing `agent` an exact id, the
 rating pass runs on the model you asked for, and a typo or ambiguous fragment
 fails fast (exit 1, no paid calls) instead of quietly overspending. Confirm the
 resolved model and per-scoop cost afterwards with `cost` / `cost --json`.
+
+### Effort and ROI ranking
+
+`--rate-effort` asks the rater for an `effort_minutes` estimate — how long it
+would take *you* to actually resolve the item, not read it — plus a coarse
+`effort_band` (`quick` ≤15m, `short` ≤60m, `deep` >60m). That unlocks two views
+beyond raw importance × urgency:
+
+- `--sort roi` ranks by **impact per minute**, so a high-value item that costs
+  two hours sinks below three five-minute wins. This is the "what can I clear
+  before my next meeting" order.
+- `--budget 90m` (below) uses effort to pack a realistic session.
+
+Effort is an AI estimate — treat it as a hint, not a stopwatch. Items the rater
+can't size are assumed 30 minutes so they neither dominate nor vanish.
+
+## Backpressure: a plan, not a wall
+
+A ranked list of 150 items is still a wall. Humans bring judgement, context, and
+intuition an AI can't — but they're easy to overwhelm, and a giant inbox invites
+paralysis, not progress. `monday`'s job is to hand you a **doable slice** and
+keep the rest ranked-but-out-of-sight until you ask.
+
+Two knobs shape the plan; both tag every item with a `bucket` field
+(`"now"` | `"later"`) and emit the `now` items first:
+
+- **`--focus N`** — only the top N are `now`; everything else is `later`. Start
+  your day with five things that matter, not a scroll of eighty.
+- **`--budget DURATION`** — pack the highest-ranked items whose cumulative
+  `effort_minutes` fit the time box (`90m`, `2h`, `1h30m`) into `now`; the rest
+  become `later`. Combine with `--sort roi` for a max-impact session. When both
+  `--focus` and `--budget` are set, the budget packs by time but never exceeds
+  the focus count.
+
+A one-line plan summary prints to stderr, e.g.:
+
+```text
+[monday] plan: 4 now (~85m), budget 90m · 46 later. Start with the "now" bucket; the rest stay ranked for when you're ready.
+```
+
+When a rated run is large (>12 items) and neither knob is set, `monday` nudges
+you toward them on stderr rather than silently dumping the backlog. The default
+output is unchanged and fully backward-compatible — `bucket` only appears once
+you opt into a plan.
+
+## Presentation: render as a dip, not a wall
+
+`monday` emits data; **how that data reaches the human decides whether it feels
+like a plan or a defeat.** When you (the cone) surface a triage run to the user,
+do not paste the raw JSON array. Render it as a [dip](../dips/SKILL.md) — an
+inline, ephemeral chat widget — following these principles:
+
+1. **Lead with the `now` bucket.** Show the doable slice big and first
+   ("Start here → 4 items, ~85 min"). Collapse `later` behind a count
+   ("+46 more, ranked, when you're ready") — visible, not in your face.
+2. **One line per item:** title, a `source #id` chip, the score or ROI, the
+   `effort_band` as a small pill, and a one-clause "why now" from the summary.
+3. **Band the list** (CRIT / HIGH / MED / LOW by score, or by `effort_band`)
+   so the eye groups it without reading every row.
+4. **Make each item actionable** — an Open link (`url`), and optionally
+   Done / Defer buttons that `slicc.lick(...)` back so triage is a loop, not a
+   report.
+5. **Frame momentum, not doom.** "3 quick wins before lunch" beats "50 open
+   items." The backlog *count* stays honest; its *contents* stay collapsed.
+
+Recommended pipeline: run `monday … --rate-effort --budget 90m` (or `--focus`),
+read the JSON, and build the dip from the `now`/`later` buckets. Keep the JSON
+contract intact for scripts; the dip is a presentation layer on top, not a
+replacement.
+
 
 ## Source protocol
 
@@ -141,6 +229,9 @@ found on `PATH`:
 | Empty `[]` output | Window too narrow or `--limit` too low | Widen `--date` (e.g. `14d`) or raise `--limit` |
 | `NOTE: "<cmd>" returned N items for --limit K` | The source ignored `--limit`; `monday` truncated it | Harmless, but the source has a bug worth fixing — it also inflates rating cost |
 | Rating never finishes / floods approval prompts | Too many items, or an old build writing one scratch file per item | Lower `--limit`, lower `--rate-max`, or reduce `--rate-concurrency`. Current builds pass prompts as arguments and write nothing |
+| `--sort roi` had no effect / warned | `--sort roi` needs effort estimates | Add `--rate-effort`; without it monday falls back to `--sort value` |
+| `--budget` put everything in `later` | Budget smaller than the cheapest item's effort, or no `--rate-effort` (items assumed 30m) | Raise the budget, add `--rate-effort` for real estimates, or use `--focus N` instead |
+| Still feels like a wall | Presented raw JSON instead of a plan | Use `--focus`/`--budget` and render the `now`/`later` buckets as a dip — see [Presentation](#presentation-render-as-a-dip-not-a-wall) |
 
 Confirm a single source satisfies the protocol before aggregating:
 `gh monday --limit 5 --date 3d | jq 'type, length'` should print `"array"` and a
@@ -164,7 +255,7 @@ A single JSON array on stdout. Sorting and rating augmentation follow pipeline s
 ]
 ```
 
-**Rated item example** (with `--rate-importance 9-1 --rate-urgency 8-1 --rate-summary 200`):
+**Rated item example** (with `--rate-importance 9-1 --rate-urgency 8-1 --rate-summary 200 --rate-effort --budget 90m`):
 ```json
 [
   {
@@ -176,10 +267,17 @@ A single JSON array on stdout. Sorting and rating augmentation follow pipeline s
     "participants": ["alice", "bob"],
     "importance": 8,
     "urgency": 7,
-    "summary": "Security-critical PR awaiting your review; blocks the 2.4 release."
+    "summary": "Security-critical PR awaiting your review; blocks the 2.4 release.",
+    "effort_minutes": 20,
+    "effort_band": "short",
+    "bucket": "now"
   }
 ]
 ```
+
+`effort_minutes` / `effort_band` appear only with `--rate-effort`; `bucket`
+appears only with `--focus` or `--budget`. Without those flags the output is
+unchanged from the plain rated shape (`importance` / `urgency` / `summary`).
 
 ```bash
 monday gh slack --date 2d | jq '.[0:5] | .[] | {id, ts, title}'

--- a/skills/monday/SKILL.md
+++ b/skills/monday/SKILL.md
@@ -33,7 +33,7 @@ monday gh slack --limit 20 --date 3d
 monday --rate-importance 9-1 --rate-urgency 8-1 --rate-summary 500
 
 # Rate with a specific model and a knowledge-base context directory
-monday gh --rate-importance 8-3 --rate-model claude-haiku-4-5 --rate-context /workspace/kb
+monday gh --rate-importance 8-3 --rate-model haiku --rate-context /workspace/kb
 ```
 
 ## Aggregation pipeline
@@ -57,7 +57,7 @@ The `monday` command executes the following steps in order:
 | `--rate-importance HI-LO` | off | Rate each item's importance on a HI..LO integer scale |
 | `--rate-urgency HI-LO` | off | Rate each item's urgency on a HI..LO integer scale |
 | `--rate-summary N` | off | Generate a ~N-character summary per item |
-| `--rate-model NAME` | `claude-haiku-4-5` | Model used by the rating agent |
+| `--rate-model NAME` | cheapest model | Rating model. Accepts an exact id from `models` or a unique case-insensitive substring (e.g. `haiku`, `us.anthropic.claude-haiku`). Validated against the live `models` catalog before any call — a typo or ambiguous fragment fails fast (exit 1) instead of running. When omitted, the cheapest haiku-class model is auto-selected. |
 | `--rate-context PATH` | none | Read-only knowledge-base path the rating agent can grep |
 | `--rate-concurrency N` | `4` | Parallel rating agents (bounded worker pool) |
 | `--rate-max N` | `60` | Refuse to rate more than N items; the rest pass through unrated |
@@ -82,6 +82,17 @@ source, then widen:
 ```bash
 monday gh --limit 5 --date 1d --rate-importance 9-1 --rate-urgency 8-1
 ```
+
+### Rating model is validated against the live catalog
+
+`--rate-model` is resolved to an **exact** `models` id before any agent spawns.
+This is deliberate: some model aliases pass `agent`'s `--model` validation but
+are not actually applied — the spawned scoop silently falls back to the parent
+model (e.g. opus at ~5× the cost of haiku; see ai-ecoverse/slicc#1752). By
+resolving against `models --json` ourselves and handing `agent` an exact id, the
+rating pass runs on the model you asked for, and a typo or ambiguous fragment
+fails fast (exit 1, no paid calls) instead of quietly overspending. Confirm the
+resolved model and per-scoop cost afterwards with `cost` / `cost --json`.
 
 ## Source protocol
 

--- a/skills/monday/SKILL.md
+++ b/skills/monday/SKILL.md
@@ -270,6 +270,12 @@ A command is **monday-compatible** when `[cmd] monday --limit N --depth N --date
 writes a JSON array to stdout, with each item carrying a stable `id` (for dedup)
 and an ISO `ts` (for sorting); all other fields pass through unchanged.
 
+**Each tool owns its own rating guidance.** A source can attach a `rating_hint`
+string to its items explaining how to read its own fields (e.g. what `merged`,
+`review_requested`, or `awaiting_checks` mean). `monday` injects it into the
+rating prompt as "Source guidance" — so the generic aggregator never hard-codes
+any one source's semantics. See [`references/SOURCE_PROTOCOL.md`](references/SOURCE_PROTOCOL.md).
+
 Each source (`gmail`, `slack`, `teams`, `outlook`, `github`/`gh`, `servicenow`)
 is its own separately installed skill that implements this sub-command. Full
 contract — invocation flags, item schema, dedup/sort semantics, a reference

--- a/skills/monday/SKILL.md
+++ b/skills/monday/SKILL.md
@@ -56,7 +56,7 @@ The `monday` command executes the following steps in order:
 2. **Invoke in parallel** — call `[cmd] monday --limit N --depth N --date Nd` for every discovered source concurrently.
 3. **Collect and validate JSON** — sources that exit non-zero, emit empty output, or return invalid JSON are logged to stderr and dropped; aggregation continues with the rest. Each source is also truncated to `--limit`, so a source that ignores the flag cannot inflate the run.
 4. **Deduplicate by `id`** — merge arrays in argument order; the first occurrence of an `id` wins. (Precedence rules: [`references/SOURCE_PROTOCOL.md`](references/SOURCE_PROTOCOL.md).)
-5. **Optionally rate** — if any `--rate-*` flag is set, submit each item to the rating agent to assign `importance`, `urgency`, `summary`, an `actionable` flag (does it need action from you, or is it FYI?), and — with `--rate-effort` — an `effort_minutes` estimate plus a coarse `effort_band` (`quick`/`short`/`deep`). Agents run through a bounded worker pool (`--rate-concurrency`) and no more than `--rate-max` items are rated. Rating failures fall back to the unrated item; aggregation still completes.
+5. **Optionally rate** — if any `--rate-*` flag is set, submit each item to the rating agent to assign `importance`, `urgency`, `summary`, a `category` (`fyi` \| `confirm` \| `review` \| `respond` \| `act` — what the item asks of you), a derived `actionable` flag (`category !== 'fyi'`), and — with `--rate-effort` — an `effort_minutes` estimate plus a coarse `effort_band` (`quick`/`short`/`deep`). Agents run through a bounded worker pool (`--rate-concurrency`) and no more than `--rate-max` items are rated. Rating failures fall back to the unrated item; aggregation still completes.
 6. **Sort** — order by `--sort`: `roi` (impact per minute — the default when `--rate-effort` is on), `value` (importance × urgency), or `newest`. Unrated runs always fall back to `ts` descending.
 7. **Plan (backpressure)** — split actionable to-dos from informational **FYI** items (merged PRs, closed issues, notifications). If `--focus N` or `--budget DURATION` is set, promote a doable slice of to-dos to a `now` bucket and hold the rest as `later`; FYI items go to a separate `fyi` bucket that never consumes the time budget. Each item gets a `bucket` field and a one-line plan summary prints to stderr. The goal is a doable slice, not a wall (see [Backpressure](#backpressure-a-plan-not-a-wall) and [Presentation](#presentation-render-as-a-dip-not-a-wall)).
 8. **Output** — write the final JSON array to stdout.
@@ -285,6 +285,7 @@ A single JSON array on stdout. Sorting and rating augmentation follow pipeline s
     "importance": 8,
     "urgency": 7,
     "summary": "Security-critical PR awaiting your review; blocks the 2.4 release.",
+    "category": "review",
     "actionable": true,
     "effort_minutes": 20,
     "effort_band": "short",
@@ -293,7 +294,8 @@ A single JSON array on stdout. Sorting and rating augmentation follow pipeline s
 ]
 ```
 
-`actionable` appears on every rated item; `effort_minutes` / `effort_band`
+`category` (`fyi`/`confirm`/`review`/`respond`/`act`) and its derived
+`actionable` flag appear on every rated item; `effort_minutes` / `effort_band`
 appear only with `--rate-effort`; `bucket` (`now` | `later` | `fyi`) appears
 once a plan is active. Without those flags the output is unchanged from the
 plain rated shape (`importance` / `urgency` / `summary`).

--- a/skills/monday/SKILL.md
+++ b/skills/monday/SKILL.md
@@ -56,9 +56,9 @@ The `monday` command executes the following steps in order:
 2. **Invoke in parallel** — call `[cmd] monday --limit N --depth N --date Nd` for every discovered source concurrently.
 3. **Collect and validate JSON** — sources that exit non-zero, emit empty output, or return invalid JSON are logged to stderr and dropped; aggregation continues with the rest. Each source is also truncated to `--limit`, so a source that ignores the flag cannot inflate the run.
 4. **Deduplicate by `id`** — merge arrays in argument order; the first occurrence of an `id` wins. (Precedence rules: [`references/SOURCE_PROTOCOL.md`](references/SOURCE_PROTOCOL.md).)
-5. **Optionally rate** — if any `--rate-*` flag is set, submit each item to the rating agent (model: `--rate-model`; optional context: `--rate-context`) to assign `importance`, `urgency`, `summary`, and — with `--rate-effort` — an `effort_minutes` estimate plus a coarse `effort_band` (`quick`/`short`/`deep`). Agents run through a bounded worker pool (`--rate-concurrency`) and no more than `--rate-max` items are rated. Rating failures fall back to the unrated item; aggregation still completes.
-6. **Sort** — order by `--sort`: `value` (importance × urgency, the default), `roi` (impact per minute — quick wins first; needs `--rate-effort`), or `newest` (timestamp). Unrated runs always fall back to `ts` descending.
-7. **Plan (backpressure)** — if `--focus N` or `--budget DURATION` is set, split the sorted list into a `now` bucket and a `later` bucket, tag each item with a `bucket` field, and emit `now` items first. A one-line plan summary goes to stderr. The goal is a doable slice, not a wall (see [Backpressure](#backpressure-a-plan-not-a-wall)).
+5. **Optionally rate** — if any `--rate-*` flag is set, submit each item to the rating agent to assign `importance`, `urgency`, `summary`, an `actionable` flag (does it need action from you, or is it FYI?), and — with `--rate-effort` — an `effort_minutes` estimate plus a coarse `effort_band` (`quick`/`short`/`deep`). Agents run through a bounded worker pool (`--rate-concurrency`) and no more than `--rate-max` items are rated. Rating failures fall back to the unrated item; aggregation still completes.
+6. **Sort** — order by `--sort`: `roi` (impact per minute — the default when `--rate-effort` is on), `value` (importance × urgency), or `newest`. Unrated runs always fall back to `ts` descending.
+7. **Plan (backpressure)** — split actionable to-dos from informational **FYI** items (merged PRs, closed issues, notifications). If `--focus N` or `--budget DURATION` is set, promote a doable slice of to-dos to a `now` bucket and hold the rest as `later`; FYI items go to a separate `fyi` bucket that never consumes the time budget. Each item gets a `bucket` field and a one-line plan summary prints to stderr. The goal is a doable slice, not a wall (see [Backpressure](#backpressure-a-plan-not-a-wall) and [Presentation](#presentation-render-as-a-dip-not-a-wall)).
 8. **Output** — write the final JSON array to stdout.
 
 ## Flags
@@ -76,9 +76,9 @@ The `monday` command executes the following steps in order:
 | `--rate-context PATH` | none | Read-only knowledge-base path the rating agent can grep |
 | `--rate-concurrency N` | `4` | Parallel rating agents (bounded worker pool) |
 | `--rate-max N` | `60` | Refuse to rate more than N items; the rest pass through unrated |
-| `--sort MODE` | `value` | Ranking: `value` (importance × urgency), `roi` (impact per minute; needs `--rate-effort`), or `newest` (timestamp) |
-| `--focus N` | off | Mark only the top N items as the `now` bucket; the rest become `later` |
-| `--budget DURATION` | off | Pack the highest-ranked items that fit a time box (`90m`, `2h`, `1h30m`) into `now`; needs `--rate-effort` |
+| `--sort MODE` | `roi` if `--rate-effort` else `value` | Ranking: `roi` (impact per minute — best bang-for-buck first), `value` (importance × urgency), or `newest` (timestamp) |
+| `--focus N` | off | Promote only the top N to-dos to the `now` bucket; the rest become `later` |
+| `--budget DURATION` | off | Pack the highest-ranked to-dos that fit a time box (`90m`, `2h`, `1h30m`) into `now`; needs `--rate-effort` |
 
 Positional args (`gh`, `slack`, `teams`, `outlook`, `gmail`, `servicenow`) select
 which sources to invoke. With no positional args, `monday` runs `which <cmd>` on
@@ -161,25 +161,42 @@ you opt into a plan.
 `monday` emits data; **how that data reaches the human decides whether it feels
 like a plan or a defeat.** When you (the cone) surface a triage run to the user,
 do not paste the raw JSON array. Render it as a [dip](../dips/SKILL.md) — an
-inline, ephemeral chat widget — following these principles:
+inline, ephemeral chat widget.
 
-1. **Lead with the `now` bucket.** Show the doable slice big and first
-   ("Start here → 4 items, ~85 min"). Collapse `later` behind a count
-   ("+46 more, ranked, when you're ready") — visible, not in your face.
-2. **One line per item:** title, a `source #id` chip, the score or ROI, the
-   `effort_band` as a small pill, and a one-clause "why now" from the summary.
-3. **Band the list** (CRIT / HIGH / MED / LOW by score, or by `effort_band`)
-   so the eye groups it without reading every row.
-4. **Make each item actionable** — an Open link (`url`), and optionally
-   Done / Defer buttons that `slicc.lick(...)` back so triage is a loop, not a
-   report.
-5. **Frame momentum, not doom.** "3 quick wins before lunch" beats "50 open
-   items." The backlog *count* stays honest; its *contents* stay collapsed.
+**The turnkey path is the bundled `monday-dip` renderer** — it is the canonical
+presentation template, so you never hand-assemble the widget:
 
-Recommended pipeline: run `monday … --rate-effort --budget 90m` (or `--focus`),
-read the JSON, and build the dip from the `now`/`later` buckets. Keep the JSON
-contract intact for scripts; the dip is a presentation layer on top, not a
-replacement.
+```bash
+monday gh --rate-importance 9-1 --rate-urgency 8-1 --rate-effort --budget 90m \
+  > /tmp/plan.json 2>/dev/null
+monday-dip /tmp/plan.json          # prints the dip shtml; emit it in chat
+```
+
+`monday-dip` reads a `monday` JSON plan and prints a `.sprinkle-action-card`
+`shtml` block to stdout. Emit that block verbatim in your reply. It encodes the
+principles below so they stay consistent:
+
+1. **Three lists, in priority order.** The `now` bucket (the doable to-do slice)
+   is shown big and first; `later` collapses behind a count; **`fyi`** (merged
+   PRs, closed issues, build notifications — awareness only, marked
+   `actionable: false`) is a separate collapsed list that never competes for
+   attention.
+2. **Bang-for-buck order.** `now` is presented in monday's ROI order (impact per
+   minute), so the best-value work leads.
+3. **No meaningless numbers.** Items show a priority *word* (Critical / High /
+   Medium / Low) and the effort/time — never the raw importance×urgency score,
+   which means nothing to a human.
+4. **Icons, not emoji.** All glyphs are Lucide (`<i data-lucide="…"
+   class="sprinkle-icon">`), per the S2 style guide's "NO EMOJIS" rule.
+5. **A loop, not a report.** Each to-do has Open (`url`) plus Done / Later
+   buttons that `slicc.lick({action, data})` back; card-level Start / Re-plan
+   actions let the user drive the next step. Handle those licks (mark done,
+   re-run with a wider `--budget`, etc.).
+
+If you must build the widget by hand (e.g. a bespoke layout), read
+[`scripts/monday-dip.jsh`](scripts/monday-dip.jsh) as the reference structure.
+Keep the JSON contract intact for scripts; the dip is a presentation layer on
+top, not a replacement.
 
 
 ## Source protocol
@@ -268,6 +285,7 @@ A single JSON array on stdout. Sorting and rating augmentation follow pipeline s
     "importance": 8,
     "urgency": 7,
     "summary": "Security-critical PR awaiting your review; blocks the 2.4 release.",
+    "actionable": true,
     "effort_minutes": 20,
     "effort_band": "short",
     "bucket": "now"
@@ -275,9 +293,10 @@ A single JSON array on stdout. Sorting and rating augmentation follow pipeline s
 ]
 ```
 
-`effort_minutes` / `effort_band` appear only with `--rate-effort`; `bucket`
-appears only with `--focus` or `--budget`. Without those flags the output is
-unchanged from the plain rated shape (`importance` / `urgency` / `summary`).
+`actionable` appears on every rated item; `effort_minutes` / `effort_band`
+appear only with `--rate-effort`; `bucket` (`now` | `later` | `fyi`) appears
+once a plan is active. Without those flags the output is unchanged from the
+plain rated shape (`importance` / `urgency` / `summary`).
 
 ```bash
 monday gh slack --date 2d | jq '.[0:5] | .[] | {id, ts, title}'

--- a/skills/monday/references/SOURCE_PROTOCOL.md
+++ b/skills/monday/references/SOURCE_PROTOCOL.md
@@ -65,15 +65,23 @@ from the `github` source:
 }
 ```
 
-### Signal guard (optional `meta` fields the aggregator acts on)
+### Signal guard (normalized disposition flags)
 
 Independently of the rating agent, `monday` applies a small deterministic guard
-from `meta` when `--trust-signals` is on (the default): `meta.merged` /
-`meta.state:"closed"` force the item to `fyi`; `meta.awaiting_checks` /
-`meta.draft` hold a PR out of the "now" bucket; `meta.relationship`
-(review_requested / mention / assign) or `meta.authored_by_you` on an open item
-keep it actionable. Sources that want this behavior populate those fields; the
-guard is skipped for sources that don't.
+from **protocol-standard** `meta` flags (when `--trust-signals` is on — the
+default). Each source normalizes its own state into these; the aggregator reads
+only these, never a source's raw fields:
+
+| `meta` flag | Meaning | Effect in `monday` |
+|-------------|---------|--------------------|
+| `resolved: true` | Done — merged, closed, answered | Forced to `fyi` |
+| `awaiting_you: true` | Your review/decision/action is requested | Kept actionable (now-eligible) |
+| `waiting_on_others: true` | You've done your part; waiting on other people | Category `waiting` → the `followup` bucket (chase, don't build) |
+| `not_ready: true` | Can't act yet (draft, CI pending/failing) | Held out of `now` into `later` |
+
+A source computes these from whatever it knows (the `github` source derives them
+from PR/issue state, merge/CI status, and your relationship to the thread). A
+source that sets none of them is simply unaffected by the guard.
 
 ### Minimal item
 

--- a/skills/monday/references/SOURCE_PROTOCOL.md
+++ b/skills/monday/references/SOURCE_PROTOCOL.md
@@ -43,10 +43,37 @@ is passed through to the output unchanged.
 | `url` | no | string | Passthrough (display). |
 | `participants` | no | string[] | Passthrough (display). |
 | `body` | no | string | Passthrough; useful context for the rating agent. |
+| `rating_hint` | no | string | **Source-owned rating guidance.** Injected verbatim into the rating prompt as "Source guidance" so each tool explains how to read its own fields (e.g. what `meta.merged` or a "review_requested" relationship means) without the generic aggregator hard-coding any source's semantics. Omit it and `monday` falls back to a generic instruction. |
+| `meta` | no | object | Passthrough; also read by the signal guard (below). |
 | _any other_ | no | any | Passed through verbatim. |
 
-`importance`, `urgency`, and `summary` are **added by `monday`** when a `--rate-*`
-flag is set — sources should not emit them.
+`importance`, `urgency`, `summary`, and `category` are **added by `monday`** when
+a `--rate-*` flag is set — sources should not emit them.
+
+### Rating hint (let each tool own its instructions)
+
+Put source-specific interpretation in `rating_hint`, not in `monday`. Example
+from the `github` source:
+
+```json
+{
+  "id": "gh-notif-123", "ts": "2025-07-14T09:12:00Z", "source": "gh",
+  "title": "Fix race condition", "url": "https://github.com/org/repo/pull/4821",
+  "meta": { "state": "open", "merged": false, "relationship": "review_requested",
+            "authored_by_you": false, "checks": "passing", "awaiting_checks": false },
+  "rating_hint": "This is a GitHub item. meta.relationship says what is expected of the reader… If meta.merged is true or meta.state is \"closed\", category MUST be fyi. If meta.awaiting_checks is true, keep urgency low — acting now is premature."
+}
+```
+
+### Signal guard (optional `meta` fields the aggregator acts on)
+
+Independently of the rating agent, `monday` applies a small deterministic guard
+from `meta` when `--trust-signals` is on (the default): `meta.merged` /
+`meta.state:"closed"` force the item to `fyi`; `meta.awaiting_checks` /
+`meta.draft` hold a PR out of the "now" bucket; `meta.relationship`
+(review_requested / mention / assign) or `meta.authored_by_you` on an open item
+keep it actionable. Sources that want this behavior populate those fields; the
+guard is skipped for sources that don't.
 
 ### Minimal item
 

--- a/skills/monday/scripts/monday-dip.jsh
+++ b/skills/monday/scripts/monday-dip.jsh
@@ -1,0 +1,176 @@
+// monday-dip — render a `monday` JSON plan as a dip (inline shtml widget).
+//
+// This is the canonical presentation template for `monday` output. It turns a
+// rated/planned JSON array into a "plan of attack" card: a doable TODO slice
+// ("now"), a held backlog ("later"), and a separate awareness list ("FYI").
+// The cone runs this and emits the resulting shtml block in chat.
+//
+// Usage:
+//   monday gh --rate-importance 9-1 --rate-urgency 8-1 --rate-effort --budget 90m \
+//     > /tmp/plan.json 2>/dev/null
+//   monday-dip /tmp/plan.json        # prints the shtml to stdout
+//
+// Design rules (keep them — they are the point):
+//   * NO EMOJIS. Icons are Lucide via <i data-lucide="name" class="sprinkle-icon">.
+//   * No raw importance×urgency numbers in the UI — they are meaningless to a
+//     human. Show a priority word and the effort/time instead.
+//   * TODO (actionable) is the plan; FYI (merged PRs, closed issues, build
+//     notifications) is awareness only and never competes for attention.
+//   * Optimise for bang-for-buck: the "now" list is already ROI-ordered by
+//     monday; present it in that order.
+
+const fs = require('fs');
+
+const path = process.argv.find((a, i) => i >= 2 && !a.startsWith('-'));
+if (!path) {
+  console.error('usage: monday-dip <plan.json>   (a JSON array from `monday`)');
+  process.exit(2);
+}
+
+let items;
+try {
+  items = JSON.parse(fs.readFileSync(path, 'utf8'));
+} catch (e) {
+  console.error(`monday-dip: could not read/parse ${path}: ${e.message}`);
+  process.exit(1);
+}
+if (!Array.isArray(items)) {
+  console.error('monday-dip: expected a JSON array from `monday`.');
+  process.exit(1);
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+const esc = (s) =>
+  String(s == null ? '' : s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+const scoreOf = (it) => (it.importance || 0) * (it.urgency || 0);
+const priorityWord = (it) => {
+  const s = scoreOf(it);
+  if (s >= 20) return ['Critical', '--negative'];
+  if (s >= 12) return ['High', '--notice'];
+  if (s >= 6) return ['Medium', '--informative'];
+  return ['Low', '--positive'];
+};
+// Lucide icon for the source item type.
+const typeIcon = (it) => {
+  const t = (it.type || '').toLowerCase();
+  if (t.includes('pr')) return 'git-pull-request';
+  if (t.includes('issue')) return 'circle-dot';
+  if (t.includes('mail') || t.includes('email')) return 'mail';
+  if (t.includes('msg') || t.includes('chat')) return 'message-square';
+  return 'bell';
+};
+const effortText = (it) =>
+  it.effort_minutes != null ? `~${it.effort_minutes} min` : (it.effort_band || '');
+
+const byBucket = (b) => items.filter((it) => it.bucket === b);
+// If the plan has no buckets (unplanned run), treat actionable items as "now".
+const hasBuckets = items.some((it) => 'bucket' in it);
+const now = hasBuckets ? byBucket('now') : items.filter((it) => it.actionable !== false);
+const later = hasBuckets ? byBucket('later') : [];
+const fyi = hasBuckets ? byBucket('fyi') : items.filter((it) => it.actionable === false);
+
+const nowMinutes = now.reduce((a, it) => a + (it.effort_minutes || 0), 0);
+const haveEffort = now.some((it) => it.effort_minutes != null);
+
+// ── row renderers ──────────────────────────────────────────────────────────────
+function todoRow(it) {
+  const [word, cls] = priorityWord(it);
+  const eff = effortText(it);
+  // Build the lick payload as a JS object literal: JSON is valid JS, and
+  // esc() turns the quotes into &quot; which the browser decodes back inside
+  // the attribute — so slicc.lick receives a real object, not a string.
+  const doneData = esc(JSON.stringify({ id: it.id, title: it.title }));
+  const deferData = esc(JSON.stringify({ id: it.id }));
+  return `      <div class="monday-item">
+        <div class="monday-item__head">
+          <i data-lucide="${typeIcon(it)}" class="sprinkle-icon sprinkle-icon--s"></i>
+          <a href="${esc(it.url)}" target="_blank" class="monday-item__title">${esc(it.title)}</a>
+        </div>
+        <div class="monday-item__meta">
+          <span class="sprinkle-badge sprinkle-badge${cls}">${word}</span>
+          ${eff ? `<span class="monday-eff"><i data-lucide="clock" class="sprinkle-icon sprinkle-icon--xs"></i> ${esc(eff)}</span>` : ''}
+          <span class="monday-src">${esc(it.subtitle || it.source || '')}</span>
+        </div>
+        ${it.summary ? `<div class="monday-item__why">${esc(it.summary)}</div>` : ''}
+        <div class="monday-item__actions">
+          <button class="sprinkle-btn sprinkle-btn--primary sprinkle-btn--s" onclick="window.open('${esc(it.url)}','_blank')"><i data-lucide="external-link" class="sprinkle-icon sprinkle-icon--xs"></i> Open</button>
+          <button class="sprinkle-btn sprinkle-btn--s" onclick="slicc.lick({action:'done',data:${doneData}})"><i data-lucide="check" class="sprinkle-icon sprinkle-icon--xs"></i> Done</button>
+          <button class="sprinkle-btn sprinkle-btn--secondary sprinkle-btn--s" onclick="slicc.lick({action:'defer',data:${deferData}})"><i data-lucide="clock" class="sprinkle-icon sprinkle-icon--xs"></i> Later</button>
+        </div>
+      </div>`;
+}
+
+function listRow(it) {
+  const eff = effortText(it);
+  return `        <li><i data-lucide="${typeIcon(it)}" class="sprinkle-icon sprinkle-icon--xs"></i> <a href="${esc(it.url)}" target="_blank">${esc(it.title)}</a> <span class="monday-src">${esc(it.subtitle || '')}${eff ? ` · ${esc(eff)}` : ''}</span></li>`;
+}
+
+// ── assemble ─────────────────────────────────────────────────────────────────
+const nowRows = now.map(todoRow).join('\n');
+const laterRows = later.map(listRow).join('\n');
+const fyiRows = fyi.map(listRow).join('\n');
+
+const headerCount = `${now.length} to-do${fyi.length ? ` · ${fyi.length} FYI` : ''}`;
+const intro = now.length
+  ? `Start here — ${haveEffort ? `about ${nowMinutes} minutes of ` : ''}${now.length} thing${now.length === 1 ? '' : 's'} worth doing now.${later.length ? ` ${later.length} more held for later.` : ''}`
+  : 'Nothing needs your action right now.';
+
+const style = `  <style>
+    .monday-item { padding: 10px 0; border-top: 1px solid var(--s2-color-border, rgba(128,128,128,.25)); }
+    .monday-item__head { display: flex; align-items: center; gap: 6px; }
+    .monday-item__title { font-weight: 600; text-decoration: none; }
+    .monday-item__meta { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin: 4px 0; font-size: 12px; }
+    .monday-eff { display: inline-flex; align-items: center; gap: 3px; opacity: .8; }
+    .monday-src { opacity: .6; }
+    .monday-item__why { font-size: 13px; margin-bottom: 6px; }
+    .monday-item__actions { display: flex; gap: 6px; }
+    .monday-list { font-size: 13px; margin: 8px 0 0; padding-left: 4px; list-style: none; }
+    .monday-list li { padding: 3px 0; display: flex; align-items: center; gap: 6px; }
+    .monday-list a { text-decoration: none; }
+    details { margin-top: 12px; }
+    summary { cursor: pointer; font-weight: 600; display: flex; align-items: center; gap: 6px; }
+  </style>`;
+
+const laterBlock = later.length
+  ? `      <details>
+        <summary><i data-lucide="list" class="sprinkle-icon sprinkle-icon--s"></i> ${later.length} more, ranked for later</summary>
+        <ul class="monday-list">
+${laterRows}
+        </ul>
+      </details>`
+  : '';
+
+const fyiBlock = fyi.length
+  ? `      <details>
+        <summary><i data-lucide="info" class="sprinkle-icon sprinkle-icon--s"></i> ${fyi.length} for your information — no action needed</summary>
+        <ul class="monday-list">
+${fyiRows}
+        </ul>
+      </details>`
+  : '';
+
+const shtml = `<div class="sprinkle-action-card">
+${style}
+  <div class="sprinkle-action-card__header">
+    <i data-lucide="calendar-check" class="sprinkle-icon sprinkle-icon--l"></i> Your plan
+    <span class="sprinkle-badge sprinkle-badge--notice">${headerCount}</span>
+  </div>
+  <div class="sprinkle-action-card__body">
+    <div style="font-size:13px;opacity:.85;margin-bottom:2px">${esc(intro)}</div>
+${nowRows}
+${laterBlock}
+${fyiBlock}
+  </div>
+  <div class="sprinkle-action-card__actions">
+    <button class="sprinkle-btn sprinkle-btn--secondary" onclick="slicc.lick({action:'replan',data:{budget:'120m'}})"><i data-lucide="refresh-cw" class="sprinkle-icon sprinkle-icon--xs"></i> Re-plan for 2h</button>
+    <button class="sprinkle-btn sprinkle-btn--primary" onclick="slicc.lick({action:'start',data:{}})"><i data-lucide="play" class="sprinkle-icon sprinkle-icon--xs"></i> Start now list</button>
+  </div>
+  <script>if (window.LucideIcons) LucideIcons.render();</script>
+</div>`;
+
+process.stdout.write(shtml + '\n');

--- a/skills/monday/scripts/monday-dip.jsh
+++ b/skills/monday/scripts/monday-dip.jsh
@@ -72,7 +72,8 @@ const byBucket = (b) => items.filter((it) => it.bucket === b);
 const hasBuckets = items.some((it) => 'bucket' in it);
 const now = hasBuckets ? byBucket('now') : items.filter((it) => it.actionable !== false);
 const later = hasBuckets ? byBucket('later') : [];
-const fyi = hasBuckets ? byBucket('fyi') : items.filter((it) => it.actionable === false);
+const followup = hasBuckets ? byBucket('followup') : items.filter((it) => it.category === 'waiting');
+const fyi = hasBuckets ? byBucket('fyi') : items.filter((it) => it.actionable === false && it.category !== 'waiting');
 
 const nowMinutes = now.reduce((a, it) => a + (it.effort_minutes || 0), 0);
 const haveEffort = now.some((it) => it.effort_minutes != null);
@@ -114,8 +115,15 @@ function listRow(it) {
 const nowRows = now.map(todoRow).join('\n');
 const laterRows = later.map(listRow).join('\n');
 const fyiRows = fyi.map(listRow).join('\n');
+// "Waiting on others" rows get a Nudge action — the ball is in someone else's court.
+function followupRow(it) {
+  const nudge = esc(JSON.stringify({ id: it.id, title: it.title }));
+  const eff = effortText(it);
+  return `        <li><i data-lucide="hourglass" class="sprinkle-icon sprinkle-icon--xs"></i> <a href="${esc(it.url)}" target="_blank">${esc(it.title)}</a> <span class="monday-src">${esc(it.subtitle || '')}${eff ? ` · ${esc(eff)}` : ''}</span> <button class="sprinkle-btn sprinkle-btn--secondary sprinkle-btn--s" onclick="slicc.lick({action:'nudge',data:${nudge}})"><i data-lucide="send" class="sprinkle-icon sprinkle-icon--xs"></i> Nudge</button></li>`;
+}
+const followupRows = followup.map(followupRow).join('\n');
 
-const headerCount = `${now.length} to-do${fyi.length ? ` · ${fyi.length} FYI` : ''}`;
+const headerCount = `${now.length} to-do${followup.length ? ` · ${followup.length} waiting` : ''}${fyi.length ? ` · ${fyi.length} FYI` : ''}`;
 const intro = now.length
   ? `Start here — ${haveEffort ? `about ${nowMinutes} minutes of ` : ''}${now.length} thing${now.length === 1 ? '' : 's'} worth doing now.${later.length ? ` ${later.length} more held for later.` : ''}`
   : 'Nothing needs your action right now.';
@@ -145,6 +153,15 @@ ${laterRows}
       </details>`
   : '';
 
+const followupBlock = followup.length
+  ? `      <details open>
+        <summary><i data-lucide="hourglass" class="sprinkle-icon sprinkle-icon--s"></i> ${followup.length} waiting on others — chase or nudge</summary>
+        <ul class="monday-list">
+${followupRows}
+        </ul>
+      </details>`
+  : '';
+
 const fyiBlock = fyi.length
   ? `      <details>
         <summary><i data-lucide="info" class="sprinkle-icon sprinkle-icon--s"></i> ${fyi.length} for your information — no action needed</summary>
@@ -164,6 +181,7 @@ ${style}
     <div style="font-size:13px;opacity:.85;margin-bottom:2px">${esc(intro)}</div>
 ${nowRows}
 ${laterBlock}
+${followupBlock}
 ${fyiBlock}
   </div>
   <div class="sprinkle-action-card__actions">

--- a/skills/monday/scripts/monday.jsh
+++ b/skills/monday/scripts/monday.jsh
@@ -6,7 +6,7 @@
 // Examples:
 //   monday gh slack --limit 20 --date 3d
 //   monday --rate-importance 9-4 --rate-urgency 8-3 --rate-summary 500
-//   monday gh --limit 10 --rate-importance 8-3 --rate-model haiku
+//   monday gh --limit 10 --rate-importance 8-3 --rate-model us.anthropic.claude-haiku
 //
 // With no positional args, auto-discovers monday-compatible commands on PATH.
 
@@ -129,7 +129,7 @@ RATING (each rated item costs one model call — start small)
   --rate-effort             Estimate effort per item (effort_minutes + a
                             quick/short/deep band). Feeds --sort roi & --budget.
   --rate-model NAME         Model for rating. Accepts an exact id from \`models\`
-                            or a unique substring (e.g. "haiku"). Validated
+                            or a unique substring (e.g. "us.anthropic.claude-haiku"). Validated
                             before any call; defaults to the cheapest model.
   --rate-context PATH       Read-only knowledge base the rater may grep
   --rate-concurrency N      Parallel rating agents (default 4)
@@ -358,7 +358,7 @@ async function resolveRateModel(requested) {
     // 1. Exact id match — the ideal case.
     if (ids.includes(requested)) return requested;
     // 2. Unique case-insensitive substring match (lets the user pass a short,
-    //    memorable fragment like "haiku" or "claude-haiku-4-5").
+    //    memorable fragment like "us.anthropic.claude-haiku").
     const needle = requested.toLowerCase();
     const matches = ids.filter((id) => id.toLowerCase().includes(needle));
     if (matches.length === 1) {
@@ -927,16 +927,6 @@ async function main() {
 
   // 4. Rate if any --rate-* flags are present
   if (hasRating && items.length > 0) {
-    // Resolve the rating model to an exact `models` id up front. This both
-    // validates the user's --rate-model (fail fast on a typo instead of paying
-    // for a wrong model) and sidesteps the alias-fallback trap in `agent`
-    // (ai-ecoverse/slicc#1752).
-    try {
-      rateModel = await resolveRateModel(rateModelArg);
-    } catch (e) {
-      console.error(`[monday] ${e.message}`);
-      process.exit(1);
-    }
     // Guard rail: rating is one model call per item, so an unexpectedly large merge
     // is expensive and slow. Rate the newest N and pass the rest through unrated
     // rather than silently launching hundreds of calls.
@@ -947,25 +937,40 @@ async function main() {
     const parsedMax = parseInt(rateMax, 10);
     const cap = Number.isFinite(parsedMax) ? Math.max(0, parsedMax) : 60;
     if (cap === 0) {
+      // Rating is explicitly disabled — do NOT resolve the model. Resolving here
+      // would let a missing `models` command or a bad --rate-model fail a run
+      // that was never going to spend a call. All items pass through unrated.
       console.error(
         '[monday] --rate-max 0: rating disabled, all items pass through unrated.'
       );
-    } else if (items.length > cap) {
-      console.error(
-        `[monday] WARNING: ${items.length} items exceeds --rate-max ${cap}. ` +
-        `Rating the ${cap} newest; the rest pass through unrated. ` +
-        `Raise --rate-max or lower --limit.`
-      );
-      const byNewest = sortItems(items, false);
-      const rated = await rateAllItems(byNewest.slice(0, cap));
-      items = [...rated, ...byNewest.slice(cap)];
     } else {
-      items = await rateAllItems(items);
+      // Resolve the rating model to an exact `models` id up front. This both
+      // validates the user's --rate-model (fail fast on a typo instead of paying
+      // for a wrong model) and sidesteps the alias-fallback trap in `agent`
+      // (ai-ecoverse/slicc#1752).
+      try {
+        rateModel = await resolveRateModel(rateModelArg);
+      } catch (e) {
+        console.error(`[monday] ${e.message}`);
+        process.exit(1);
+      }
+      if (items.length > cap) {
+        console.error(
+          `[monday] WARNING: ${items.length} items exceeds --rate-max ${cap}. ` +
+          `Rating the ${cap} newest; the rest pass through unrated. ` +
+          `Raise --rate-max or lower --limit.`
+        );
+        const byNewest = sortItems(items, false);
+        const rated = await rateAllItems(byNewest.slice(0, cap));
+        items = [...rated, ...byNewest.slice(cap)];
+      } else {
+        items = await rateAllItems(items);
+      }
+      if (cacheHits) {
+        console.error(`[monday] rating cache: reused ${cacheHits} cached rating(s); the rest were freshly rated (--no-cache to disable, monday cache-clear to reset).`);
+      }
+      flushCache();
     }
-    if (cacheHits) {
-      console.error(`[monday] rating cache: reused ${cacheHits} cached rating(s); the rest were freshly rated (--no-cache to disable, monday cache-clear to reset).`);
-    }
-    flushCache();
   }
 
   // 5. Sort. Default to ROI (bang-for-buck — impact per minute) whenever effort

--- a/skills/monday/scripts/monday.jsh
+++ b/skills/monday/scripts/monday.jsh
@@ -91,6 +91,8 @@ RATING (each rated item costs one model call — start small)
   --rate-importance HI-LO   Rate importance, e.g. 9-1
   --rate-urgency HI-LO      Rate urgency, e.g. 8-1
   --rate-summary N          ~N-character summary per item
+  --rate-effort             Estimate effort per item (effort_minutes + a
+                            quick/short/deep band). Feeds --sort roi & --budget.
   --rate-model NAME         Model for rating. Accepts an exact id from \`models\`
                             or a unique substring (e.g. "haiku"). Validated
                             before any call; defaults to the cheapest model.
@@ -98,14 +100,29 @@ RATING (each rated item costs one model call — start small)
   --rate-concurrency N      Parallel rating agents (default 4)
   --rate-max N              Refuse to rate more than N items (default 60)
 
+RANKING & BACKPRESSURE (turn a wall of items into a plan of attack)
+  --sort MODE               value (default: importance x urgency), roi
+                            (impact per minute — quick wins first; needs
+                            --rate-effort), or newest (timestamp)
+  --focus N                 Mark only the top N items as the "now" bucket;
+                            everything else becomes "later". A doable slice
+                            instead of the full backlog.
+  --budget DURATION         Pack the highest-ranked items that fit a time box
+                            into "now" (e.g. 90m, 2h, 1h30m); needs
+                            --rate-effort. The rest become "later".
+
 OUTPUT
-  JSON array on stdout; progress and warnings on stderr. Sorted by
-  urgency x importance when rated, else by timestamp descending.
+  JSON array on stdout; progress, plan summary, and warnings on stderr.
+  Sorted by the chosen --sort mode. When --focus or --budget is set, each item
+  carries a "bucket" field ("now" | "later") so a presenter can show a doable
+  slice first and collapse the rest.
 
 EXAMPLES
   monday gh --limit 5 --date 1d
   monday slack teams --limit 10 --date 3d
-  monday gh --limit 5 --rate-importance 9-1 --rate-urgency 8-1`);
+  monday gh --limit 5 --rate-importance 9-1 --rate-urgency 8-1
+  monday gh --rate-importance 9-1 --rate-urgency 8-1 --rate-effort --sort roi
+  monday --rate-importance 9-1 --rate-urgency 8-1 --rate-effort --budget 90m`);
   process.exit(0);
 }
 
@@ -132,8 +149,14 @@ let   rateModel      = rateModelArg;                          // resolved to an 
 const rateContext    = flags['rate-context']      || null;  // e.g. "/workspace/kb"
 const rateConcurrency = flags['rate-concurrency'] || '4';   // parallel rating agents
 const rateMax        = flags['rate-max']          || '60';  // hard ceiling on rated items
+const rateEffort     = !!flags['rate-effort'];              // estimate effort_minutes per item
 
-const hasRating = !!(rateImportance || rateUrgency || rateSummary);
+// Ranking & backpressure flags (local only — shape the plan, not the data source)
+const sortMode = (typeof flags.sort === 'string' ? flags.sort : 'value').toLowerCase();
+const focusArg  = typeof flags.focus  === 'string' ? flags.focus  : null; // top-N "now" cap
+const budgetArg = typeof flags.budget === 'string' ? flags.budget : null; // time box, e.g. "90m"
+
+const hasRating = !!(rateImportance || rateUrgency || rateSummary || rateEffort);
 
 // ─── Known Monday-Compatible Commands ────────────────────────────────────────
 
@@ -356,10 +379,16 @@ function buildRatingPrompt(item) {
     parts.push('- **summary**: a one-sentence summary');
   }
 
+  if (rateEffort) {
+    parts.push('- **effort_minutes**: your best integer estimate of how many minutes it would take a human to actually resolve or respond to this item (not to read it). A quick ack or approval might be 5; a substantive reply or small task 20-45; a deep review or real work 90+. Base it on the type, scope, and content — estimate concretely, do not default to a round number.');
+  }
+
   parts.push('');
   parts.push('## Output');
   parts.push('Return ONLY a valid JSON object on a single line, no markdown fences, no explanation:');
-  parts.push('{"importance": N, "urgency": N, "summary": "..."}');
+  const schemaFields = ['"importance": N', '"urgency": N', '"summary": "..."'];
+  if (rateEffort) schemaFields.push('"effort_minutes": N');
+  parts.push(`{${schemaFields.join(', ')}}`);
 
   return parts.join('\n');
 }
@@ -411,12 +440,18 @@ async function rateItem(item) {
     }
 
     const rating = JSON.parse(jsonMatch[0]);
-    return {
+    const rated = {
       ...item,
       importance: rating.importance ?? 5,
       urgency: rating.urgency ?? 5,
       summary: rating.summary ?? '',
     };
+    if (rateEffort) {
+      const em = Number(rating.effort_minutes);
+      rated.effort_minutes = Number.isFinite(em) && em > 0 ? Math.round(em) : null;
+      rated.effort_band = effortBand(rated.effort_minutes);
+    }
+    return rated;
   } catch (e) {
     console.error(`[monday] WARNING: failed to parse rating for ${item.id}: ${e.message}`);
     console.error(`  output: ${raw.slice(0, 300)}`);
@@ -457,25 +492,118 @@ async function rateAllItems(items) {
   return out;
 }
 
-// ─── Sorting ─────────────────────────────────────────────────────────────────
+// ─── Ranking, Effort & Backpressure ──────────────────────────────────────────
+
+/** value score = importance x urgency. */
+const scoreOf = (it) => (it.urgency || 0) * (it.importance || 0);
+
+/** Derive a coarse effort band from a minute estimate. */
+function effortBand(mins) {
+  if (mins == null) return null;
+  if (mins <= 15) return 'quick';
+  if (mins <= 60) return 'short';
+  return 'deep';
+}
 
 /**
- * Sort items. If rated, by urgency*importance descending, then ts descending.
- * Otherwise, by ts descending.
+ * Parse a human duration into whole minutes. Accepts "90m", "2h", "1h30m",
+ * "1.5h", or a bare number (minutes). Returns null if unparsable.
  */
-function sortItems(items, rated) {
+function parseDuration(s) {
+  if (!s) return null;
+  const str = String(s).trim().toLowerCase();
+  if (/^\d+$/.test(str)) return parseInt(str, 10); // bare number = minutes
+  let mins = 0;
+  let matched = false;
+  const h = str.match(/(\d+(?:\.\d+)?)\s*h/);
+  if (h) { mins += parseFloat(h[1]) * 60; matched = true; }
+  const m = str.match(/(\d+(?:\.\d+)?)\s*m/);
+  if (m) { mins += parseFloat(m[1]); matched = true; }
+  return matched ? Math.round(mins) : null;
+}
+
+/**
+ * Return-on-investment: value per minute of effort. Items missing an effort
+ * estimate are treated as a middling 30 min so they neither dominate nor vanish.
+ */
+const EFFORT_UNKNOWN_MIN = 30;
+const roiOf = (it) => scoreOf(it) / Math.max(1, it.effort_minutes || EFFORT_UNKNOWN_MIN);
+
+/**
+ * Sort items by the chosen mode.
+ *   value  — importance x urgency desc (default), ts desc as tie-break
+ *   roi    — value per minute desc (quick wins first), value then ts as tie-break
+ *   newest — ts desc
+ * When not rated, everything collapses to ts desc regardless of mode.
+ */
+function sortItems(items, rated, mode = 'value') {
+  const byTs = (a, b) =>
+    (b.ts ? new Date(b.ts).getTime() : 0) - (a.ts ? new Date(a.ts).getTime() : 0);
   return items.sort((a, b) => {
-    if (rated) {
-      const scoreA = (a.urgency || 0) * (a.importance || 0);
-      const scoreB = (b.urgency || 0) * (b.importance || 0);
-      if (scoreB !== scoreA) return scoreB - scoreA;
+    if (rated && mode === 'roi') {
+      const d = roiOf(b) - roiOf(a);
+      if (d !== 0) return d;
+      const s = scoreOf(b) - scoreOf(a);
+      if (s !== 0) return s;
+    } else if (rated && mode !== 'newest') {
+      const s = scoreOf(b) - scoreOf(a);
+      if (s !== 0) return s;
     }
-    // Tie-break (or primary if not rated): ts descending
-    const tsA = a.ts ? new Date(a.ts).getTime() : 0;
-    const tsB = b.ts ? new Date(b.ts).getTime() : 0;
-    return tsB - tsA;
+    return byTs(a, b);
   });
 }
+
+/**
+ * Backpressure: split an already-sorted list into "now" and "later" buckets so a
+ * human sees a doable slice first instead of the whole backlog. Humans have the
+ * judgement; the tool's job is to protect their attention, not dump on it.
+ *
+ *   --focus N   : the top N items are "now".
+ *   --budget T  : pack the top items whose cumulative effort fits T minutes into
+ *                 "now" (items with no effort estimate assumed 30 min).
+ *   both        : budget packs by time, but never exceeds the focus count.
+ *
+ * Returns { items (each tagged with a `bucket` field), nowCount, nowMinutes,
+ * laterCount, budgetMin }. When neither flag is set, planning is a no-op and
+ * `bucket` is left off entirely (output stays backward-compatible).
+ */
+function buildPlan(items) {
+  const budgetMin = parseDuration(budgetArg);
+  const focusN = focusArg != null ? parseInt(focusArg, 10) : null;
+  const focusValid = Number.isFinite(focusN) && focusN >= 0 ? focusN : null;
+  const planning = budgetMin != null || focusValid != null;
+  if (!planning) {
+    return { items, planning: false };
+  }
+
+  let usedMin = 0;
+  let nowCount = 0;
+  const tagged = items.map((it) => {
+    let inNow = true;
+    if (budgetMin != null) {
+      const cost = it.effort_minutes != null ? Math.max(1, it.effort_minutes) : EFFORT_UNKNOWN_MIN;
+      const fitsTime = usedMin + cost <= budgetMin;
+      const fitsFocus = focusValid == null || nowCount < focusValid;
+      inNow = fitsTime && fitsFocus;
+      if (inNow) usedMin += cost;
+    } else {
+      inNow = nowCount < focusValid;
+    }
+    if (inNow) nowCount++;
+    return { ...it, bucket: inNow ? 'now' : 'later' };
+  });
+
+  return {
+    items: [...tagged.filter((it) => it.bucket === 'now'), ...tagged.filter((it) => it.bucket === 'later')],
+    planning: true,
+    nowCount,
+    nowMinutes: usedMin,
+    laterCount: tagged.length - nowCount,
+    budgetMin,
+    focusN: focusValid,
+  };
+}
+
 
 // ─── Main ────────────────────────────────────────────────────────────────────
 
@@ -550,10 +678,44 @@ async function main() {
     }
   }
 
-  // 5. Sort
-  items = sortItems(items, hasRating);
+  // 5. Sort by the requested mode. ROI needs effort estimates; fall back with a
+  // warning rather than silently sorting on a bogus 30-min-for-everything ROI.
+  let mode = sortMode;
+  if (mode === 'roi' && !rateEffort) {
+    console.error(
+      '[monday] --sort roi needs --rate-effort; falling back to --sort value. ' +
+      'Add --rate-effort to rank by impact-per-minute.'
+    );
+    mode = 'value';
+  } else if (!['value', 'roi', 'newest'].includes(mode)) {
+    console.error(`[monday] unknown --sort "${sortMode}"; using value.`);
+    mode = 'value';
+  }
+  items = sortItems(items, hasRating, mode);
 
-  // 6. Output
+  // 6. Backpressure: build a "now"/"later" plan when --focus or --budget is set.
+  const plan = buildPlan(items);
+  items = plan.items;
+  if (plan.planning) {
+    const bits = [`${plan.nowCount} now`];
+    if (rateEffort) bits[0] += ` (~${plan.nowMinutes}m)`;
+    if (plan.budgetMin != null) bits.push(`budget ${plan.budgetMin}m`);
+    if (plan.focusN != null) bits.push(`focus ${plan.focusN}`);
+    console.error(
+      `[monday] plan: ${bits.join(', ')} · ${plan.laterCount} later. ` +
+      `Start with the "now" bucket; the rest stay ranked for when you're ready.`
+    );
+  } else if (hasRating && items.length > 12) {
+    // Soft nudge: a big ranked list is still a wall. Point at the tools that
+    // turn it into a doable slice — a plan of attack, not a verdict of doom.
+    console.error(
+      `[monday] ${items.length} items ranked. That's a lot to face at once — ` +
+      `add --focus 5 (or --budget 90m with --rate-effort) to get a doable "now" ` +
+      `slice; everything else stays ranked for later.`
+    );
+  }
+
+  // 7. Output
   console.log(JSON.stringify(items, null, 2));
 }
 

--- a/skills/monday/scripts/monday.jsh
+++ b/skills/monday/scripts/monday.jsh
@@ -414,7 +414,7 @@ function buildRatingPrompt(item) {
 
   parts.push('## Instructions');
   parts.push('Rate this item based on its content, participants, recency, and context.');
-  parts.push('If the item has a `meta` block, use it: `meta.viewer` is the reader\'s own username, so `meta.authored_by_you: true` means the reader opened this and is likely waiting on others or on a merge; `meta.relationship` (e.g. review_requested, assignee, mention, author) tells you what is expected of the reader. Weight items where the reader is personally on the hook (their review is requested, it is assigned to them, they are directly mentioned, or they authored it and it is now ready) higher than things they are merely subscribed to.');
+  parts.push('If the item has a `meta` block, use it: `meta.viewer` is the reader\'s own username, so `meta.authored_by_you: true` means the reader opened this and is likely waiting on others or on a merge; `meta.relationship` (e.g. review_requested, assignee, mention, author) tells you what is expected of the reader. Weight items where the reader is personally on the hook (their review is requested, it is assigned to them, they are directly mentioned, or they authored it and it is now ready) higher than things they are merely subscribed to. If `meta.merged` is true or `meta.state` is "closed", the item is already done — category MUST be `fyi`. If `meta.awaiting_checks` is true (a PR whose CI is still pending or failing) or `meta.draft` is true, it is not ready to merge/act on yet — keep its urgency low, since acting now would be premature.');
   parts.push('');
 
   if (rateImportance) {
@@ -496,12 +496,24 @@ function applySignalGuard(rated) {
   if (!trustSignals) return rated;
   const m = rated.meta || {};
   const closed = m.state === 'closed' || m.state === 'merged' || m.merged === true;
+  // Downgrade: an already merged/closed item is done — never a to-do, whatever
+  // the rater guessed from stale notification text.
+  if (closed) {
+    if (rated.category !== 'fyi') {
+      rated.category = 'fyi';
+      rated.actionable = false;
+      rated.reclassified_by_signal = 'closed';
+    }
+    return rated;
+  }
+  // Upgrade: you were asked to review/act, or authored an open item — keep it a
+  // to-do even if the rater guessed FYI.
   const asked = ['review_requested', 'mention', 'assign', 'assigned'].includes(m.relationship);
   const mineOpen = m.authored_by_you === true && m.state === 'open';
-  if (!closed && rated.category === 'fyi' && (asked || mineOpen)) {
+  if (rated.category === 'fyi' && (asked || mineOpen)) {
     rated.category = 'review';
     rated.actionable = true;
-    rated.reclassified_by_signal = true;
+    rated.reclassified_by_signal = 'relationship';
   }
   return rated;
 }
@@ -736,10 +748,16 @@ function buildPlan(items) {
 
   let usedMin = 0;
   let nowCount = 0;
+  // A PR that is a draft or still red/pending on CI isn't ready to act on — hold
+  // it for "later" rather than the top of the list, even if it ranks high.
+  const notReadyNow = (it) =>
+    it.type === 'pr' && it.meta && (it.meta.draft === true || it.meta.awaiting_checks === true);
   const taggedTodo = todo.map((it) => {
     let inNow = true;
     if (sliceRequested) {
-      if (budgetMin != null) {
+      if (notReadyNow(it)) {
+        inNow = false; // waiting on checks / draft → not top of the list
+      } else if (budgetMin != null) {
         const cost = it.effort_minutes != null ? Math.max(1, it.effort_minutes) : EFFORT_UNKNOWN_MIN;
         const fitsTime = usedMin + cost <= budgetMin;
         const fitsFocus = focusValid == null || nowCount < focusValid;

--- a/skills/monday/scripts/monday.jsh
+++ b/skills/monday/scripts/monday.jsh
@@ -362,6 +362,7 @@ function buildRatingPrompt(item) {
 
   parts.push('## Instructions');
   parts.push('Rate this item based on its content, participants, recency, and context.');
+  parts.push('If the item has a `meta` block, use it: `meta.viewer` is the reader\'s own username, so `meta.authored_by_you: true` means the reader opened this and is likely waiting on others or on a merge; `meta.relationship` (e.g. review_requested, assignee, mention, author) tells you what is expected of the reader. Weight items where the reader is personally on the hook (their review is requested, it is assigned to them, they are directly mentioned, or they authored it and it is now ready) higher than things they are merely subscribed to.');
   parts.push('');
 
   if (rateImportance) {
@@ -385,17 +386,23 @@ function buildRatingPrompt(item) {
   }
 
   if (rateEffort) {
-    parts.push('- **effort_minutes**: your best integer estimate of how many minutes it would take a human to actually resolve or respond to this item (not to read it). A quick ack or approval might be 5; a substantive reply or small task 20-45; a deep review or real work 90+. Base it on the type, scope, and content — estimate concretely, do not default to a round number.');
+    parts.push('- **effort_minutes**: your best integer estimate of how many minutes it would take the reader to ACTUALLY handle this — the work itself, not reading it. Be realistic and do not over-estimate; most inbox items are small. Anchors: clicking approve/merge on a PR that is already reviewed, acking a mention, or a one-line reply = 1-2 min; a quick look-then-approve or a short comment = 3-8 min; a genuine review or a considered reply = 15-30 min; real implementation, a deep review, or a long writeup = 60+ min. A pure "confirm" action is almost always 1-2 minutes — reserve larger numbers for items that truly require reading, thinking, or writing.');
   }
 
-  parts.push('- **actionable**: true if this item needs an action FROM the reader — a review, reply, decision, merge, or fix that is still pending. false if it is purely informational: an already-merged PR, a closed or resolved issue, a build/release notification, a CC/FYI mention, or anything reported only so the reader is aware. When in doubt about whether the reader still has to do something, prefer false for items that are already done or closed.');
+  parts.push('- **category**: the single word that best describes what is expected of the reader:');
+  parts.push('  - `fyi` — no action; awareness only (already-merged PR, closed/resolved issue, build or release notification, CC/FYI mention).');
+  parts.push('  - `confirm` — a quick yes/no decision or acknowledgement: approve, merge an already-reviewed PR, sign off, dismiss. Low effort.');
+  parts.push('  - `review` — the reader must read/examine something before deciding: review a PR\'s code, read a doc or proposal.');
+  parts.push('  - `respond` — the reader owes a written reply: answer a question, reply to a comment or message, weigh in on a discussion.');
+  parts.push('  - `act` — the reader has real work to do: implement a fix, make a change, complete a task.');
+  parts.push('  Choose exactly one. If it is already done or closed, it is `fyi`.');
 
   parts.push('');
   parts.push('## Output');
   parts.push('Return ONLY a valid JSON object on a single line, no markdown fences, no explanation:');
   const schemaFields = ['"importance": N', '"urgency": N', '"summary": "..."'];
   if (rateEffort) schemaFields.push('"effort_minutes": N');
-  schemaFields.push('"actionable": true|false');
+  schemaFields.push('"category": "fyi|confirm|review|respond|act"');
   parts.push(`{${schemaFields.join(', ')}}`);
 
   return parts.join('\n');
@@ -459,9 +466,12 @@ async function rateItem(item) {
       rated.effort_minutes = Number.isFinite(em) && em > 0 ? Math.round(em) : null;
       rated.effort_band = effortBand(rated.effort_minutes);
     }
-    // Default to actionable when the rater omits it — safer to surface a to-do
-    // than to bury a real task in the FYI pile.
-    rated.actionable = rating.actionable === false ? false : true;
+    // Category is the reader's expected posture (fyi/confirm/review/respond/act).
+    // `actionable` is derived from it for backward-compatible consumers.
+    const CATEGORIES = ['fyi', 'confirm', 'review', 'respond', 'act'];
+    const cat = typeof rating.category === 'string' ? rating.category.toLowerCase().trim() : '';
+    rated.category = CATEGORIES.includes(cat) ? cat : 'act'; // default to a to-do, not FYI
+    rated.actionable = rated.category !== 'fyi';
     return rated;
   } catch (e) {
     console.error(`[monday] WARNING: failed to parse rating for ${item.id}: ${e.message}`);
@@ -721,8 +731,7 @@ async function main() {
   }
   if (mode === 'roi' && !rateEffort) {
     console.error(
-      '[monday] --sort roi needs --rate-effort; falling back to --sort value. ' +
-      'Add --rate-effort to rank by impact-per-minute.'
+      '[monday] --sort roi needs --rate-effort; falling back to --sort value. ' +      'Add --rate-effort to rank by impact-per-minute.'
     );
     mode = 'value';
   }
@@ -742,14 +751,14 @@ async function main() {
     if (plan.fyiCount) tail.push(`${plan.fyiCount} FYI`);
     console.error(
       `[monday] plan: ${bits.join(', ')}` +
-      (tail.length ? ` · ${tail.join(' · ')}` : '') +
+      (tail.length ? ` � ${tail.join(' � ')}` : '') +
       `. Start with the "now" bucket; "later" stays ranked and "FYI" is just for awareness.`
     );
   } else if (hasRating && items.length > 12) {
     // Soft nudge: a big ranked list is still a wall. Point at the tools that
-    // turn it into a doable slice — a plan of attack, not a verdict of doom.
+    // turn it into a doable slice  a plan of attack, not a verdict of doom.
     console.error(
-      `[monday] ${items.length} items ranked. That's a lot to face at once — ` +
+      `[monday] ${items.length} items ranked. That's a lot to face at once  ` +
       `add --focus 5 (or --budget 90m with --rate-effort) to get a doable "now" ` +
       `slice; everything else stays ranked for later.`
     );

--- a/skills/monday/scripts/monday.jsh
+++ b/skills/monday/scripts/monday.jsh
@@ -12,13 +12,44 @@
 
 // Runtime bridge: the jsh runtime no longer injects `exec` as a bare global;
 // obtain it explicitly. `exec` is callable directly.
-// (No `fs` import: rating passes prompts as argv, so this script writes nothing.)
 const exec = require('sliccy:exec');
+// `fs` is used for the persistent rating cache and the done/ignore list only —
+// the rating agents still write nothing (prompts are passed as argv).
+const fs = require('fs');
 
 // Single POSIX-shell-quote a value for safe interpolation into an exec()
 // command line (exec runs through the jsh shell bridge).
 function escapeShellArg(value) {
   return "'" + String(value).replace(/'/g, "'\\''") + "'";
+}
+
+// ─── Persistent state (rating cache + done/ignore list) ──────────────────────
+// Both live outside the repo, keyed off $MONDAY_HOME or ~/.monday, so a rerun
+// doesn't re-pay for unchanged items and dismissed items stay dismissed.
+const STATE_DIR =
+  process.env.MONDAY_HOME ||
+  (process.env.HOME && process.env.HOME !== '/'
+    ? `${process.env.HOME}/.monday`
+    : '/shared/monday');
+const CACHE_FILE = `${STATE_DIR}/rating-cache.json`;
+const SUPPRESS_FILE = `${STATE_DIR}/suppress.json`;
+
+function ensureStateDir() {
+  try { fs.mkdirSync(STATE_DIR, { recursive: true }); } catch { /* best effort; writeFile will surface real errors */ }
+}
+function readJson(path, fallback) {
+  try { return JSON.parse(fs.readFileSync(path, 'utf8')); } catch { return fallback; }
+}
+function writeJson(path, obj) {
+  ensureStateDir();
+  fs.writeFileSync(path, JSON.stringify(obj, null, 2));
+}
+
+// Stable, dependency-free string hash (djb2/xor) for cache keys.
+function hashKey(s) {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = (((h << 5) + h) ^ s.charCodeAt(i)) >>> 0;
+  return h.toString(16);
 }
 
 // ─── Argument Parsing ────────────────────────────────────────────────────────
@@ -77,6 +108,10 @@ if (flags.help || flags.h) {
 
 USAGE
   monday [source...] [flags]
+  monday done|ignore <id>...        # never show these items again
+  monday restore <id>...            # undo a done/ignore
+  monday ignored                    # list the done/ignore list
+  monday cache-clear                # wipe the rating cache
 
   With no sources, auto-discovers monday-compatible commands on PATH.
   Sources: gh, slack, teams, outlook, gmail, servicenow, linkedin, tiktok
@@ -113,11 +148,23 @@ RANKING & BACKPRESSURE (turn a wall of items into a plan of attack)
 
   Every rated item is also tagged actionable vs not: informational items
   (merged PRs, closed issues, build/FYI notifications) go to a separate "fyi"
-  bucket — awareness only, never counted against your time budget.
+  bucket — awareness only, never counted against your time budget. Items where
+  you are the author (still open) or were asked to review/act are kept
+  actionable even if the rater guessed FYI (disable with --no-trust-signals).
+
+STATE (persisted under $MONDAY_HOME or ~/.monday)
+  --no-cache             Don't reuse or write cached ratings this run
+  --include-ignored      Show items on the done/ignore list anyway
+  --no-trust-signals     Don't override the rater from source relationship meta
+
+  Ratings are cached (keyed by item content + rating params + model), so a
+  rerun only pays for new or changed items. "monday done|ignore <id>" hides an
+  item permanently; "monday restore <id>" brings it back.
 
 OUTPUT
   JSON array on stdout; progress, plan summary, and warnings on stderr.
-  Sorted by the chosen --sort mode. Rated items carry an "actionable" flag;
+  Sorted by the chosen --sort mode. Rated items carry a "category"
+  (fyi/confirm/review/respond/act) and derived "actionable" flag;
   when a plan is active each item carries a "bucket" field
   ("now" | "later" | "fyi") so a presenter can show a doable slice first,
   hold the rest, and keep informational items in a separate awareness list.
@@ -160,6 +207,11 @@ const rateEffort     = !!flags['rate-effort'];              // estimate effort_m
 const sortArg  = typeof flags.sort === 'string' ? flags.sort.toLowerCase() : null; // null = auto
 const focusArg  = typeof flags.focus  === 'string' ? flags.focus  : null; // top-N "now" cap
 const budgetArg = typeof flags.budget === 'string' ? flags.budget : null; // time box, e.g. "90m"
+
+// State flags
+const noCache = !!flags['no-cache'];               // bypass the rating cache for this run
+const includeIgnored = !!flags['include-ignored']; // show items on the done/ignore list anyway
+const trustSignals = flags['no-trust-signals'] ? false : true; // deterministic actionable override
 
 const hasRating = !!(rateImportance || rateUrgency || rateSummary || rateEffort);
 
@@ -408,11 +460,73 @@ function buildRatingPrompt(item) {
   return parts.join('\n');
 }
 
+// ─── Rating cache & deterministic signal guard ───────────────────────────────
+
+// Any rating parameter or model change must invalidate cached ratings.
+const ratingSignature = [rateImportance, rateUrgency, rateSummary, rateEffort ? 'E' : '', rateContext || '']
+  .map((x) => (x == null ? '' : String(x)))
+  .join('|');
+function cacheKeyFor(item) {
+  return hashKey(
+    [item.id, item.title, item.subtitle, item.body, item.ts, ratingSignature]
+      .map((x) => (x == null ? '' : String(x)))
+      .join('\u0001')
+  );
+}
+// Loaded once, mutated during rating, flushed after. --no-cache starts empty.
+const ratingCache = noCache ? {} : readJson(CACHE_FILE, {});
+let cacheHits = 0;
+function flushCache() {
+  if (noCache) return;
+  try { writeJson(CACHE_FILE, ratingCache); } catch (e) {
+    console.error(`[monday] WARNING: could not write rating cache: ${e.message}`);
+  }
+}
+
 /**
- * Rate a single item by spawning an agent.
- * Returns the item with importance/urgency/summary merged in.
+ * Deterministic actionable override. Trust explicit relationship signals from the
+ * source over the rater: if you were asked to review/act on something not closed,
+ * or you authored an item still open, it is a to-do — never silently FYI. This
+ * closes the gap where a rater buries your own open PR in the FYI pile. Disable
+ * with --no-trust-signals.
+ */
+function applySignalGuard(rated) {
+  if (!trustSignals) return rated;
+  const m = rated.meta || {};
+  const closed = m.state === 'closed' || m.state === 'merged' || m.merged === true;
+  const asked = ['review_requested', 'mention', 'assign', 'assigned'].includes(m.relationship);
+  const mineOpen = m.authored_by_you === true && m.state === 'open';
+  if (!closed && rated.category === 'fyi' && (asked || mineOpen)) {
+    rated.category = 'review';
+    rated.actionable = true;
+    rated.reclassified_by_signal = true;
+  }
+  return rated;
+}
+
+/**
+ * Rate a single item by spawning an agent (or reusing a cached rating).
+ * Returns the item with importance/urgency/summary/category (+ effort) merged in.
  */
 async function rateItem(item) {
+  const key = cacheKeyFor(item);
+  if (!noCache && ratingCache[key]) {
+    cacheHits++;
+    const c = ratingCache[key];
+    const rated = {
+      ...item,
+      importance: c.importance ?? 5,
+      urgency: c.urgency ?? 5,
+      summary: c.summary ?? '',
+      category: c.category ?? 'act',
+      actionable: (c.category ?? 'act') !== 'fyi',
+    };
+    if (rateEffort) {
+      rated.effort_minutes = c.effort_minutes ?? null;
+      rated.effort_band = effortBand(rated.effort_minutes);
+    }
+    return applySignalGuard(rated);
+  }
   const prompt = buildRatingPrompt(item);
 
   // Build the agent command
@@ -472,7 +586,16 @@ async function rateItem(item) {
     const cat = typeof rating.category === 'string' ? rating.category.toLowerCase().trim() : '';
     rated.category = CATEGORIES.includes(cat) ? cat : 'act'; // default to a to-do, not FYI
     rated.actionable = rated.category !== 'fyi';
-    return rated;
+    // Cache the rater's raw output (the signal guard is applied on read, not stored).
+    ratingCache[cacheKeyFor(item)] = {
+      importance: rated.importance,
+      urgency: rated.urgency,
+      summary: rated.summary,
+      category: rated.category,
+      effort_minutes: rated.effort_minutes ?? null,
+      at: new Date().toISOString(),
+    };
+    return applySignalGuard(rated);
   } catch (e) {
     console.error(`[monday] WARNING: failed to parse rating for ${item.id}: ${e.message}`);
     console.error(`  output: ${raw.slice(0, 300)}`);
@@ -650,7 +773,68 @@ function buildPlan(items) {
 
 // ─── Main ────────────────────────────────────────────────────────────────────
 
+// ─── Done / ignore list management ────────────────────────────────────────────
+// A permanent, personal suppression list: items you mark `done` or `ignore` stay
+// out of every future run until you `restore` them. Keyed by the stable item id.
+const MGMT_COMMANDS = new Set([
+  'done', 'ignore', 'unignore', 'restore', 'ignored', 'list-ignored', 'cache-clear', 'forget-cache',
+]);
+
+function loadSuppress() {
+  const s = readJson(SUPPRESS_FILE, { items: {} });
+  if (!s.items) s.items = {};
+  return s;
+}
+
+async function handleManagement(action, ids) {
+  if (action === 'ignored' || action === 'list-ignored') {
+    const store = loadSuppress();
+    const list = Object.entries(store.items).map(([id, v]) => ({ id, ...v }));
+    console.error(`[monday] ${list.length} item(s) on your done/ignore list (${SUPPRESS_FILE})`);
+    console.log(JSON.stringify(list, null, 2));
+    return;
+  }
+  if (action === 'cache-clear' || action === 'forget-cache') {
+    try { writeJson(CACHE_FILE, {}); console.error('[monday] rating cache cleared.'); }
+    catch (e) { console.error(`[monday] could not clear cache: ${e.message}`); }
+    return;
+  }
+  // done | ignore | unignore | restore
+  if (ids.length === 0) {
+    console.error(`[monday] usage: monday ${action} <id> [<id>...]   (ids come from monday output or the dip's Done/Later buttons)`);
+    process.exit(2);
+  }
+  const store = loadSuppress();
+  const remove = action === 'unignore' || action === 'restore';
+  let n = 0;
+  for (const id of ids) {
+    if (remove) {
+      if (store.items[id]) { delete store.items[id]; n++; }
+    } else {
+      store.items[id] = {
+        action: action === 'done' ? 'done' : 'ignore',
+        at: new Date().toISOString(),
+        ...(typeof flags.title === 'string' ? { title: flags.title } : {}),
+      };
+      n++;
+    }
+  }
+  writeJson(SUPPRESS_FILE, store);
+  console.error(
+    remove
+      ? `[monday] restored ${n} item(s); they can resurface in future runs.`
+      : `[monday] ${action === 'done' ? 'marked done' : 'ignoring'} ${n} item(s); they won't appear in future runs (monday restore <id> to undo).`
+  );
+}
+
 async function main() {
+  // Management subcommands (done/ignore/restore/ignored/cache-clear) short-circuit
+  // the aggregation pipeline entirely.
+  if (subcommands.length && MGMT_COMMANDS.has(subcommands[0])) {
+    await handleManagement(subcommands[0], subcommands.slice(1));
+    return;
+  }
+
   // 1. Determine which sub-commands to run
   let commands = subcommands;
 
@@ -681,6 +865,20 @@ async function main() {
   // 3. Merge and deduplicate
   let items = mergeItems(results);
   console.error(`[monday] merged ${items.length} items from ${commands.length} sources`);
+
+  // 3b. Drop items on the permanent done/ignore list (unless --include-ignored).
+  if (!includeIgnored) {
+    const suppress = loadSuppress();
+    const before = items.length;
+    items = items.filter((it) => !suppress.items[it.id]);
+    const hidden = before - items.length;
+    if (hidden) {
+      console.error(
+        `[monday] hid ${hidden} item(s) on your done/ignore list ` +
+        `(monday ignored to view · monday restore <id> to unhide · --include-ignored to override).`
+      );
+    }
+  }
 
   // 4. Rate if any --rate-* flags are present
   if (hasRating && items.length > 0) {
@@ -719,6 +917,10 @@ async function main() {
     } else {
       items = await rateAllItems(items);
     }
+    if (cacheHits) {
+      console.error(`[monday] rating cache: reused ${cacheHits} cached rating(s); the rest were freshly rated (--no-cache to disable, monday cache-clear to reset).`);
+    }
+    flushCache();
   }
 
   // 5. Sort. Default to ROI (bang-for-buck — impact per minute) whenever effort
@@ -731,7 +933,8 @@ async function main() {
   }
   if (mode === 'roi' && !rateEffort) {
     console.error(
-      '[monday] --sort roi needs --rate-effort; falling back to --sort value. ' +      'Add --rate-effort to rank by impact-per-minute.'
+      '[monday] --sort roi needs --rate-effort; falling back to --sort value. ' +
+      'Add --rate-effort to rank by impact-per-minute.'
     );
     mode = 'value';
   }
@@ -751,7 +954,7 @@ async function main() {
     if (plan.fyiCount) tail.push(`${plan.fyiCount} FYI`);
     console.error(
       `[monday] plan: ${bits.join(', ')}` +
-      (tail.length ? ` � ${tail.join(' � ')}` : '') +
+      (tail.length ? ` � ${tail.join(' � ')}` : '') +
       `. Start with the "now" bucket; "later" stays ranked and "FYI" is just for awareness.`
     );
   } else if (hasRating && items.length > 12) {

--- a/skills/monday/scripts/monday.jsh
+++ b/skills/monday/scripts/monday.jsh
@@ -6,7 +6,7 @@
 // Examples:
 //   monday gh slack --limit 20 --date 3d
 //   monday --rate-importance 9-4 --rate-urgency 8-3 --rate-summary 500
-//   monday gh --limit 10 --rate-importance 8-3 --rate-model claude-haiku-4-5
+//   monday gh --limit 10 --rate-importance 8-3 --rate-model haiku
 //
 // With no positional args, auto-discovers monday-compatible commands on PATH.
 
@@ -91,7 +91,9 @@ RATING (each rated item costs one model call — start small)
   --rate-importance HI-LO   Rate importance, e.g. 9-1
   --rate-urgency HI-LO      Rate urgency, e.g. 8-1
   --rate-summary N          ~N-character summary per item
-  --rate-model NAME         Model for rating (default claude-haiku-4-5)
+  --rate-model NAME         Model for rating. Accepts an exact id from \`models\`
+                            or a unique substring (e.g. "haiku"). Validated
+                            before any call; defaults to the cheapest model.
   --rate-context PATH       Read-only knowledge base the rater may grep
   --rate-concurrency N      Parallel rating agents (default 4)
   --rate-max N              Refuse to rate more than N items (default 60)
@@ -117,7 +119,16 @@ const date  = flags['date']  || '7d';
 const rateImportance = flags['rate-importance'] || null;   // e.g. "8-3"
 const rateUrgency    = flags['rate-urgency']    || null;   // e.g. "9-2"
 const rateSummary    = flags['rate-summary']     || null;   // e.g. "1000"
-const rateModel      = flags['rate-model']       || 'claude-haiku-4-5';
+// Rating model. Resolved against `models --json` in main() before any agent
+// spawns — see resolveRateModel(). We deliberately do NOT hardcode a default
+// model id here: exact ids carry a version+date suffix that drifts, and the
+// bare alias `claude-haiku-4-5` is a trap (it passes `agent`'s validation but
+// the spawned scoop silently falls back to the parent model, e.g. opus at ~5x
+// the cost — see ai-ecoverse/slicc#1752). Instead we look up the live model
+// list and resolve the user's request (or auto-pick the cheapest model) to an
+// exact `models` id, which is proven to carry through to the scoop.
+const rateModelArg   = flags['rate-model']       || null;   // user request (may be a substring)
+let   rateModel      = rateModelArg;                          // resolved to an exact id in main()
 const rateContext    = flags['rate-context']      || null;  // e.g. "/workspace/kb"
 const rateConcurrency = flags['rate-concurrency'] || '4';   // parallel rating agents
 const rateMax        = flags['rate-max']          || '60';  // hard ceiling on rated items
@@ -221,6 +232,85 @@ function mergeItems(arrays) {
 }
 
 // ─── Rating via Agent ────────────────────────────────────────────────────────
+
+/**
+ * Fetch the live model catalog via `models --json`.
+ * Returns an array of { id, cost: { input, output, ... }, reasoning, ... }.
+ * Throws with a clear message if the command is unavailable or unparsable.
+ */
+async function getModels() {
+  const r = await exec('models --json 2>/dev/null');
+  if (r.exitCode !== 0 || !r.stdout.trim()) {
+    throw new Error(
+      "could not read the model catalog via `models --json`. Is the `models` command available?"
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(r.stdout);
+  } catch {
+    throw new Error('`models --json` did not return valid JSON.');
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error('`models --json` returned no models.');
+  }
+  return parsed;
+}
+
+/**
+ * Resolve a requested rating model to an EXACT `models` id.
+ *
+ * Why resolve here instead of trusting `agent --model`? Because `agent` accepts
+ * some aliases that it then fails to apply — notably the bare `claude-haiku-4-5`
+ * validates fine but silently spawns the parent model (opus) at ~5x the cost
+ * (ai-ecoverse/slicc#1752). Exact ids from `models` are proven to carry through,
+ * so we always hand `agent` an exact id and never rely on alias resolution.
+ *
+ * @param {string|null} requested  user's --rate-model value, or null to auto-pick.
+ * @returns {Promise<string>} an exact model id from the catalog.
+ */
+async function resolveRateModel(requested) {
+  const catalog = await getModels();
+  const ids = catalog.map((m) => m.id);
+  const costOf = (m) => (m.cost?.input || 0) + (m.cost?.output || 0);
+
+  if (requested) {
+    // 1. Exact id match — the ideal case.
+    if (ids.includes(requested)) return requested;
+    // 2. Unique case-insensitive substring match (lets the user pass a short,
+    //    memorable fragment like "haiku" or "claude-haiku-4-5").
+    const needle = requested.toLowerCase();
+    const matches = ids.filter((id) => id.toLowerCase().includes(needle));
+    if (matches.length === 1) {
+      console.error(`[monday] --rate-model "${requested}" resolved to ${matches[0]}`);
+      return matches[0];
+    }
+    if (matches.length > 1) {
+      throw new Error(
+        `--rate-model "${requested}" is ambiguous, matches ${matches.length} models:\n  ` +
+        matches.join('\n  ') +
+        '\nSpecify a more exact id (see `models`).'
+      );
+    }
+    // 3. No match — fail fast rather than silently falling back to an expensive model.
+    throw new Error(
+      `--rate-model "${requested}" is not a known model. Available ids (see \`models\`):\n  ` +
+      ids.join('\n  ')
+    );
+  }
+
+  // Auto-pick: cheapest model, preferring a haiku-class model when present
+  // (fast + cheap is the right default for bulk triage rating).
+  const byCost = [...catalog].sort((a, b) => costOf(a) - costOf(b));
+  const haiku = byCost.filter((m) => m.id.toLowerCase().includes('haiku'));
+  const pick = (haiku.length ? haiku : byCost)[0];
+  console.error(
+    `[monday] no --rate-model given; auto-selected cheapest ${haiku.length ? 'haiku-class ' : ''}` +
+    `model: ${pick.id} (${pick.cost?.input}/${pick.cost?.output} per MTok)`
+  );
+  return pick.id;
+}
+
 
 /**
  * Build the agent prompt for rating a single item.
@@ -423,6 +513,16 @@ async function main() {
 
   // 4. Rate if any --rate-* flags are present
   if (hasRating && items.length > 0) {
+    // Resolve the rating model to an exact `models` id up front. This both
+    // validates the user's --rate-model (fail fast on a typo instead of paying
+    // for a wrong model) and sidesteps the alias-fallback trap in `agent`
+    // (ai-ecoverse/slicc#1752).
+    try {
+      rateModel = await resolveRateModel(rateModelArg);
+    } catch (e) {
+      console.error(`[monday] ${e.message}`);
+      process.exit(1);
+    }
     // Guard rail: rating is one model call per item, so an unexpectedly large merge
     // is expensive and slow. Rate the newest N and pass the rest through unrated
     // rather than silently launching hundreds of calls.

--- a/skills/monday/scripts/monday.jsh
+++ b/skills/monday/scripts/monday.jsh
@@ -414,7 +414,16 @@ function buildRatingPrompt(item) {
 
   parts.push('## Instructions');
   parts.push('Rate this item based on its content, participants, recency, and context.');
-  parts.push('If the item has a `meta` block, use it: `meta.viewer` is the reader\'s own username, so `meta.authored_by_you: true` means the reader opened this and is likely waiting on others or on a merge; `meta.relationship` (e.g. review_requested, assignee, mention, author) tells you what is expected of the reader. Weight items where the reader is personally on the hook (their review is requested, it is assigned to them, they are directly mentioned, or they authored it and it is now ready) higher than things they are merely subscribed to. If `meta.merged` is true or `meta.state` is "closed", the item is already done — category MUST be `fyi`. If `meta.awaiting_checks` is true (a PR whose CI is still pending or failing) or `meta.draft` is true, it is not ready to merge/act on yet — keep its urgency low, since acting now would be premature.');
+  // Source-specific guidance travels with the item via `rating_hint` (see the
+  // monday protocol): each tool explains how to read its own fields, so this
+  // aggregator stays generic. Generic fallback covers sources that omit it.
+  if (typeof item.rating_hint === 'string' && item.rating_hint.trim()) {
+    parts.push('');
+    parts.push('### Source guidance');
+    parts.push(item.rating_hint.trim());
+  } else if (item.meta) {
+    parts.push('If the item has a `meta` block, use whatever it carries (relationship to the reader, state, etc.) to judge how much the reader is personally on the hook, and whether the item is already resolved (then it is `fyi`) or not yet ready to act on (keep urgency low).');
+  }
   parts.push('');
 
   if (rateImportance) {
@@ -470,7 +479,7 @@ function cacheKeyFor(item) {
   // Keyed on the item's content AND the rating params AND the resolved model
   // (rateModel is set before any rateItem call) — change any of them, re-rate.
   return hashKey(
-    [item.id, item.title, item.subtitle, item.body, item.ts, ratingSignature, rateModel]
+    [item.id, item.title, item.subtitle, item.body, item.ts, item.rating_hint, ratingSignature, rateModel]
       .map((x) => (x == null ? '' : String(x)))
       .join('\u0001')
   );

--- a/skills/monday/scripts/monday.jsh
+++ b/skills/monday/scripts/monday.jsh
@@ -456,6 +456,7 @@ function buildRatingPrompt(item) {
   parts.push('  - `review` — the reader must read/examine something before deciding: review a PR\'s code, read a doc or proposal.');
   parts.push('  - `respond` — the reader owes a written reply: answer a question, reply to a comment or message, weigh in on a discussion.');
   parts.push('  - `act` — the reader has real work to do: implement a fix, make a change, complete a task.');
+  parts.push('  - `waiting` — the reader has done their part and is now waiting on other people (their PR awaiting review/merge, a question they asked awaiting a reply). Something to chase or track, not to build.');
   parts.push('  Choose exactly one. If it is already done or closed, it is `fyi`.');
 
   parts.push('');
@@ -501,28 +502,37 @@ function flushCache() {
  * closes the gap where a rater buries your own open PR in the FYI pile. Disable
  * with --no-trust-signals.
  */
+/**
+ * Deterministic disposition guard. Reads ONLY the protocol-standard normalized
+ * flags a source may set — so the aggregator stays source-agnostic:
+ *   meta.resolved          → done; force `fyi`.
+ *   meta.awaiting_you      → your action is requested; keep it a to-do.
+ *   meta.waiting_on_others → you're chasing a follow-up; category `waiting`.
+ * (meta.not_ready is consumed by the planner, not here.) Disable with
+ * --no-trust-signals. A source that sets none of these is unaffected.
+ */
 function applySignalGuard(rated) {
   if (!trustSignals) return rated;
   const m = rated.meta || {};
-  const closed = m.state === 'closed' || m.state === 'merged' || m.merged === true;
-  // Downgrade: an already merged/closed item is done — never a to-do, whatever
-  // the rater guessed from stale notification text.
-  if (closed) {
+  if (m.resolved === true) {
     if (rated.category !== 'fyi') {
       rated.category = 'fyi';
       rated.actionable = false;
-      rated.reclassified_by_signal = 'closed';
+      rated.reclassified_by_signal = 'resolved';
     }
     return rated;
   }
-  // Upgrade: you were asked to review/act, or authored an open item — keep it a
-  // to-do even if the rater guessed FYI.
-  const asked = ['review_requested', 'mention', 'assign', 'assigned'].includes(m.relationship);
-  const mineOpen = m.authored_by_you === true && m.state === 'open';
-  if (rated.category === 'fyi' && (asked || mineOpen)) {
+  if (m.awaiting_you === true && rated.category === 'fyi') {
     rated.category = 'review';
     rated.actionable = true;
-    rated.reclassified_by_signal = 'relationship';
+    rated.reclassified_by_signal = 'awaiting_you';
+    return rated;
+  }
+  if (m.waiting_on_others === true && rated.category !== 'waiting') {
+    // You've done your part — this is a follow-up to chase, not work to do.
+    rated.category = 'waiting';
+    rated.actionable = false;
+    rated.reclassified_by_signal = 'waiting_on_others';
   }
   return rated;
 }
@@ -542,7 +552,7 @@ async function rateItem(item) {
       urgency: c.urgency ?? 5,
       summary: c.summary ?? '',
       category: c.category ?? 'act',
-      actionable: (c.category ?? 'act') !== 'fyi',
+      actionable: !['fyi', 'waiting'].includes(c.category ?? 'act'),
     };
     if (rateEffort) {
       rated.effort_minutes = c.effort_minutes ?? null;
@@ -605,10 +615,10 @@ async function rateItem(item) {
     }
     // Category is the reader's expected posture (fyi/confirm/review/respond/act).
     // `actionable` is derived from it for backward-compatible consumers.
-    const CATEGORIES = ['fyi', 'confirm', 'review', 'respond', 'act'];
+    const CATEGORIES = ['fyi', 'confirm', 'review', 'respond', 'act', 'waiting'];
     const cat = typeof rating.category === 'string' ? rating.category.toLowerCase().trim() : '';
     rated.category = CATEGORIES.includes(cat) ? cat : 'act'; // default to a to-do, not FYI
-    rated.actionable = rated.category !== 'fyi';
+    rated.actionable = !['fyi', 'waiting'].includes(rated.category);
     // Cache the rater's raw output (the signal guard is applied on read, not stored).
     ratingCache[cacheKeyFor(item)] = {
       importance: rated.importance,
@@ -736,10 +746,11 @@ function sortItems(items, rated, mode = 'value') {
  *
  * `items` must already be sorted by the chosen mode (ROI by default when effort
  * is present — best bang-for-buck first). Returns the list re-ordered
- * now → later → fyi, each tagged with a `bucket` field, plus plan counts. When
- * no plan flag is set AND every item is actionable, planning is a no-op and no
- * `bucket` is added (output stays backward-compatible); FYI splitting alone,
- * however, still tags buckets so a presenter can separate the two lists.
+ * now → later → followup → fyi, each tagged with a `bucket` field, plus plan
+ * counts. `followup` holds `waiting` items (you're chasing others — nothing to
+ * build). When no plan flag is set AND everything is a plain to-do, planning is
+ * a no-op (output stays backward-compatible); any FYI or waiting items, however,
+ * still get bucketed so a presenter can separate the lists.
  */
 function buildPlan(items) {
   const budgetMin = parseDuration(budgetArg);
@@ -747,25 +758,26 @@ function buildPlan(items) {
   const focusValid = Number.isFinite(focusN) && focusN >= 0 ? focusN : null;
   const sliceRequested = budgetMin != null || focusValid != null;
 
-  const todo = items.filter((it) => it.actionable !== false);
-  const fyi = items.filter((it) => it.actionable === false);
+  const waiting = items.filter((it) => it.category === 'waiting');
+  const fyi = items.filter((it) => it.actionable === false && it.category !== 'waiting');
+  const todo = items.filter((it) => it.actionable !== false && it.category !== 'waiting');
 
   // Nothing to plan and nothing to separate → leave output untouched.
-  if (!sliceRequested && fyi.length === 0) {
+  if (!sliceRequested && fyi.length === 0 && waiting.length === 0) {
     return { items, planning: false };
   }
 
   let usedMin = 0;
   let nowCount = 0;
-  // A PR that is a draft or still red/pending on CI isn't ready to act on — hold
-  // it for "later" rather than the top of the list, even if it ranks high.
-  const notReadyNow = (it) =>
-    it.type === 'pr' && it.meta && (it.meta.draft === true || it.meta.awaiting_checks === true);
+  // An item flagged not_ready by its source (a draft or CI-pending PR) isn't
+  // ready to act on — hold it for "later" rather than the top, even if it ranks
+  // high. Reads the normalized protocol flag, not any source's raw fields.
+  const notReadyNow = (it) => it.meta && it.meta.not_ready === true;
   const taggedTodo = todo.map((it) => {
     let inNow = true;
     if (sliceRequested) {
       if (notReadyNow(it)) {
-        inNow = false; // waiting on checks / draft → not top of the list
+        inNow = false; // not ready (draft / CI pending) → not top of the list
       } else if (budgetMin != null) {
         const cost = it.effort_minutes != null ? Math.max(1, it.effort_minutes) : EFFORT_UNKNOWN_MIN;
         const fitsTime = usedMin + cost <= budgetMin;
@@ -776,16 +788,18 @@ function buildPlan(items) {
         inNow = nowCount < focusValid;
       }
     }
-    // With no slice flag, every to-do is "now" (but still split from FYI).
+    // With no slice flag, every to-do is "now" (but still split from FYI/waiting).
     if (inNow) nowCount++;
     return { ...it, bucket: inNow ? 'now' : 'later' };
   });
+  const taggedWaiting = waiting.map((it) => ({ ...it, bucket: 'followup' }));
   const taggedFyi = fyi.map((it) => ({ ...it, bucket: 'fyi' }));
 
   return {
     items: [
       ...taggedTodo.filter((it) => it.bucket === 'now'),
       ...taggedTodo.filter((it) => it.bucket === 'later'),
+      ...taggedWaiting,
       ...taggedFyi,
     ],
     planning: true,
@@ -793,6 +807,7 @@ function buildPlan(items) {
     nowCount,
     nowMinutes: usedMin,
     laterCount: taggedTodo.length - nowCount,
+    followupCount: taggedWaiting.length,
     fyiCount: taggedFyi.length,
     budgetMin,
     focusN: focusValid,
@@ -981,10 +996,11 @@ async function main() {
     if (plan.focusN != null) bits.push(`focus ${plan.focusN}`);
     const tail = [];
     if (plan.laterCount) tail.push(`${plan.laterCount} later`);
+    if (plan.followupCount) tail.push(`${plan.followupCount} waiting on others`);
     if (plan.fyiCount) tail.push(`${plan.fyiCount} FYI`);
     console.error(
       `[monday] plan: ${bits.join(', ')}` +
-      (tail.length ? ` � ${tail.join(' � ')}` : '') +
+      (tail.length ? ` | ${tail.join(' | ')}` : '') +
       `. Start with the "now" bucket; "later" stays ranked and "FYI" is just for awareness.`
     );
   } else if (hasRating && items.length > 12) {

--- a/skills/monday/scripts/monday.jsh
+++ b/skills/monday/scripts/monday.jsh
@@ -108,9 +108,9 @@ if (flags.help || flags.h) {
 
 USAGE
   monday [source...] [flags]
-  monday done|ignore <id>...        # never show these items again
-  monday restore <id>...            # undo a done/ignore
-  monday ignored                    # list the done/ignore list
+  monday done|ignore|mute <id>...   # never show these items again
+  monday restore <id>...            # undo a done/ignore/mute
+  monday ignored                    # list what's silenced
   monday cache-clear                # wipe the rating cache
 
   With no sources, auto-discovers monday-compatible commands on PATH.
@@ -467,8 +467,10 @@ const ratingSignature = [rateImportance, rateUrgency, rateSummary, rateEffort ? 
   .map((x) => (x == null ? '' : String(x)))
   .join('|');
 function cacheKeyFor(item) {
+  // Keyed on the item's content AND the rating params AND the resolved model
+  // (rateModel is set before any rateItem call) — change any of them, re-rate.
   return hashKey(
-    [item.id, item.title, item.subtitle, item.body, item.ts, ratingSignature]
+    [item.id, item.title, item.subtitle, item.body, item.ts, ratingSignature, rateModel]
       .map((x) => (x == null ? '' : String(x)))
       .join('\u0001')
   );
@@ -777,7 +779,7 @@ function buildPlan(items) {
 // A permanent, personal suppression list: items you mark `done` or `ignore` stay
 // out of every future run until you `restore` them. Keyed by the stable item id.
 const MGMT_COMMANDS = new Set([
-  'done', 'ignore', 'unignore', 'restore', 'ignored', 'list-ignored', 'cache-clear', 'forget-cache',
+  'done', 'ignore', 'mute', 'unignore', 'unmute', 'restore', 'ignored', 'list-ignored', 'muted', 'cache-clear', 'forget-cache',
 ]);
 
 function loadSuppress() {
@@ -787,10 +789,10 @@ function loadSuppress() {
 }
 
 async function handleManagement(action, ids) {
-  if (action === 'ignored' || action === 'list-ignored') {
+  if (action === 'ignored' || action === 'list-ignored' || action === 'muted') {
     const store = loadSuppress();
     const list = Object.entries(store.items).map(([id, v]) => ({ id, ...v }));
-    console.error(`[monday] ${list.length} item(s) on your done/ignore list (${SUPPRESS_FILE})`);
+    console.error(`[monday] ${list.length} item(s) silenced (done/ignore/mute) — ${SUPPRESS_FILE}`);
     console.log(JSON.stringify(list, null, 2));
     return;
   }
@@ -799,20 +801,21 @@ async function handleManagement(action, ids) {
     catch (e) { console.error(`[monday] could not clear cache: ${e.message}`); }
     return;
   }
-  // done | ignore | unignore | restore
+  // done | ignore | mute | unignore | unmute | restore
   if (ids.length === 0) {
-    console.error(`[monday] usage: monday ${action} <id> [<id>...]   (ids come from monday output or the dip's Done/Later buttons)`);
+    console.error(`[monday] usage: monday ${action} <id> [<id>...]   (ids come from monday output or the dip's buttons)`);
     process.exit(2);
   }
   const store = loadSuppress();
-  const remove = action === 'unignore' || action === 'restore';
+  const remove = action === 'unignore' || action === 'unmute' || action === 'restore';
+  const label = action === 'done' ? 'done' : action === 'mute' ? 'mute' : 'ignore';
   let n = 0;
   for (const id of ids) {
     if (remove) {
       if (store.items[id]) { delete store.items[id]; n++; }
     } else {
       store.items[id] = {
-        action: action === 'done' ? 'done' : 'ignore',
+        action: label,
         at: new Date().toISOString(),
         ...(typeof flags.title === 'string' ? { title: flags.title } : {}),
       };
@@ -822,8 +825,8 @@ async function handleManagement(action, ids) {
   writeJson(SUPPRESS_FILE, store);
   console.error(
     remove
-      ? `[monday] restored ${n} item(s); they can resurface in future runs.`
-      : `[monday] ${action === 'done' ? 'marked done' : 'ignoring'} ${n} item(s); they won't appear in future runs (monday restore <id> to undo).`
+      ? `[monday] un-silenced ${n} item(s); they can resurface in future runs.`
+      : `[monday] ${label === 'done' ? 'marked done' : label === 'mute' ? 'muted' : 'ignoring'} ${n} item(s); they won't appear in future runs (monday restore <id> to undo).`
   );
 }
 

--- a/skills/monday/scripts/monday.jsh
+++ b/skills/monday/scripts/monday.jsh
@@ -101,21 +101,26 @@ RATING (each rated item costs one model call — start small)
   --rate-max N              Refuse to rate more than N items (default 60)
 
 RANKING & BACKPRESSURE (turn a wall of items into a plan of attack)
-  --sort MODE               value (default: importance x urgency), roi
-                            (impact per minute — quick wins first; needs
-                            --rate-effort), or newest (timestamp)
-  --focus N                 Mark only the top N items as the "now" bucket;
-                            everything else becomes "later". A doable slice
-                            instead of the full backlog.
-  --budget DURATION         Pack the highest-ranked items that fit a time box
+  --sort MODE               roi (impact per minute — best bang-for-buck first;
+                            the default when --rate-effort is on), value
+                            (importance x urgency), or newest (timestamp)
+  --focus N                 Promote only the top N to-dos to the "now" bucket;
+                            the rest become "later". A doable slice, not the
+                            whole backlog.
+  --budget DURATION         Pack the highest-ranked to-dos that fit a time box
                             into "now" (e.g. 90m, 2h, 1h30m); needs
                             --rate-effort. The rest become "later".
 
+  Every rated item is also tagged actionable vs not: informational items
+  (merged PRs, closed issues, build/FYI notifications) go to a separate "fyi"
+  bucket — awareness only, never counted against your time budget.
+
 OUTPUT
   JSON array on stdout; progress, plan summary, and warnings on stderr.
-  Sorted by the chosen --sort mode. When --focus or --budget is set, each item
-  carries a "bucket" field ("now" | "later") so a presenter can show a doable
-  slice first and collapse the rest.
+  Sorted by the chosen --sort mode. Rated items carry an "actionable" flag;
+  when a plan is active each item carries a "bucket" field
+  ("now" | "later" | "fyi") so a presenter can show a doable slice first,
+  hold the rest, and keep informational items in a separate awareness list.
 
 EXAMPLES
   monday gh --limit 5 --date 1d
@@ -152,7 +157,7 @@ const rateMax        = flags['rate-max']          || '60';  // hard ceiling on r
 const rateEffort     = !!flags['rate-effort'];              // estimate effort_minutes per item
 
 // Ranking & backpressure flags (local only — shape the plan, not the data source)
-const sortMode = (typeof flags.sort === 'string' ? flags.sort : 'value').toLowerCase();
+const sortArg  = typeof flags.sort === 'string' ? flags.sort.toLowerCase() : null; // null = auto
 const focusArg  = typeof flags.focus  === 'string' ? flags.focus  : null; // top-N "now" cap
 const budgetArg = typeof flags.budget === 'string' ? flags.budget : null; // time box, e.g. "90m"
 
@@ -383,11 +388,14 @@ function buildRatingPrompt(item) {
     parts.push('- **effort_minutes**: your best integer estimate of how many minutes it would take a human to actually resolve or respond to this item (not to read it). A quick ack or approval might be 5; a substantive reply or small task 20-45; a deep review or real work 90+. Base it on the type, scope, and content — estimate concretely, do not default to a round number.');
   }
 
+  parts.push('- **actionable**: true if this item needs an action FROM the reader — a review, reply, decision, merge, or fix that is still pending. false if it is purely informational: an already-merged PR, a closed or resolved issue, a build/release notification, a CC/FYI mention, or anything reported only so the reader is aware. When in doubt about whether the reader still has to do something, prefer false for items that are already done or closed.');
+
   parts.push('');
   parts.push('## Output');
   parts.push('Return ONLY a valid JSON object on a single line, no markdown fences, no explanation:');
   const schemaFields = ['"importance": N', '"urgency": N', '"summary": "..."'];
   if (rateEffort) schemaFields.push('"effort_minutes": N');
+  schemaFields.push('"actionable": true|false');
   parts.push(`{${schemaFields.join(', ')}}`);
 
   return parts.join('\n');
@@ -451,6 +459,9 @@ async function rateItem(item) {
       rated.effort_minutes = Number.isFinite(em) && em > 0 ? Math.round(em) : null;
       rated.effort_band = effortBand(rated.effort_minutes);
     }
+    // Default to actionable when the rater omits it — safer to surface a to-do
+    // than to bury a real task in the FYI pile.
+    rated.actionable = rating.actionable === false ? false : true;
     return rated;
   } catch (e) {
     console.error(`[monday] WARNING: failed to parse rating for ${item.id}: ${e.message}`);
@@ -554,51 +565,73 @@ function sortItems(items, rated, mode = 'value') {
 }
 
 /**
- * Backpressure: split an already-sorted list into "now" and "later" buckets so a
- * human sees a doable slice first instead of the whole backlog. Humans have the
- * judgement; the tool's job is to protect their attention, not dump on it.
+ * Backpressure: turn a ranked list into a plan of attack. Two axes:
  *
- *   --focus N   : the top N items are "now".
- *   --budget T  : pack the top items whose cumulative effort fits T minutes into
- *                 "now" (items with no effort estimate assumed 30 min).
- *   both        : budget packs by time, but never exceeds the focus count.
+ *   1. TODO vs FYI — items the rater marked `actionable: false` (merged PRs,
+ *      closed issues, build notifications, CC mentions) are things to be *aware*
+ *      of, not act on. They go to the "fyi" bucket, never consume the time
+ *      budget, and are presented as a separate, glanceable list.
+ *   2. now vs later — among the actionable TODO items, a doable slice is
+ *      promoted to "now" and the rest held as "later":
+ *        --focus N   : the top N to-dos are "now".
+ *        --budget T  : pack the to-dos whose cumulative effort fits T minutes
+ *                      (items with no effort estimate assumed 30 min).
+ *        both        : budget packs by time, but never exceeds the focus count.
  *
- * Returns { items (each tagged with a `bucket` field), nowCount, nowMinutes,
- * laterCount, budgetMin }. When neither flag is set, planning is a no-op and
- * `bucket` is left off entirely (output stays backward-compatible).
+ * `items` must already be sorted by the chosen mode (ROI by default when effort
+ * is present — best bang-for-buck first). Returns the list re-ordered
+ * now → later → fyi, each tagged with a `bucket` field, plus plan counts. When
+ * no plan flag is set AND every item is actionable, planning is a no-op and no
+ * `bucket` is added (output stays backward-compatible); FYI splitting alone,
+ * however, still tags buckets so a presenter can separate the two lists.
  */
 function buildPlan(items) {
   const budgetMin = parseDuration(budgetArg);
   const focusN = focusArg != null ? parseInt(focusArg, 10) : null;
   const focusValid = Number.isFinite(focusN) && focusN >= 0 ? focusN : null;
-  const planning = budgetMin != null || focusValid != null;
-  if (!planning) {
+  const sliceRequested = budgetMin != null || focusValid != null;
+
+  const todo = items.filter((it) => it.actionable !== false);
+  const fyi = items.filter((it) => it.actionable === false);
+
+  // Nothing to plan and nothing to separate → leave output untouched.
+  if (!sliceRequested && fyi.length === 0) {
     return { items, planning: false };
   }
 
   let usedMin = 0;
   let nowCount = 0;
-  const tagged = items.map((it) => {
+  const taggedTodo = todo.map((it) => {
     let inNow = true;
-    if (budgetMin != null) {
-      const cost = it.effort_minutes != null ? Math.max(1, it.effort_minutes) : EFFORT_UNKNOWN_MIN;
-      const fitsTime = usedMin + cost <= budgetMin;
-      const fitsFocus = focusValid == null || nowCount < focusValid;
-      inNow = fitsTime && fitsFocus;
-      if (inNow) usedMin += cost;
-    } else {
-      inNow = nowCount < focusValid;
+    if (sliceRequested) {
+      if (budgetMin != null) {
+        const cost = it.effort_minutes != null ? Math.max(1, it.effort_minutes) : EFFORT_UNKNOWN_MIN;
+        const fitsTime = usedMin + cost <= budgetMin;
+        const fitsFocus = focusValid == null || nowCount < focusValid;
+        inNow = fitsTime && fitsFocus;
+        if (inNow) usedMin += cost;
+      } else {
+        inNow = nowCount < focusValid;
+      }
     }
+    // With no slice flag, every to-do is "now" (but still split from FYI).
     if (inNow) nowCount++;
     return { ...it, bucket: inNow ? 'now' : 'later' };
   });
+  const taggedFyi = fyi.map((it) => ({ ...it, bucket: 'fyi' }));
 
   return {
-    items: [...tagged.filter((it) => it.bucket === 'now'), ...tagged.filter((it) => it.bucket === 'later')],
+    items: [
+      ...taggedTodo.filter((it) => it.bucket === 'now'),
+      ...taggedTodo.filter((it) => it.bucket === 'later'),
+      ...taggedFyi,
+    ],
     planning: true,
+    sliceRequested,
     nowCount,
     nowMinutes: usedMin,
-    laterCount: tagged.length - nowCount,
+    laterCount: taggedTodo.length - nowCount,
+    fyiCount: taggedFyi.length,
     budgetMin,
     focusN: focusValid,
   };
@@ -678,32 +711,39 @@ async function main() {
     }
   }
 
-  // 5. Sort by the requested mode. ROI needs effort estimates; fall back with a
-  // warning rather than silently sorting on a bogus 30-min-for-everything ROI.
-  let mode = sortMode;
+  // 5. Sort. Default to ROI (bang-for-buck — impact per minute) whenever effort
+  // is available, else value; an explicit --sort always wins. ROI without effort
+  // can't be computed, so fall back with a warning rather than a bogus ranking.
+  let mode = sortArg;
+  if (mode && !['value', 'roi', 'newest'].includes(mode)) {
+    console.error(`[monday] unknown --sort "${sortArg}"; using ${rateEffort ? 'roi' : 'value'}.`);
+    mode = null;
+  }
   if (mode === 'roi' && !rateEffort) {
     console.error(
       '[monday] --sort roi needs --rate-effort; falling back to --sort value. ' +
       'Add --rate-effort to rank by impact-per-minute.'
     );
     mode = 'value';
-  } else if (!['value', 'roi', 'newest'].includes(mode)) {
-    console.error(`[monday] unknown --sort "${sortMode}"; using value.`);
-    mode = 'value';
   }
+  if (!mode) mode = rateEffort ? 'roi' : 'value'; // bang-for-buck by default when we can
   items = sortItems(items, hasRating, mode);
 
-  // 6. Backpressure: build a "now"/"later" plan when --focus or --budget is set.
+  // 6. Backpressure: split TODO vs FYI, and promote a doable "now" slice.
   const plan = buildPlan(items);
   items = plan.items;
   if (plan.planning) {
-    const bits = [`${plan.nowCount} now`];
-    if (rateEffort) bits[0] += ` (~${plan.nowMinutes}m)`;
+    const bits = [`${plan.nowCount} to-do now`];
+    if (rateEffort && plan.sliceRequested) bits[0] += ` (~${plan.nowMinutes}m)`;
     if (plan.budgetMin != null) bits.push(`budget ${plan.budgetMin}m`);
     if (plan.focusN != null) bits.push(`focus ${plan.focusN}`);
+    const tail = [];
+    if (plan.laterCount) tail.push(`${plan.laterCount} later`);
+    if (plan.fyiCount) tail.push(`${plan.fyiCount} FYI`);
     console.error(
-      `[monday] plan: ${bits.join(', ')} · ${plan.laterCount} later. ` +
-      `Start with the "now" bucket; the rest stay ranked for when you're ready.`
+      `[monday] plan: ${bits.join(', ')}` +
+      (tail.length ? ` · ${tail.join(' · ')}` : '') +
+      `. Start with the "now" bucket; "later" stays ranked and "FYI" is just for awareness.`
     );
   } else if (hasRating && items.length > 12) {
     // Soft nudge: a big ranked list is still a wall. Point at the tools that


### PR DESCRIPTION
Turns monday from "rank everything" into "here's a doable plan of attack." Validated live against real GitHub triage runs (rating on haiku, verified via `cost --json`).

## monday

- **Rate-model validation** — `--rate-model` resolved to an exact `models` id before any agent spawns; typo/ambiguous fails fast; omitted → cheapest haiku. Sidesteps the `agent --model` alias-fallback trap (ai-ecoverse/slicc#1752).
- **Category taxonomy** — the rater classifies each item as `fyi | confirm | review | respond | act` (what it asks of you); `actionable` is derived (`category !== 'fyi'`). Informational items (merged PRs, closed issues, notifications) become a separate `fyi` bucket — awareness only, never counted against your time budget.
- **Effort + ROI** — `--rate-effort` estimates `effort_minutes` + a `quick/short/deep` band. `--sort` defaults to `roi` (impact per minute — best bang-for-buck first) when effort is on; also `value` and `newest`.
- **Backpressure** — `--focus N` and `--budget 90m|2h|1h30m` promote a doable slice of to-dos to a `now` bucket and hold the rest as `later`; FYI stays out of the budget. Plan summary on stderr; big unplanned runs get nudged. Output stays backward-compatible (new fields only when opted in).
- **`monday-dip` renderer** — the canonical presentation template: reads a monday JSON plan and prints a `.sprinkle-action-card` dip (three lists: now / later / fyi). Lucide icons, no emoji, priority WORDS not raw scores, ROI order, Open/Done/Later + Start/Re-plan lick buttons.

## github

- **`gh monday` item enrichment** — notifications, PRs, and issues now carry `meta.authored_by_you`, `meta.relationship` (author / review_requested / assignee / …), and `meta.viewer`, so the classifier can use real relationship signals instead of guessing.

## Docs

SKILL.md gains Effort/ROI, Backpressure, and "render as a dip, not a wall" sections, the `monday-dip` recipe, the category/actionable/effort/bucket output shape, flags, and troubleshooting. `biome lint` clean.

Merge preference: merge commit or rebase (no squash).

## State & signals (added)

- **Rating cache** — every rating is cached under `$MONDAY_HOME`/`~/.monday`, keyed by item content + rating params + model; a rerun only pays for new/changed items (cold ~38s → warm ~9s in testing). `--no-cache` / `monday cache-clear`.
- **Done / ignore list** — `monday done|ignore <id>` hides an item from all future runs (filtered right after merge, so it costs nothing); `monday ignored` lists, `monday restore <id>` undoes. These are the same ids the dip Done/Later buttons emit.
- **Deterministic signal guard** — trusts source relationship metadata (`meta.authored_by_you`, `meta.relationship=review_requested/mention/assign`, `meta.state`) over the rater: an item you were asked to review, or authored and left open, stays actionable even if the rater guessed FYI; merged/closed items are never resurfaced. `--no-trust-signals` to disable. Verified live: a poisoned-to-FYI `review_requested` item is upgraded back to `review`, while authored-notification and state_change items correctly stay FYI.