### PR TITLE
Add metaculus forecasting skill

### DIFF
--- a/skills/metaculus/SKILL.md
+++ b/skills/metaculus/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: metaculus
+description: Interact with the Metaculus forecasting platform via its REST API — browse and search forecasting questions, read question detail and resolution criteria, submit or withdraw forecasts (binary, multiple-choice, and continuous), read and post comments, and list tournaments and their questions. Use when the user mentions Metaculus, forecasting questions, prediction questions, community predictions, forecasting tournaments (e.g. the AI Forecasting Benchmark / FutureEval bot tournaments), wants to make or update a forecast, check how a question is resolving, or query anything from metaculus.com without clicking through the site. Activate on "Metaculus", "forecast this question", "prediction market question", "community prediction", "forecasting tournament", "submit a forecast", "metaculus question".
+allowed-tools: bash
+---
+
+# Metaculus
+
+CLI access to the [Metaculus](https://www.metaculus.com) forecasting API:
+browse/search questions, read detail, submit and withdraw forecasts, comment,
+and list tournaments.
+
+## Setup / auth
+
+Get a personal API token from <https://www.metaculus.com/accounts/settings/>
+(API section), then store it once:
+
+```sh
+metaculus auth <token>        # saved to git-ignored skill config
+metaculus auth --show         # show masked stored token
+```
+
+Token resolution order: `--token <t>` flag | `METACULUS_TOKEN` env var | stored
+config. Almost every endpoint requires authentication.
+
+## Commands
+
+```sh
+metaculus me                                   # your account profile
+
+# Browse / search questions (posts)
+metaculus questions [--search q] [--status open|closed|resolved|upcoming] \
+                    [--type binary|multiple_choice|numeric|date|group] \
+                    [--tournament <id|slug>] [--order-by <field>] \
+                    [--limit n] [--offset n] [--json]
+
+# One question in detail (--cp adds the community prediction, when visible)
+metaculus question <post_id> [--cp] [--json]
+
+# Forecast (see "Forecasting" below — uses the QUESTION id, not the post id)
+metaculus forecast <question_id> <prob>            # binary, 0.001–0.999
+metaculus forecast <question_id> --data '<json>'   # MC / continuous
+metaculus withdraw <question_id>
+
+# Comments
+metaculus comments [--post <id>] [--author me|<id>] [--limit n] [--json]
+metaculus comment <post_id> <text> [--private] [--parent <comment_id>]
+
+# Tournaments / projects
+metaculus tournaments [--json]
+metaculus tournament <id|slug> [--json]
+
+# Raw API passthrough for anything not wrapped above
+metaculus api <METHOD> <path> [--data '<json>'] [--query k=v ...] [--json]
+```
+
+## Forecasting
+
+Questions live inside **posts**. A post has an id (the number in the page URL);
+its nested question has its **own** id. **You read by post id but forecast by
+question id.** `metaculus question <post_id>` prints both `post_id` and
+`question_id` — use `question_id` for `forecast`/`withdraw`.
+
+Value field by question type:
+
+| Type              | How to submit                                                              |
+|-------------------|----------------------------------------------------------------------------|
+| `binary`          | `metaculus forecast <qid> 0.65`                                            |
+| `multiple_choice` | `metaculus forecast <qid> --data '{"probability_yes_per_category":{"Yes":0.6,"No":0.4}}'` |
+| `numeric`/`date`  | `metaculus forecast <qid> --data '{"continuous_cdf":[…201 increasing values 0..1…]}'` |
+
+Constraints: binary probabilities clamp to **0.001–0.999**; continuous CDFs must
+be exactly **201** monotonically-increasing points (per-step increase ≤ 0.2).
+
+Forecasting is a real mutation against the user's Metaculus track record — get
+explicit confirmation before submitting, and prefer showing the user the value
+first.
+
+## Gotchas
+
+- **post id ≠ question id** (see above). Group/conditional posts have `question:
+  null` and expose sub-questions under `.group_of_questions[]` / `.conditional`.
+- **Community prediction is gated:** `--cp` / `?with_cp=true` returns `null`
+  centers until the calling account has itself forecast on that question.
+- **Restricted endpoints (HTTP 403):** unrestricted `/api/comments/` listing (scope
+  to `--author me`), and `/api/aggregation_explorer/`. Contact
+  support@metaculus.com for broader access.
+- The Swagger UI at `/api/` sits behind a Cloudflare JS challenge — open it in a
+  browser, not headless curl.
+
+## Reference
+
+`references/curl.md` — the underlying REST endpoints as raw `curl` commands
+(auth, question read/search, forecast/withdraw payload shapes, comments,
+tournaments) with the response fields to look for.

--- a/skills/metaculus/SKILL.md
+++ b/skills/metaculus/SKILL.md
@@ -38,9 +38,9 @@ metaculus questions [--search q] [--status open|closed|resolved|upcoming] \
 metaculus question <post_id> [--cp] [--json]
 
 # Forecast (see "Forecasting" below — uses the QUESTION id, not the post id)
-metaculus forecast <question_id> <prob>            # binary, 0.001–0.999
-metaculus forecast <question_id> --data '<json>'   # MC / continuous
-metaculus withdraw <question_id>
+metaculus forecast <question_id> <prob> --confirm            # binary, 0.001–0.999
+metaculus forecast <question_id> --data '<json>' --confirm   # MC / continuous
+metaculus withdraw <question_id> --confirm
 
 # Comments
 metaculus comments [--post <id>] [--author me|<id>] [--limit n] [--json]
@@ -65,16 +65,19 @@ Value field by question type:
 
 | Type              | How to submit                                                              |
 |-------------------|----------------------------------------------------------------------------|
-| `binary`          | `metaculus forecast <qid> 0.65`                                            |
-| `multiple_choice` | `metaculus forecast <qid> --data '{"probability_yes_per_category":{"Yes":0.6,"No":0.4}}'` |
-| `numeric`/`date`  | `metaculus forecast <qid> --data '{"continuous_cdf":[…201 increasing values 0..1…]}'` |
+| `binary`          | `metaculus forecast <qid> 0.65 --confirm`                                  |
+| `multiple_choice` | `metaculus forecast <qid> --data '{"probability_yes_per_category":{"Yes":0.6,"No":0.4}}' --confirm` |
+| `numeric`/`date`  | `metaculus forecast <qid> --data '{"continuous_cdf":[…201 increasing values 0..1…]}' --confirm` |
 
 Constraints: binary probabilities clamp to **0.001–0.999**; continuous CDFs must
 be exactly **201** monotonically-increasing points (per-step increase ≤ 0.2).
 
-Forecasting is a real mutation against the user's Metaculus track record — get
-explicit confirmation before submitting, and prefer showing the user the value
-first.
+`forecast` and `withdraw` are real mutations against the user's Metaculus track
+record, so they **require `--confirm`**. Without it, the command prints a preview
+of the exact payload and submits nothing — show the user that preview and get
+explicit approval before re-running with `--confirm`. A `--data` payload whose
+embedded `question` id contradicts the positional id is rejected (no silent
+forecast on the wrong question).
 
 ## Gotchas
 
@@ -87,6 +90,9 @@ first.
   support@metaculus.com for broader access.
 - The Swagger UI at `/api/` sits behind a Cloudflare JS challenge — open it in a
   browser, not headless curl.
+- **Credentials only go to metaculus.com:** the `api` passthrough refuses to
+  attach the token to an absolute URL on any non-`metaculus.com` host, so a stray
+  or malicious URL can't exfiltrate the token.
 
 ## Reference
 

--- a/skills/metaculus/references/curl.md
+++ b/skills/metaculus/references/curl.md
@@ -1,0 +1,139 @@
+# Metaculus API — curl reference
+
+Base URL: `https://www.metaculus.com/api`  (a legacy `/api2` alias also exists).
+Interactive docs (Swagger, Cloudflare-gated in headless clients): https://www.metaculus.com/api/
+
+## Authentication
+
+Every request needs a token. Create one at
+<https://www.metaculus.com/accounts/settings/> (API section) and pass it as an
+`Authorization: Token <token>` header. The bare API root and most endpoints
+reject anonymous access ("The API is only available to authenticated users").
+
+```sh
+TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+AUTH="-H Authorization: Token $TOKEN"
+
+# who am I
+curl -s "https://www.metaculus.com/api/users/me/" -H "Authorization: Token $TOKEN"
+```
+
+## Reading questions / posts
+
+Questions live inside **posts**. A post has an `id` (the number in the page URL)
+and, for a single question, a nested `question` object with its **own** `id`.
+**The post id and the question id are usually different** — you read by post id
+but you **forecast by question id** (`.question.id`).
+
+```sh
+# List posts (paginated: count/next/previous/results)
+curl -s "https://www.metaculus.com/api/posts/?limit=20" -H "Authorization: Token $TOKEN"
+
+# Useful query params:
+#   search=<text>            full-text search
+#   statuses=open|closed|resolved|upcoming|pending   (repeatable)
+#   forecast_type=binary|multiple_choice|numeric|date|group
+#   tournaments=<id>         filter to a tournament/project id
+#   order_by=-nr_forecasters|-published_at|-created_at|hotness|...   (prefix - = desc)
+#   limit / offset           pagination
+curl -s "https://www.metaculus.com/api/posts/?statuses=open&forecast_type=binary&order_by=-nr_forecasters&limit=5" \
+  -H "Authorization: Token $TOKEN"
+
+# Single post (includes .question with resolution criteria, fine print, scaling)
+curl -s "https://www.metaculus.com/api/posts/44798/" -H "Authorization: Token $TOKEN"
+
+# Include the community prediction / aggregations:
+#   NOTE: Metaculus hides the community prediction until the calling account has
+#   itself forecast on that question — expect null centers otherwise.
+curl -s "https://www.metaculus.com/api/posts/44798/?with_cp=true" -H "Authorization: Token $TOKEN"
+# Community prediction lives at:
+#   .question.aggregations.recency_weighted.latest.centers          (array)
+#   .question.aggregations.recency_weighted.latest.forecaster_count
+#   .question.aggregations.recency_weighted.latest.interval_lower_bounds / interval_upper_bounds
+```
+
+## Submitting a forecast
+
+`POST /api/questions/forecast/` with a **JSON array** of forecast objects (you can
+submit several at once). Each object keys on the **question id** (`.question.id`),
+NOT the post id. The value field depends on the question type:
+
+| Question type      | Value field                     | Shape / constraints                                   |
+|--------------------|---------------------------------|-------------------------------------------------------|
+| `binary`           | `probability_yes`               | number in **0.001 – 0.999**                            |
+| `multiple_choice`  | `probability_yes_per_category`  | object `{ "<option>": <prob>, ... }` summing to ~1     |
+| `numeric` / `date` | `continuous_cdf`                | array of **201** increasing values 0..1, step ≤ 0.2    |
+
+```sh
+# Binary
+curl -s -X POST "https://www.metaculus.com/api/questions/forecast/" \
+  -H "Authorization: Token $TOKEN" -H "Content-Type: application/json" \
+  -d '[{"question":44945,"probability_yes":0.65}]'
+
+# Multiple choice
+curl -s -X POST "https://www.metaculus.com/api/questions/forecast/" \
+  -H "Authorization: Token $TOKEN" -H "Content-Type: application/json" \
+  -d '[{"question":123,"probability_yes_per_category":{"Yes":0.6,"No":0.4}}]'
+
+# Continuous (numeric or date) — 201-point CDF
+curl -s -X POST "https://www.metaculus.com/api/questions/forecast/" \
+  -H "Authorization: Token $TOKEN" -H "Content-Type: application/json" \
+  -d '[{"question":123,"continuous_cdf":[/* 201 increasing values */]}]'
+```
+
+Validation errors come back as HTTP 400 with `non_field_errors`, e.g.
+`"probability_yes should be between 0.001 and 0.999"`.
+
+## Withdrawing a forecast
+
+`POST /api/questions/withdraw/` with an array of `{ "question": <question_id> }`.
+
+```sh
+curl -s -X POST "https://www.metaculus.com/api/questions/withdraw/" \
+  -H "Authorization: Token $TOKEN" -H "Content-Type: application/json" \
+  -d '[{"question":44945}]'
+```
+
+## Comments
+
+```sh
+# List comments — the list endpoint is restricted: you MUST scope it to your own
+# user id (author=<your id>) and/or author_is_staff=true, else HTTP 403.
+curl -s "https://www.metaculus.com/api/comments/?author=112033&limit=20" \
+  -H "Authorization: Token $TOKEN"
+curl -s "https://www.metaculus.com/api/comments/?post=44975&author=112033" \
+  -H "Authorization: Token $TOKEN"
+
+# Create a comment on a post
+curl -s -X POST "https://www.metaculus.com/api/comments/create/" \
+  -H "Authorization: Token $TOKEN" -H "Content-Type: application/json" \
+  -d '{"on_post":44975,"text":"My reasoning...","is_private":false}'
+# Optional: "parent_id":<comment_id> to reply in a thread.
+```
+
+## Tournaments / projects
+
+```sh
+# List tournaments (returns a plain array, not paginated)
+curl -s "https://www.metaculus.com/api/projects/tournaments/" -H "Authorization: Token $TOKEN"
+
+# One tournament, by numeric id or slug
+curl -s "https://www.metaculus.com/api/projects/tournaments/aibq4/" -H "Authorization: Token $TOKEN"
+
+# All questions in a tournament (via the posts filter)
+curl -s "https://www.metaculus.com/api/posts/?tournaments=32506&limit=50" -H "Authorization: Token $TOKEN"
+```
+
+## Notes & gotchas
+
+- **post id ≠ question id.** Read by post id (`/posts/<post_id>/`); forecast/withdraw
+  by `.question.id`. For group/conditional posts, `.question` is null and the
+  sub-questions live under `.group_of_questions[]` / `.conditional`.
+- **Community prediction is gated:** `?with_cp=true` returns `centers: null` until the
+  authenticated account has itself forecast on the question.
+- **Restricted endpoints** (HTTP 403 for normal tokens): unrestricted `/api/comments/`
+  listing, `/api/aggregation_explorer/`. Contact support@metaculus.com for access.
+- Rates/values: binary probabilities are clamped to 0.001–0.999; continuous CDFs
+  must be exactly 201 monotonic points with per-step increase ≤ 0.2.
+- The Swagger spec at `/api/` and `/static/openapi.*.yml` sits behind a Cloudflare
+  JS challenge, so it is not fetchable from a plain headless `curl`; use a browser.

--- a/skills/metaculus/scripts/.gitignore
+++ b/skills/metaculus/scripts/.gitignore
@@ -1,0 +1,3 @@
+# Holds the Metaculus API token — never commit.
+.config
+.env

--- a/skills/metaculus/scripts/metaculus.jsh
+++ b/skills/metaculus/scripts/metaculus.jsh
@@ -1,0 +1,251 @@
+// metaculus.jsh — Metaculus API client (forecasting questions + tournaments).
+//
+//   metaculus auth <token> | --show
+//   metaculus me
+//   metaculus questions [--search q] [--status open|closed|resolved|upcoming]
+//                       [--type binary|multiple_choice|numeric|date|group]
+//                       [--tournament <id|slug>] [--order-by <field>]
+//                       [--limit n] [--offset n] [--json]
+//   metaculus question <post_id> [--cp] [--json]
+//   metaculus forecast <question_id> <prob>          binary (0.001–0.999)
+//   metaculus forecast <question_id> --data '<json>' MC / continuous
+//   metaculus withdraw <question_id>
+//   metaculus comment <post_id> <text> [--private] [--parent <comment_id>]
+//   metaculus comments [--post <id>] [--author me|<id>] [--limit n] [--json]
+//   metaculus tournaments [--json]
+//   metaculus tournament <id|slug> [--json]
+//   metaculus api <METHOD> <path> [--data '<json>'] [--query k=v ...] [--json]
+//
+// Auth priority: --token <t> | METACULUS_TOKEN | skill config (`metaculus auth`).
+// Get a token at https://www.metaculus.com/accounts/settings/ (API section).
+
+const cli   = require('sliccy:cli');
+const fmt   = require('sliccy:fmt');
+const skill = require('sliccy:skill');
+
+const BASE = 'https://www.metaculus.com/api';
+
+function str(v) { return typeof v === 'string' ? v : undefined; }
+
+// ─── config / auth ──────────────────────────────────────────────────────────
+async function loadConfig() { return (await skill.config()) || {}; }
+async function saveConfig(u) { await skill.config({ ...(await loadConfig()), ...u }); }
+async function getToken(override) {
+  const t = override || process.env.METACULUS_TOKEN || (await loadConfig()).token;
+  if (!t) cli.die('No API token. Run `metaculus auth <token>` or set METACULUS_TOKEN.\n' +
+                  'Create one at https://www.metaculus.com/accounts/settings/');
+  return t;
+}
+
+// ─── request helper ───────────────────────────────────────────────────────────
+// Returns parsed JSON (or text). Throws {message,status} on non-2xx.
+async function req(token, method, path, { query, body } = {}) {
+  let url = path.startsWith('http') ? path : BASE + (path.startsWith('/') ? path : '/' + path);
+  if (query && Object.keys(query).length) {
+    const qs = Object.entries(query)
+      .filter(([, v]) => v !== undefined && v !== null && v !== '')
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+      .join('&');
+    if (qs) url += (url.includes('?') ? '&' : '?') + qs;
+  }
+  const headers = { 'Authorization': `Token ${token}` };
+  let payload;
+  if (body !== undefined) { headers['Content-Type'] = 'application/json'; payload = JSON.stringify(body); }
+  const res = await fetch(url, { method, headers, body: payload });
+  const text = await res.text();
+  let data; try { data = text ? JSON.parse(text) : null; } catch { data = text; }
+  if (!res.ok) {
+    const msg = (data && (data.detail || data.error || data.non_field_errors)) || text || res.statusText;
+    const e = new Error(typeof msg === 'string' ? msg : JSON.stringify(msg));
+    e.status = res.status;
+    throw e;
+  }
+  return data;
+}
+
+// ─── formatting ─────────────────────────────────────────────────────────────
+function questionRow(p) {
+  const q = p.question || {};
+  const type = q.type || (p.group_of_questions ? 'group' : (p.notebook ? 'notebook' : '?'));
+  return [String(p.id), p.status || '', type, String(p.nr_forecasters ?? ''), fmt.trunc(p.title || '', 60)];
+}
+
+// ─── main ─────────────────────────────────────────────────────────────────────
+const HELP = `metaculus — Metaculus forecasting API
+
+  metaculus auth <token> | --show
+  metaculus me
+  metaculus questions [--search q] [--status open|closed|resolved|upcoming]
+                      [--type binary|multiple_choice|numeric|date|group]
+                      [--tournament <id|slug>] [--order-by <field>]
+                      [--limit n] [--offset n] [--json]
+  metaculus question <post_id> [--cp] [--json]
+  metaculus forecast <question_id> <prob>            binary, 0.001–0.999
+  metaculus forecast <question_id> --data '<json>'   MC/continuous forecast object
+  metaculus withdraw <question_id>
+  metaculus comment <post_id> <text> [--private] [--parent <comment_id>]
+  metaculus comments [--post <id>] [--author me|<id>] [--limit n] [--json]
+  metaculus tournaments [--json]
+  metaculus tournament <id|slug> [--json]
+  metaculus api <METHOD> <path> [--data '<json>'] [--query k=v] [--json]
+
+Auth: --token <t> | METACULUS_TOKEN | \`metaculus auth <token>\`.
+Forecast payload shapes:
+  binary          {"question":<id>,"probability_yes":0.65}
+  multiple_choice {"question":<id>,"probability_yes_per_category":{"Yes":0.6,"No":0.4}}
+  continuous      {"question":<id>,"continuous_cdf":[201 increasing values 0..1]}`;
+
+async function main() {
+  const { positional, flags } = process.argv.parseFlags();
+  const [cmd] = positional;
+  if (!cmd || flags.help || flags.h) return cli.help(HELP);
+
+  // auth: no token needed
+  if (cmd === 'auth') {
+    if (flags.show) {
+      const cfg = await loadConfig();
+      if (!cfg.token) return cli.out('No token stored.');
+      const t = cfg.token;
+      return cli.out(`Stored token: ${t.slice(0, 6)}…${t.slice(-4)}`);
+    }
+    const token = str(flags.token) || positional[1];
+    if (!token) return cli.die('usage: metaculus auth <token>  (or: metaculus auth --show)');
+    await saveConfig({ token });
+    return cli.out('API token saved to skill config.');
+  }
+
+  const token = await getToken(str(flags.token));
+
+  switch (cmd) {
+    case 'me': {
+      const j = await req(token, 'GET', '/users/me/');
+      if (flags.json) return cli.out(j);
+      return cli.out({ id: j.id, username: j.username, joined: j.date_joined, email: j.email,
+                       is_bot: j.is_bot, pro: j.metadata?.pro_details?.is_current_pro });
+    }
+
+    case 'questions': {
+      const query = {
+        limit: str(flags.limit) || 20,
+        offset: str(flags.offset),
+        search: str(flags.search),
+        statuses: str(flags.status),
+        forecast_type: str(flags.type),
+        tournaments: str(flags.tournament),
+        order_by: str(flags['order-by']),
+      };
+      const j = await req(token, 'GET', '/posts/', { query });
+      if (flags.json) return cli.out(j);
+      const rows = (j.results || []).map(questionRow);
+      cli.out(fmt.table([['ID', 'STATUS', 'TYPE', 'FCASTERS', 'TITLE'], ...rows]));
+      if (j.count != null) cli.out(`\n${rows.length} shown${j.count ? ` of ${j.count}` : ''}.`);
+      return;
+    }
+
+    case 'question': {
+      const id = str(flags.id) || positional[1];
+      if (!id) return cli.die('usage: metaculus question <post_id> [--cp] [--json]');
+      const j = await req(token, 'GET', `/posts/${id}/`, { query: { with_cp: flags.cp ? 'true' : undefined } });
+      if (flags.json) return cli.out(j);
+      const q = j.question || {};
+      const out = {
+        post_id: j.id,
+        question_id: q.id,   // use THIS for `forecast`/`withdraw` (differs from post_id)
+        title: j.title, type: q.type, status: j.status, resolved: j.resolved,
+        nr_forecasters: j.nr_forecasters, open_time: j.open_time,
+        scheduled_close_time: j.scheduled_close_time, scheduled_resolve_time: j.scheduled_resolve_time,
+        resolution: q.resolution, url: `https://www.metaculus.com/questions/${j.id}/`,
+      };
+      if (flags.cp) {
+        const cp = q.aggregations?.recency_weighted?.latest;
+        out.community_prediction = cp
+          ? { centers: cp.centers, forecaster_count: cp.forecaster_count }
+          : 'not available (Metaculus hides the community prediction until you have forecast on this question)';
+      }
+      return cli.out(out);
+    }
+
+    case 'forecast': {
+      const qid = str(flags.question) || positional[1];
+      if (!qid) return cli.die('usage: metaculus forecast <question_id> <prob>  |  --data \'<json>\'');
+      let entry;
+      if (flags.data) {
+        entry = JSON.parse(str(flags.data));
+        if (entry.question == null) entry.question = Number(qid);
+      } else {
+        const prob = positional[2];
+        if (prob == null) return cli.die('binary forecast needs a probability, e.g. `metaculus forecast 123 0.65`');
+        entry = { question: Number(qid), probability_yes: Number(prob) };
+      }
+      const j = await req(token, 'POST', '/questions/forecast/', { body: [entry] });
+      return cli.out(flags.json ? j : { ok: true, submitted: entry, response: j });
+    }
+
+    case 'withdraw': {
+      const qid = str(flags.question) || positional[1];
+      if (!qid) return cli.die('usage: metaculus withdraw <question_id>');
+      const j = await req(token, 'POST', '/questions/withdraw/', { body: [{ question: Number(qid) }] });
+      return cli.out(flags.json ? j : { ok: true, withdrawn: Number(qid), response: j });
+    }
+
+    case 'comment': {
+      const postId = str(flags.post) || positional[1];
+      const text = str(flags.text) || positional.slice(2).join(' ');
+      if (!postId || !text) return cli.die('usage: metaculus comment <post_id> <text> [--private] [--parent <id>]');
+      const body = { on_post: Number(postId), text, is_private: !!flags.private };
+      if (flags.parent) body.parent_id = Number(str(flags.parent));
+      const j = await req(token, 'POST', '/comments/create/', { body });
+      return cli.out(flags.json ? j : { ok: true, comment_id: j.id, on_post: Number(postId) });
+    }
+
+    case 'comments': {
+      let author = str(flags.author);
+      if (author === 'me') author = String((await req(token, 'GET', '/users/me/')).id);
+      const query = { limit: str(flags.limit) || 20, offset: str(flags.offset),
+                      post: str(flags.post), author };
+      const j = await req(token, 'GET', '/comments/', { query });
+      if (flags.json) return cli.out(j);
+      const rows = (j.results || []).map((c) => [String(c.id),
+        c.author?.username || '', (c.created_at || '').slice(0, 10),
+        fmt.trunc((c.text || '').replace(/\s+/g, ' '), 70)]);
+      return cli.out(fmt.table([['ID', 'AUTHOR', 'DATE', 'TEXT'], ...rows]));
+    }
+
+    case 'tournaments': {
+      const j = await req(token, 'GET', '/projects/tournaments/');
+      if (flags.json) return cli.out(j);
+      const rows = (j || []).map((t) => [String(t.id), t.slug || '',
+        t.prize_pool ? `$${t.prize_pool}` : '', fmt.trunc(t.name || '', 50)]);
+      return cli.out(fmt.table([['ID', 'SLUG', 'PRIZE', 'NAME'], ...rows]));
+    }
+
+    case 'tournament': {
+      const idOrSlug = str(flags.id) || positional[1];
+      if (!idOrSlug) return cli.die('usage: metaculus tournament <id|slug>');
+      const j = await req(token, 'GET', `/projects/tournaments/${idOrSlug}/`);
+      if (flags.json) return cli.out(j);
+      return cli.out({ id: j.id, name: j.name, slug: j.slug, prize_pool: j.prize_pool,
+        questions_count: j.questions_count, start_date: j.start_date, close_date: j.close_date,
+        is_ongoing: j.is_ongoing });
+    }
+
+    case 'api': {
+      const method = (positional[1] || 'GET').toUpperCase();
+      const path = positional[2];
+      if (!path) return cli.die('usage: metaculus api <METHOD> <path> [--data \'<json>\'] [--query k=v]');
+      const query = {};
+      for (const q of [].concat(flags.query || [])) {
+        const s = str(q); if (!s) continue;
+        const i = s.indexOf('='); if (i > 0) query[s.slice(0, i)] = s.slice(i + 1);
+      }
+      const body = flags.data ? JSON.parse(str(flags.data)) : undefined;
+      const j = await req(token, method, path, { query, body });
+      return cli.out(j);
+    }
+
+    default:
+      return cli.die(`unknown command: ${cmd}\n\n${HELP}`);
+  }
+}
+
+await main().catch((e) => cli.die(e.message + (e.status ? ` (HTTP ${e.status})` : ''), { prefix: 'metaculus' }));

--- a/skills/metaculus/scripts/metaculus.jsh
+++ b/skills/metaculus/scripts/metaculus.jsh
@@ -7,9 +7,9 @@
 //                       [--tournament <id|slug>] [--order-by <field>]
 //                       [--limit n] [--offset n] [--json]
 //   metaculus question <post_id> [--cp] [--json]
-//   metaculus forecast <question_id> <prob>          binary (0.001–0.999)
-//   metaculus forecast <question_id> --data '<json>' MC / continuous
-//   metaculus withdraw <question_id>
+//   metaculus forecast <question_id> <prob> --confirm          binary (0.001–0.999)
+//   metaculus forecast <question_id> --data '<json>' --confirm MC / continuous
+//   metaculus withdraw <question_id> --confirm
 //   metaculus comment <post_id> <text> [--private] [--parent <comment_id>]
 //   metaculus comments [--post <id>] [--author me|<id>] [--limit n] [--json]
 //   metaculus tournaments [--json]
@@ -39,8 +39,19 @@ async function getToken(override) {
 
 // ─── request helper ───────────────────────────────────────────────────────────
 // Returns parsed JSON (or text). Throws {message,status} on non-2xx.
+// SECURITY: the auth token is only ever attached to metaculus.com hosts, so an
+// absolute URL pointing elsewhere (e.g. `metaculus api GET https://evil/`) can
+// never leak the token.
+function assertMetaculusHost(url) {
+  let host;
+  try { host = new URL(url).host; } catch { throw new Error(`invalid URL: ${url}`); }
+  if (!/(^|\.)metaculus\.com$/i.test(host)) {
+    throw new Error(`refusing to send credentials to non-Metaculus host: ${host}`);
+  }
+}
 async function req(token, method, path, { query, body } = {}) {
   let url = path.startsWith('http') ? path : BASE + (path.startsWith('/') ? path : '/' + path);
+  assertMetaculusHost(url);
   if (query && Object.keys(query).length) {
     const qs = Object.entries(query)
       .filter(([, v]) => v !== undefined && v !== null && v !== '')
@@ -80,9 +91,9 @@ const HELP = `metaculus — Metaculus forecasting API
                       [--tournament <id|slug>] [--order-by <field>]
                       [--limit n] [--offset n] [--json]
   metaculus question <post_id> [--cp] [--json]
-  metaculus forecast <question_id> <prob>            binary, 0.001–0.999
-  metaculus forecast <question_id> --data '<json>'   MC/continuous forecast object
-  metaculus withdraw <question_id>
+  metaculus forecast <question_id> <prob> --confirm            binary, 0.001–0.999
+  metaculus forecast <question_id> --data '<json>' --confirm   MC/continuous forecast object
+  metaculus withdraw <question_id> --confirm
   metaculus comment <post_id> <text> [--private] [--parent <comment_id>]
   metaculus comments [--post <id>] [--author me|<id>] [--limit n] [--json]
   metaculus tournaments [--json]
@@ -154,11 +165,19 @@ async function main() {
         title: j.title, type: q.type, status: j.status, resolved: j.resolved,
         nr_forecasters: j.nr_forecasters, open_time: j.open_time,
         scheduled_close_time: j.scheduled_close_time, scheduled_resolve_time: j.scheduled_resolve_time,
-        resolution: q.resolution, url: `https://www.metaculus.com/questions/${j.id}/`,
+        resolution: q.resolution,
+        // resolution rules matter for forecasting — surface them (agents need them)
+        description: q.description || null,
+        resolution_criteria: q.resolution_criteria || null,
+        fine_print: q.fine_print || null,
+        options: q.options || undefined,
+        url: `https://www.metaculus.com/questions/${j.id}/`,
       };
       if (flags.cp) {
         const cp = q.aggregations?.recency_weighted?.latest;
-        out.community_prediction = cp
+        // A latest object may exist yet still have null centers (CP is gated
+        // until you have forecast) — test centers explicitly, not just `cp`.
+        out.community_prediction = (cp && cp.centers != null)
           ? { centers: cp.centers, forecaster_count: cp.forecaster_count }
           : 'not available (Metaculus hides the community prediction until you have forecast on this question)';
       }
@@ -171,11 +190,24 @@ async function main() {
       let entry;
       if (flags.data) {
         entry = JSON.parse(str(flags.data));
-        if (entry.question == null) entry.question = Number(qid);
+        // Reject a payload whose embedded question id contradicts the positional
+        // id — otherwise we'd silently forecast on a different question.
+        if (entry.question != null && Number(entry.question) !== Number(qid)) {
+          return cli.die(`question id mismatch: positional ${qid} vs --data question ${entry.question}. ` +
+            `Pass one, or make them match.`);
+        }
+        entry.question = Number(qid);
       } else {
         const prob = positional[2];
         if (prob == null) return cli.die('binary forecast needs a probability, e.g. `metaculus forecast 123 0.65`');
         entry = { question: Number(qid), probability_yes: Number(prob) };
+      }
+      // Forecasting is a real mutation against the user's track record — require
+      // an explicit --confirm. Without it, preview the payload and stop.
+      if (!flags.confirm) {
+        cli.out({ preview: entry,
+          note: 'This will submit a forecast on your Metaculus account. Re-run with --confirm to send it.' });
+        return;
       }
       const j = await req(token, 'POST', '/questions/forecast/', { body: [entry] });
       return cli.out(flags.json ? j : { ok: true, submitted: entry, response: j });
@@ -183,7 +215,12 @@ async function main() {
 
     case 'withdraw': {
       const qid = str(flags.question) || positional[1];
-      if (!qid) return cli.die('usage: metaculus withdraw <question_id>');
+      if (!qid) return cli.die('usage: metaculus withdraw <question_id> [--confirm]');
+      if (!flags.confirm) {
+        cli.out({ preview: { withdraw_question: Number(qid) },
+          note: 'This will withdraw your active forecast. Re-run with --confirm to proceed.' });
+        return;
+      }
       const j = await req(token, 'POST', '/questions/withdraw/', { body: [{ question: Number(qid) }] });
       return cli.out(flags.json ? j : { ok: true, withdrawn: Number(qid), response: j });
     }


### PR DESCRIPTION
## Metaculus skill

CLI + reference for the [Metaculus](https://www.metaculus.com) forecasting API.

### What it does
- `metaculus questions` — browse/search posts (filters: `--search`, `--status`, `--type`, `--tournament <id|slug>`, `--order-by`, `--limit/--offset`)
- `metaculus question <post_id> [--cp]` — question detail, resolution criteria, and (when visible) the community prediction; surfaces both `post_id` and `question_id`
- `metaculus forecast <question_id> <prob>` / `--data '<json>'` — submit binary / multiple-choice / continuous forecasts
- `metaculus withdraw <question_id>` — withdraw a forecast
- `metaculus comment` / `metaculus comments` — post and list comments
- `metaculus tournaments` / `metaculus tournament <id|slug>` — list projects and their questions
- `metaculus api <METHOD> <path>` — raw passthrough
- `metaculus auth <token>` — store a personal API token (git-ignored `scripts/.config`)

### Files
- `skills/metaculus/SKILL.md`
- `skills/metaculus/scripts/metaculus.jsh`
- `skills/metaculus/scripts/.gitignore` (never commit the token)
- `skills/metaculus/references/curl.md` — the underlying REST endpoints as raw `curl` commands (auth, question read/search, forecast/withdraw payload shapes, comments, tournaments)

### Verified live
Against a real authenticated account: `me`, `questions` (incl. search + tournament slug/id filtering), `question --cp`, `comments --author me`, `tournaments`, `tournament <slug>`, `api` passthrough, and forecast/withdraw payload validation (binary `probability_yes` 0.001–0.999, MC `probability_yes_per_category`, continuous 201-point `continuous_cdf`). No test forecasts were left on any question.

### Notes
- **post id ≠ question id** — you read by post id but forecast by `.question.id`; documented and surfaced in the detail output.
- Community prediction is gated by Metaculus until the caller has forecast on the question; the skill reports this rather than showing an empty value.

Draft — leaving for review before merge.

— Sliccy 🍦
