### PR TITLE
Metaculus: forecast-withdrawal awareness + metaculus-ext (community prediction & divergence)

### DIFF
--- a/skills/metaculus/SKILL.md
+++ b/skills/metaculus/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: metaculus
-description: Interact with the Metaculus forecasting platform via its REST API — browse and search forecasting questions, read question detail and resolution criteria, submit or withdraw forecasts (binary, multiple-choice, and continuous), read and post comments, and list tournaments and their questions. Use when the user mentions Metaculus, forecasting questions, prediction questions, community predictions, forecasting tournaments (e.g. the AI Forecasting Benchmark / FutureEval bot tournaments), wants to make or update a forecast, check how a question is resolving, or query anything from metaculus.com without clicking through the site. Activate on "Metaculus", "forecast this question", "prediction market question", "community prediction", "forecasting tournament", "submit a forecast", "metaculus question".
+description: Interact with the Metaculus forecasting platform via its REST API — browse and search forecasting questions, read question detail and resolution criteria, submit or withdraw forecasts (binary, multiple-choice, and continuous), list your own forecasts and which are still active vs auto-withdrawn, read and post comments, and list tournaments and their questions. A companion `metaculus-ext` reads the community prediction (which the API gates) from a logged-in browser tab and ranks how far your active forecasts diverge from the crowd. Use when the user mentions Metaculus, forecasting questions, prediction questions, community predictions, forecasting tournaments (e.g. the AI Forecasting Benchmark / FutureEval bot tournaments), wants to make or update a forecast, see their current/active forecasts, compare their forecasts to the community, check how a question is resolving, or query anything from metaculus.com without clicking through the site. Activate on "Metaculus", "forecast this question", "prediction market question", "community prediction", "forecasting tournament", "submit a forecast", "my metaculus forecasts", "out on a limb", "metaculus question".
 allowed-tools: bash
 ---
 
@@ -34,8 +34,12 @@ metaculus questions [--search q] [--status open|closed|resolved|upcoming] \
                     [--tournament <id|slug>] [--order-by <field>] \
                     [--limit n] [--offset n] [--json]
 
-# One question in detail (--cp adds the community prediction, when visible)
+# One question in detail (--cp adds the community prediction, when visible;
+# also surfaces YOUR forecast and whether it is still active — see "My forecasts")
 metaculus question <post_id> [--cp] [--json]
+
+# Your own forecasts on open questions, flagged active vs auto-withdrawn
+metaculus mine [--status active|withdrawn|all] [--json]
 
 # Forecast (see "Forecasting" below — uses the QUESTION id, not the post id)
 metaculus forecast <question_id> <prob> --confirm            # binary, 0.001–0.999
@@ -79,12 +83,55 @@ explicit approval before re-running with `--confirm`. A `--data` payload whose
 embedded `question` id contradicts the positional id is rejected (no silent
 forecast on the wrong question).
 
+## My forecasts & auto-withdrawal
+
+Metaculus **auto-withdraws** stale forecasts (each forecast has a
+prediction-expiration; once it lapses your forecast stops counting toward the
+community aggregate). The API exposes this on `question.my_forecasts.latest`:
+an `end_time` in the **past** means the forecast is no longer standing, even
+though the question is still open.
+
+- `metaculus mine` lists your forecasts on open questions and flags each
+  `active` vs `withdrawn`. Default `--status active` = the forecasts you're
+  **currently** making; `--status withdrawn` / `all` for the rest.
+- `metaculus question <id>` includes a `my_forecast` block with `active` and a
+  human `status` ("withdrawn (auto-expired)").
+
+Don't treat "questions I've ever forecast on and are still open" as "my current
+predictions" — most may have auto-withdrawn.
+
+## Community prediction & divergence (metaculus-ext)
+
+A normal API token **cannot read the community prediction** — the
+`aggregations.recency_weighted.latest` block comes back null regardless of auth
+(same gating as the restricted `aggregation_explorer` endpoint). The website
+shows it because it is server-rendered into the page.
+
+`metaculus-ext` (a separate binary, so `metaculus` stays a clean API client)
+reads the CP from a **logged-in www.metaculus.com browser tab** — exactly the
+pattern `gcloud-ext` uses for the Cloud Console billing API. Open metaculus.com
+signed in, then:
+
+```sh
+metaculus-ext cp <post_id> [post_id...] [--json]     # community prediction for questions
+metaculus-ext divergence [--min-forecasters N] [--limit N] \
+                         [--include-withdrawn] [--json]   # your active bets ranked by
+                                                          # distance from the crowd
+```
+
+`divergence` combines the token API (your forecasts + active/withdrawn state)
+with the browser session (the crowd's number) and ranks your **active** binary
+forecasts by `|you − crowd|` — the real "out on a limb" metric. (Extremity ≠
+divergence: a 1% forecast where the crowd is also at 1% is high-conviction but
+not contrarian.) Requires an open, logged-in metaculus.com tab.
+
 ## Gotchas
 
 - **post id ≠ question id** (see above). Group/conditional posts have `question:
   null` and expose sub-questions under `.group_of_questions[]` / `.conditional`.
-- **Community prediction is gated:** `--cp` / `?with_cp=true` returns `null`
-  centers until the calling account has itself forecast on that question.
+- **A forecast on an open question may be auto-withdrawn** (see "My forecasts").
+- **Community prediction is gated from the API** — use `metaculus-ext` with a
+  logged-in browser tab (see above).
 - **Restricted endpoints (HTTP 403):** unrestricted `/api/comments/` listing (scope
   to `--author me`), and `/api/aggregation_explorer/`. Contact
   support@metaculus.com for broader access.

--- a/skills/metaculus/SKILL.md
+++ b/skills/metaculus/SKILL.md
@@ -125,6 +125,13 @@ forecasts by `|you − crowd|` — the real "out on a limb" metric. (Extremity �
 divergence: a 1% forecast where the crowd is also at 1% is high-conviction but
 not contrarian.) Requires an open, logged-in metaculus.com tab.
 
+Notes: `cp` is type-aware — binary renders as a probability, multiple-choice as
+per-option probabilities, and numeric/date centers are scaled to real
+units/dates (never a misleading `%`); it falls back to `n/a` when the CP isn't
+embedded. `divergence` is binary + single-question (it can't map one page's CP
+onto multiple sub-questions of a group post); `metaculus mine` does list your
+group/conditional forecasts.
+
 ## Gotchas
 
 - **post id ≠ question id** (see above). Group/conditional posts have `question:

--- a/skills/metaculus/scripts/metaculus-ext.jsh
+++ b/skills/metaculus/scripts/metaculus-ext.jsh
@@ -52,6 +52,49 @@ async function api(token, path, query) {
   return res.json();
 }
 
+// Convert an internal 0..1 aggregation location to a real value using the
+// question's scaling (Metaculus' own formula: linear when zero_point is null,
+// log otherwise). Used to render numeric/date community predictions correctly.
+function scaleLocation(x, scaling) {
+  if (!scaling) return x;
+  const { range_min, range_max, zero_point } = scaling;
+  if (range_min == null || range_max == null) return x;
+  if (zero_point != null) {
+    const r = (range_max - zero_point) / (range_min - zero_point);
+    return range_min + (range_max - range_min) * (Math.pow(r, x) - 1) / (r - 1);
+  }
+  return range_min + (range_max - range_min) * x;
+}
+
+// Render a question's community centers according to its type.
+function formatCp(type, centers, meta) {
+  if (!centers || !centers.length) return 'n/a';
+  if (type === 'binary') return `${(centers[0] * 100).toFixed(1)}%`;
+  if (type === 'multiple_choice') {
+    const opts = (meta && meta.options) || [];
+    return centers.map((c, i) => `${opts[i] || 'opt' + i}: ${(c * 100).toFixed(0)}%`).join(', ');
+  }
+  // numeric / date / discrete: centers are internal locations → scale to real units
+  const scaling = meta && meta.scaling;
+  const median = scaleLocation(centers[Math.floor(centers.length / 2)] ?? centers[0], scaling);
+  if (type === 'date') return new Date(median * 1000).toISOString().slice(0, 10);
+  const unit = (meta && meta.unit) ? ' ' + meta.unit : '';
+  return `${(+median).toPrecision(4)}${unit} (median)`;
+}
+
+// Fetch type/scaling/options/unit for a set of post ids from the token API.
+async function questionMeta(token, ids) {
+  const meta = {};
+  for (const id of ids) {
+    try {
+      const j = await api(token, `/posts/${id}/`);
+      const q = j.question || {};
+      meta[id] = { type: q.type, scaling: q.scaling, options: q.options, unit: q.unit };
+    } catch { meta[id] = {}; }
+  }
+  return meta;
+}
+
 // ─── browser session: read CP out of the server-rendered question page ────────
 async function findTab() {
   const tab = await browser.findTab({ urlMatch: /(^|\.)metaculus\.com/ });
@@ -119,16 +162,22 @@ async function cpForIds(ids) {
 // ─── commands ─────────────────────────────────────────────────────────────────
 async function cmdCp(ids, flags) {
   if (!ids.length) cli.die('usage: metaculus-ext cp <post_id> [post_id...]', { prefix: 'metaculus-ext' });
-  const res = await cpForIds(ids.map(Number));
-  if (flags.json) return cli.out(res);
-  const rows = ids.map((id) => {
-    const r = res[id] || {};
-    const cp = r.centers && r.centers.length === 1 ? `${(r.centers[0] * 100).toFixed(1)}%`
-      : r.centers ? `[${r.centers.map((x) => (x * 100).toFixed(0) + '%').join(', ')}]`
-      : (r.err ? 'error' : 'n/a');
-    return [String(id), cp, r.fc != null ? String(r.fc) : ''];
+  const nids = ids.map(Number);
+  const token = await getToken();
+  const [res, meta] = await Promise.all([cpForIds(nids), questionMeta(token, nids)]);
+  if (flags.json) {
+    return cli.out(Object.fromEntries(nids.map((id) => {
+      const r = res[id] || {}, m = meta[id] || {};
+      return [id, { type: m.type, centers: r.centers, forecaster_count: r.fc,
+        formatted: r.centers ? formatCp(m.type, r.centers, m) : (r.err ? 'error' : 'n/a') }];
+    })));
+  }
+  const rows = nids.map((id) => {
+    const r = res[id] || {}, m = meta[id] || {};
+    const cp = r.centers ? formatCp(m.type, r.centers, m) : (r.err ? 'error' : 'n/a');
+    return [String(id), m.type || '', cp, r.fc != null ? String(r.fc) : ''];
   });
-  cli.out(fmt.table([['POST', 'COMMUNITY', 'FORECASTERS'], ...rows]));
+  cli.out(fmt.table([['POST', 'TYPE', 'COMMUNITY', 'FORECASTERS'], ...rows]));
 }
 
 async function cmdDivergence(flags) {
@@ -146,9 +195,13 @@ async function cmdDivergence(flags) {
     });
     const res = j.results || [];
     for (const p of res) {
-      const q = p.question || {};
-      const mf = q.my_forecasts && q.my_forecasts.latest;
-      if (!mf || q.type !== 'binary') continue;               // v1: binary only
+      // Only single-question posts here: the CP is read per page/post id, which
+      // can't disambiguate multiple sub-questions of a group/conditional post, so
+      // including them would map one sub-question's CP onto all. `metaculus mine`
+      // does list group forecasts (no CP mapping needed there).
+      const q = p.question;
+      const mf = q && q.my_forecasts && q.my_forecasts.latest;
+      if (!mf || q.type !== 'binary') continue;               // v1: binary, single-question
       const active = mf.end_time == null || mf.end_time > nowS;
       if (!active && !flags['include-withdrawn']) continue;    // current forecasts only
       const pyes = (mf.forecast_values || [])[1];

--- a/skills/metaculus/scripts/metaculus-ext.jsh
+++ b/skills/metaculus/scripts/metaculus-ext.jsh
@@ -1,0 +1,229 @@
+// metaculus-ext.jsh — SLICC-only extensions to the `metaculus` skill that are
+// NOT expressible through the public Metaculus API. Kept in a separate binary
+// (`metaculus-ext`) so `metaculus` itself stays a clean API client.
+//
+//   metaculus-ext cp <post_id> [post_id...] [--json]
+//       Community prediction for one or more questions.
+//   metaculus-ext divergence [--min-forecasters N] [--limit N]
+//                            [--include-withdrawn] [--json]
+//       Rank YOUR active binary forecasts by how far they sit from the crowd.
+//
+// WHY: Metaculus strips the community-prediction aggregations from API
+// responses (`aggregations.recency_weighted.latest` comes back null for a
+// normal API token — the same gating as the restricted `aggregation_explorer`
+// endpoint). The website still shows the CP because it is server-rendered into
+// the page. So, exactly like gcloud-ext replays the Console's private billing
+// API from a logged-in tab, this replays the *page* fetch from a logged-in
+// metaculus.com browser tab and reads the CP out of the embedded Next.js flight
+// data. It needs an open, logged-in www.metaculus.com tab.
+//
+// Caveat: this parses an undocumented server-rendered payload. If Metaculus
+// changes its page structure this may break — re-inspect a question page's
+// `"recency_weighted":{ ... "latest": ...}` block and update extractCp().
+
+const cli     = require('sliccy:cli');
+const fmt     = require('sliccy:fmt');
+const skill   = require('sliccy:skill');
+const c       = require('sliccy:color');
+const browser = require('sliccy:browser');
+
+const API = 'https://www.metaculus.com/api';
+
+function str(v) { return typeof v === 'string' ? v : undefined; }
+function num(v, d) { const n = Number(str(v)); return Number.isFinite(n) ? n : d; }
+
+// ─── token-backed API (reuses the metaculus skill config) ────────────────────
+async function getToken() {
+  const t = process.env.METACULUS_TOKEN || ((await skill.config()) || {}).token;
+  if (!t) cli.die('No API token. Run `metaculus auth <token>` first.', { prefix: 'metaculus-ext' });
+  return t;
+}
+async function api(token, path, query) {
+  let url = API + path;
+  if (query) {
+    const qs = Object.entries(query).filter(([, v]) => v != null && v !== '')
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join('&');
+    if (qs) url += (url.includes('?') ? '&' : '?') + qs;
+  }
+  // credentials only ever go to metaculus.com
+  if (!/(^|\.)metaculus\.com$/i.test(new URL(url).host)) throw new Error('refusing non-metaculus host');
+  const res = await fetch(url, { headers: { Authorization: `Token ${token}` } });
+  if (!res.ok) throw new Error(`API ${res.status} on ${path}`);
+  return res.json();
+}
+
+// ─── browser session: read CP out of the server-rendered question page ────────
+async function findTab() {
+  const tab = await browser.findTab({ urlMatch: /(^|\.)metaculus\.com/ });
+  if (!tab) cli.die(
+    'No logged-in metaculus.com tab found.\n' +
+    'Open https://www.metaculus.com (signed in) and retry.', { prefix: 'metaculus-ext' });
+  return tab;
+}
+
+// Fetch CP for a batch of post ids from inside the logged-in tab. Returns
+// { <id>: { centers:[...], fc:<n> } | { err } }. Parsing note: the CP lives in
+// the SSR flight data as `"recency_weighted":{...,"latest":{...,"forecaster_count":N,...,"centers":[...]}}`.
+// `String.fromCharCode(34)` = `"`, `(92)` = `\` — avoids quote-escaping hell.
+async function fetchCpBatch(tab, ids, conc = 6) {
+  const src = `
+    (async () => {
+      const IDS = ${JSON.stringify(ids)};
+      const Q = String.fromCharCode(34), BS = String.fromCharCode(92);
+      const out = {};
+      let i = 0;
+      async function worker() {
+        while (i < IDS.length) {
+          const id = IDS[i++];
+          try {
+            const res = await fetch('/questions/' + id + '/', { credentials: 'include' });
+            const html = await res.text();
+            const u = html.split(BS + Q).join(Q).split(BS + 'n').join('').split(BS + BS).join(BS);
+            const key = Q + 'recency_weighted' + Q + ':{';
+            const idx = u.indexOf(key);
+            let centers = null, fc = null;
+            if (idx >= 0) {
+              const li = u.indexOf(Q + 'latest' + Q, idx);
+              if (li >= 0) {
+                const chunk = u.slice(li, li + 500);
+                const fm = chunk.match(new RegExp(Q + 'forecaster_count' + Q + ':(\\\\d+)'));
+                const cm = chunk.match(new RegExp(Q + 'centers' + Q + ':' + BS + '[([^' + BS + ']]*)' + BS + ']'));
+                if (fm) fc = Number(fm[1]);
+                if (cm) centers = cm[1].split(',').map(Number);
+              }
+            }
+            out[id] = { centers, fc };
+          } catch (e) { out[id] = { err: String(e) }; }
+        }
+      }
+      await Promise.all(Array.from({ length: ${conc} }, worker));
+      return out;
+    })()
+  `;
+  return browser.evalAsync(tab, src);
+}
+
+// chunk helper
+function chunk(arr, n) { const o = []; for (let i = 0; i < arr.length; i += n) o.push(arr.slice(i, i + n)); return o; }
+
+async function cpForIds(ids) {
+  const tab = await findTab();
+  const results = {};
+  for (const c of chunk(ids, 24)) {
+    const r = await fetchCpBatch(tab, c);
+    Object.assign(results, r || {});
+  }
+  return results;
+}
+
+// ─── commands ─────────────────────────────────────────────────────────────────
+async function cmdCp(ids, flags) {
+  if (!ids.length) cli.die('usage: metaculus-ext cp <post_id> [post_id...]', { prefix: 'metaculus-ext' });
+  const res = await cpForIds(ids.map(Number));
+  if (flags.json) return cli.out(res);
+  const rows = ids.map((id) => {
+    const r = res[id] || {};
+    const cp = r.centers && r.centers.length === 1 ? `${(r.centers[0] * 100).toFixed(1)}%`
+      : r.centers ? `[${r.centers.map((x) => (x * 100).toFixed(0) + '%').join(', ')}]`
+      : (r.err ? 'error' : 'n/a');
+    return [String(id), cp, r.fc != null ? String(r.fc) : ''];
+  });
+  cli.out(fmt.table([['POST', 'COMMUNITY', 'FORECASTERS'], ...rows]));
+}
+
+async function cmdDivergence(flags) {
+  const token = await getToken();
+  const me = await api(token, '/users/me/');
+  const minF = num(flags['min-forecasters'], 0);
+  const limit = num(flags.limit, 15);
+
+  // 1. Pull all my open forecasts (with my_forecasts + end_time).
+  const mine = [];
+  const nowS = Date.now() / 1000;
+  for (let offset = 0; offset < 1000; offset += 50) {
+    const j = await api(token, '/posts/', {
+      forecaster_id: me.id, statuses: 'open', with_cp: 'true', limit: 50, offset,
+    });
+    const res = j.results || [];
+    for (const p of res) {
+      const q = p.question || {};
+      const mf = q.my_forecasts && q.my_forecasts.latest;
+      if (!mf || q.type !== 'binary') continue;               // v1: binary only
+      const active = mf.end_time == null || mf.end_time > nowS;
+      if (!active && !flags['include-withdrawn']) continue;    // current forecasts only
+      const pyes = (mf.forecast_values || [])[1];
+      if (pyes == null) continue;
+      mine.push({ id: p.id, title: p.title, pyes, active });
+    }
+    if (res.length < 50) break;
+  }
+  if (!mine.length) cli.die('No active binary forecasts found.', { prefix: 'metaculus-ext' });
+
+  // 2. Fetch the community prediction for each from the logged-in tab.
+  const cp = await cpForIds(mine.map((m) => m.id));
+
+  // 3. Compute signed divergence (me − crowd).
+  const rows = [];
+  for (const m of mine) {
+    const r = cp[m.id];
+    if (!r || !r.centers || r.centers.length !== 1) continue;
+    if (r.fc != null && r.fc < minF) continue;
+    const crowd = r.centers[0];
+    rows.push({ ...m, crowd, fc: r.fc, div: m.pyes - crowd, adiv: Math.abs(m.pyes - crowd) });
+  }
+  rows.sort((a, b) => b.adiv - a.adiv);
+  const top = rows.slice(0, limit);
+
+  if (flags.json) return cli.out({ compared: rows.length, active_total: mine.length, rows: top });
+
+  cli.out('');
+  cli.out(`  ${c.dim(`${rows.length} of your ${mine.length} active binary forecasts have a community prediction`)}`);
+  cli.out('');
+  const body = top.map((r) => {
+    const dir = r.div > 0 ? c.green('▲ higher') : c.red('▼ lower');
+    return [
+      `${(r.adiv * 100).toFixed(0)}pp`,
+      `${(r.pyes * 100).toFixed(0)}%`,
+      `${(r.crowd * 100).toFixed(0)}%`,
+      r.fc != null ? String(r.fc) : '',
+      dir,
+      fmt.trunc(r.title, 52),
+    ];
+  });
+  cli.out(fmt.table([['Δ', 'YOU', 'CROWD', 'f', 'DIR', 'QUESTION'], ...body]));
+}
+
+// ─── main ─────────────────────────────────────────────────────────────────────
+const HELP = `
+metaculus-ext — SLICC-only extensions to the metaculus skill (not public API).
+
+USAGE
+  metaculus-ext cp <post_id> [post_id...] [--json]
+      Community prediction for one or more questions.
+
+  metaculus-ext divergence [--min-forecasters N] [--limit N]
+                           [--include-withdrawn] [--json]
+      Rank YOUR active binary forecasts by distance from the community
+      prediction (the real "out on a limb" metric). By default only counts
+      forecasts you're currently making (skips auto-withdrawn ones).
+
+Both read the community prediction from a logged-in www.metaculus.com browser
+tab (the API omits it). Open metaculus.com signed in, then run these.
+
+EXAMPLES
+  metaculus-ext cp 44798 19453
+  metaculus-ext divergence --min-forecasters 20 --limit 20
+`.trim();
+
+async function main() {
+  const { positional, flags } = process.argv.parseFlags();
+  const [cmd, ...rest] = positional;
+  if (!cmd || flags.help || flags.h || cmd === 'help') return cli.help(HELP);
+  switch (cmd) {
+    case 'cp':          return cmdCp(rest, flags);
+    case 'divergence':  return cmdDivergence(flags);
+    default:            return cli.die(`unknown command: ${cmd}\n\n${HELP}`, { prefix: 'metaculus-ext' });
+  }
+}
+
+await main().catch((e) => cli.die(e.message, { prefix: 'metaculus-ext' }));

--- a/skills/metaculus/scripts/metaculus.jsh
+++ b/skills/metaculus/scripts/metaculus.jsh
@@ -2,6 +2,7 @@
 //
 //   metaculus auth <token> | --show
 //   metaculus me
+//   metaculus mine [--status active|withdrawn|all] [--json]
 //   metaculus questions [--search q] [--status open|closed|resolved|upcoming]
 //                       [--type binary|multiple_choice|numeric|date|group]
 //                       [--tournament <id|slug>] [--order-by <field>]
@@ -86,6 +87,7 @@ const HELP = `metaculus — Metaculus forecasting API
 
   metaculus auth <token> | --show
   metaculus me
+  metaculus mine [--status active|withdrawn|all] [--json]
   metaculus questions [--search q] [--status open|closed|resolved|upcoming]
                       [--type binary|multiple_choice|numeric|date|group]
                       [--tournament <id|slug>] [--order-by <field>]
@@ -179,9 +181,58 @@ async function main() {
         // until you have forecast) — test centers explicitly, not just `cp`.
         out.community_prediction = (cp && cp.centers != null)
           ? { centers: cp.centers, forecaster_count: cp.forecaster_count }
-          : 'not available (Metaculus hides the community prediction until you have forecast on this question)';
+          : 'not available via API (gated — use `metaculus-ext cp ' + j.id + '` with a logged-in browser tab)';
+      }
+      // Surface the caller's own forecast + whether it is still active. Metaculus
+      // auto-withdraws stale forecasts (prediction expiration); a `latest` whose
+      // end_time is in the past means the forecast is no longer standing.
+      const mine = q.my_forecasts?.latest;
+      if (mine) {
+        const nowS = Date.now() / 1000;
+        const active = mine.end_time == null || mine.end_time > nowS;
+        out.my_forecast = {
+          probability_yes: (mine.forecast_values || [])[1] ?? null,
+          active,
+          status: active ? 'active' : 'withdrawn (auto-expired)',
+          end_time: mine.end_time ? new Date(mine.end_time * 1000).toISOString() : null,
+        };
       }
       return cli.out(out);
+    }
+
+    case 'mine': {
+      // List the caller's forecasts on currently-open questions, flagging which
+      // are still active vs auto-withdrawn (Metaculus expires stale forecasts).
+      const me = await req(token, 'GET', '/users/me/');
+      const want = (str(flags.status) || 'active').toLowerCase(); // active|withdrawn|all
+      const nowS = Date.now() / 1000;
+      const rows = [];
+      for (let offset = 0; offset < 2000; offset += 50) {
+        const j = await req(token, 'GET', '/posts/', {
+          query: { forecaster_id: me.id, statuses: 'open', with_cp: 'true', limit: 50, offset },
+        });
+        const res = j.results || [];
+        for (const p of res) {
+          const q = p.question || {};
+          const mf = q.my_forecasts?.latest;
+          if (!mf) continue;
+          const active = mf.end_time == null || mf.end_time > nowS;
+          if (want === 'active' && !active) continue;
+          if (want === 'withdrawn' && active) continue;
+          rows.push({
+            post_id: p.id, question_id: q.id, type: q.type,
+            probability_yes: q.type === 'binary' ? (mf.forecast_values || [])[1] ?? null : null,
+            active, title: p.title,
+          });
+        }
+        if (res.length < 50) break;
+      }
+      if (flags.json) return cli.out({ count: rows.length, status: want, forecasts: rows });
+      const table = rows.map((r) => [String(r.post_id), r.active ? 'active' : 'withdrawn', r.type || '',
+        r.probability_yes != null ? `${(r.probability_yes * 100).toFixed(0)}%` : '', fmt.trunc(r.title, 56)]);
+      cli.out(fmt.table([['POST', 'STATUS', 'TYPE', 'P(yes)', 'TITLE'], ...table]));
+      cli.out(`\n${rows.length} ${want} forecast(s).`);
+      return;
     }
 
     case 'forecast': {

--- a/skills/metaculus/scripts/metaculus.jsh
+++ b/skills/metaculus/scripts/metaculus.jsh
@@ -28,6 +28,20 @@ const BASE = 'https://www.metaculus.com/api';
 
 function str(v) { return typeof v === 'string' ? v : undefined; }
 
+// Collect every question the caller has forecast within a post, whether it is a
+// single question, a group, or a conditional pair. Returns [{ q, mf }].
+function questionsInPost(p) {
+  const qs = [];
+  if (p.question) qs.push(p.question);
+  if (Array.isArray(p.group_of_questions)) qs.push(...p.group_of_questions);
+  if (p.conditional) {
+    if (p.conditional.question_yes) qs.push(p.conditional.question_yes);
+    if (p.conditional.question_no) qs.push(p.conditional.question_no);
+  }
+  return qs.map((q) => ({ q, mf: q && q.my_forecasts && q.my_forecasts.latest }))
+           .filter((x) => x.mf);
+}
+
 // ─── config / auth ──────────────────────────────────────────────────────────
 async function loadConfig() { return (await skill.config()) || {}; }
 async function saveConfig(u) { await skill.config({ ...(await loadConfig()), ...u }); }
@@ -184,8 +198,9 @@ async function main() {
           : 'not available via API (gated — use `metaculus-ext cp ' + j.id + '` with a logged-in browser tab)';
       }
       // Surface the caller's own forecast + whether it is still active. Metaculus
-      // auto-withdraws stale forecasts (prediction expiration); a `latest` whose
-      // end_time is in the past means the forecast is no longer standing.
+      // auto-withdraws stale forecasts (prediction expiration), but a forecast can
+      // also be withdrawn manually — both leave end_time in the past, and the API
+      // doesn't distinguish them, so we only assert "withdrawn", not the cause.
       const mine = q.my_forecasts?.latest;
       if (mine) {
         const nowS = Date.now() / 1000;
@@ -193,7 +208,7 @@ async function main() {
         out.my_forecast = {
           probability_yes: (mine.forecast_values || [])[1] ?? null,
           active,
-          status: active ? 'active' : 'withdrawn (auto-expired)',
+          status: active ? 'active' : 'withdrawn or expired',
           end_time: mine.end_time ? new Date(mine.end_time * 1000).toISOString() : null,
         };
       }
@@ -213,17 +228,16 @@ async function main() {
         });
         const res = j.results || [];
         for (const p of res) {
-          const q = p.question || {};
-          const mf = q.my_forecasts?.latest;
-          if (!mf) continue;
-          const active = mf.end_time == null || mf.end_time > nowS;
-          if (want === 'active' && !active) continue;
-          if (want === 'withdrawn' && active) continue;
-          rows.push({
-            post_id: p.id, question_id: q.id, type: q.type,
-            probability_yes: q.type === 'binary' ? (mf.forecast_values || [])[1] ?? null : null,
-            active, title: p.title,
-          });
+          for (const { q, mf } of questionsInPost(p)) {
+            const active = mf.end_time == null || mf.end_time > nowS;
+            if (want === 'active' && !active) continue;
+            if (want === 'withdrawn' && active) continue;
+            rows.push({
+              post_id: p.id, question_id: q.id, type: q.type,
+              probability_yes: q.type === 'binary' ? (mf.forecast_values || [])[1] ?? null : null,
+              active, title: q.title && q.title !== p.title ? `${p.title} — ${q.title}` : p.title,
+            });
+          }
         }
         if (res.length < 50) break;
       }


### PR DESCRIPTION
## Metaculus: forecast-withdrawal awareness + `metaculus-ext` (community prediction & divergence)

Follow-up to #259, driven by two gaps found in real use.

### 1. Auto-withdrawal was invisible (`metaculus.jsh`)
Metaculus **auto-withdraws** stale forecasts (prediction-expiration), so "questions I've forecast on that are still open" is *not* the same as "forecasts I'm currently making" — in one real account, 149 of ~243 were auto-withdrawn. The API does expose it (`question.my_forecasts.latest.end_time` in the past = no longer standing), we just weren't reading it.

- New `metaculus mine [--status active|withdrawn|all] [--json]` — lists your forecasts on open questions, flagging each `active` vs `withdrawn`.
- `metaculus question <id>` now includes a `my_forecast` block with `active` + human `status` ("withdrawn (auto-expired)").

### 2. Community prediction is gated from the API → `metaculus-ext.jsh` (new)
A normal API token **cannot read the community prediction** — `aggregations.recency_weighted.latest` is null regardless of auth (same gating as the restricted `aggregation_explorer`). The website shows it because it's server-rendered into the page.

Mirroring `gcloud-ext` (which replays the Cloud Console's private billing API from a logged-in tab), `metaculus-ext` reads the CP from a **logged-in www.metaculus.com browser tab** (`sliccy:browser` `findTab` + `evalAsync`, parsing the Next.js flight data). Kept as a separate binary so `metaculus` stays a clean public-API client.

```
metaculus-ext cp <post_id> [post_id...] [--json]
metaculus-ext divergence [--min-forecasters N] [--limit N] [--include-withdrawn] [--json]
```

`divergence` combines the token API (your forecasts + active/withdrawn state) with the browser session (the crowd's number) and ranks your **active** binary forecasts by `|you − crowd|` — the real "out on a limb" metric. (Extremity ≠ divergence: a 1% forecast where the crowd is also 1% is high-conviction but not contrarian.)

### Files
- `skills/metaculus/scripts/metaculus.jsh` — `mine` + `my_forecast` status
- `skills/metaculus/scripts/metaculus-ext.jsh` — new
- `skills/metaculus/SKILL.md` — new sections + updated description

### Verified live
Against a real authenticated account with a logged-in tab: `mine` (active/withdrawn split), `question` withdrawal block (confirmed a real auto-withdrawn forecast), `metaculus-ext cp` (returns community % + forecaster count; new/unrevealed questions correctly show n/a), and `metaculus-ext divergence` (ranked 45 of 56 active binary forecasts by divergence). No mutations.

Draft — for review.

— Sliccy 🍦
