### PR TITLE
feat(loose-ends): persistent loose-ends to-do sprinkle skill

### DIFF
--- a/skills/loose-ends/SKILL.md
+++ b/skills/loose-ends/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: loose-ends
+description: "A persistent to-do / follow-up list that lives in a sprinkle panel alongside the chat. Use when the user wants to track loose ends, open follow-ups, waiting-on-others items, or 'things I still need to do' across sessions — a durable backlog the cone maintains and resurfaces. Each item has a title and a rich context blob (why it's open, what to do, links). The panel offers two actions per row: 'Do' (hand the item to the cone to work on now) and 'Done' (remove it). Triggers on 'loose ends', 'my to-do list', 'open follow-ups', 'things I still need to do', 'track this for later', 'add a loose end', 'what's still open'."
+allowed-tools: bash
+---
+
+# Loose ends
+
+A durable, cross-session to-do list rendered as a sprinkle panel. Unlike the
+`monday` triage (which rates a live feed) or `review` (which tracks
+publish/annotate state), loose-ends is a hand-curated backlog of open threads
+the user wants kept in view until they're truly done.
+
+Each task carries a **title** and a free-form **context** blob — the "why it's
+open / what to do next / links" — so a future session (or a future you) can pick
+it up cold. The panel shows the title, an expandable context preview, and two
+buttons: **Do** and **Done**.
+
+## Architecture — who owns what
+
+Two owners, one authoritative file. Keep them separate:
+
+- **Store — cone-owned.** `/shared/loose-ends.json` is the single source of
+  truth. **Only the cone writes it.** It survives scoop restarts and session
+  reloads, so task truth never depends on the (disposable) UI scoop being alive.
+- **Sprinkle — scoop-owned.** One scoop named `loose-ends` owns the panel at
+  `/shared/sprinkles/loose-ends/loose-ends.shtml`. Per the SLICC sprinkle rule,
+  **the cone MUST NOT write the `.shtml` or run `sprinkle`** — it delegates every
+  panel operation (open, reload, `sprinkle send`) to that scoop via `feed_scoop`.
+
+The scoop is a puppet: the store is what matters. If the scoop dies, recreate it
+and reseed from the store (see [Resurrecting](#resurrecting-in-a-new-session)).
+
+### Store schema
+
+```json
+{
+  "updated": "2026-07-30T17:22:24.862Z",
+  "tasks": [
+    {
+      "id": "le-example",
+      "title": "Short imperative title",
+      "context": "The full why/what/links blob. Can be long — the panel truncates a preview and expands on click.",
+      "created": "2026-07-30T17:15:00Z"
+    }
+  ]
+}
+```
+
+- `id` — stable, unique, kebab-case (e.g. `le-<slug>`). Upserts key on it.
+- `title` — one-line imperative summary shown in bold.
+- `context` — optional rich text; the panel shows a ~140-char preview with a
+  "more" toggle.
+- `created` — ISO timestamp (informational).
+- Bump the top-level `updated` on every store write.
+
+## Quick-start / bootstrap
+
+The skill ships a helper (`loose-ends`) that the **owning scoop** runs to install
+the template, open the panel, and reseed it from the store in one step:
+
+1. **Create the scoop:** `scoop_scoop("loose-ends")`.
+2. **Bootstrap + reseed in one step** (delegate to the scoop):
+   ```
+   feed_scoop("loose-ends", "Run: loose-ends bootstrap
+   That copies the template into /shared/sprinkles/loose-ends/, refreshes the VFS, opens the panel, and loads all tasks from /shared/loose-ends.json. Confirm the panel is visible, then STAY ALIVE for lick events — do NOT finish.")
+   ```
+3. That's it — the panel is now live and seeded. The cone handles licks and store
+   writes from here.
+
+> If the store doesn't exist yet, `loose-ends bootstrap` opens an empty panel
+> (the cone creates `/shared/loose-ends.json` on the first `add-item`).
+
+### The `loose-ends` helper (scoop-side, read-only on the store)
+
+```
+loose-ends bootstrap   # copy template → sprinkle refresh → sprinkle open → reseed from store
+loose-ends reseed      # just re-send load-items from the store to an open panel
+```
+
+Options (all `--long` form): `--name <n>` (default `loose-ends`),
+`--store <path>` (default `/shared/loose-ends.json`),
+`--template <path>` (default the skill's `templates/loose-ends.shtml`).
+
+The helper only **reads** the store — it never writes tasks (that stays the
+cone's job). Run it from the owning scoop; it drives `sprinkle`.
+
+## Adding, updating, and removing tasks
+
+The cone owns the store, so it does two things per change: **write the JSON**
+(direct file edit) **and** tell the scoop to update the panel.
+
+**Add / update a task (upsert by `id`):**
+1. Cone appends/replaces the task in `/shared/loose-ends.json` and bumps `updated`.
+2. Cone → scoop:
+   ```
+   feed_scoop("loose-ends", "sprinkle send loose-ends '{\"action\":\"add-item\",\"task\":{\"id\":\"le-foo\",\"title\":\"...\",\"context\":\"...\",\"created\":\"2026-07-30T00:00:00Z\"}}'")
+   ```
+   `add-item` upserts: an existing `id` is replaced in place; a new `id` is
+   appended.
+
+**Remove a task:**
+1. Cone deletes it from the store and bumps `updated`.
+2. Cone → scoop: `sprinkle send loose-ends '{"action":"remove-item","id":"le-foo"}'`.
+
+**Replace the whole list** (e.g. after a bulk edit) — reseed:
+`sprinkle send loose-ends '{"action":"load-items","tasks":[ ... ]}'` (or just
+`loose-ends reseed`).
+
+## Lick events (panel → cone)
+
+The panel fires these licks back to the cone as `[Sprinkle Event: loose-ends]`:
+
+| Action | Data | When | Cone handler |
+|--------|------|------|--------------|
+| `do`   | `{ id, title, context }` | User clicks **Do** | Start working the task now, using `context` as the brief. The row stays in the list (a "Do" is not a completion). |
+| `done` | `{ id, title }` | User clicks **Done** | The panel already removed the row optimistically. Remove that `id` from `/shared/loose-ends.json` and bump `updated`. No panel round-trip needed. |
+
+> **`done` is optimistic in the panel.** The row disappears the instant the user
+> clicks, then the lick fires. The cone's only job is to make the store match by
+> deleting the task. Do not re-send `remove-item` for a `done` (the row is
+> already gone) unless you're reconciling a mismatch.
+
+## Inbound messages (cone → panel, via `sprinkle send loose-ends`)
+
+| Action | Payload | Effect |
+|--------|---------|--------|
+| `load-items` | `{ tasks:[...] }` | Replace the entire list (full reseed). |
+| `add-item` | `{ task:{id,title,context,created} }` | Upsert one task by `id` (replace if present, else append). |
+| `remove-item` | `{ id }` | Remove one task by `id`. |
+
+## Resurrecting in a new session
+
+Session/page reloads close all tabs and drop the running scoop, but the store
+persists. To bring the panel back exactly as it was:
+
+1. `scoop_scoop("loose-ends")` (recreate the owning scoop).
+2. `feed_scoop("loose-ends", "Run: loose-ends bootstrap — then stay alive for lick events, do NOT finish.")`
+
+`bootstrap` re-copies the template, reopens the panel, and reseeds every task
+from `/shared/loose-ends.json`. The cone resumes handling `do`/`done` licks and
+store writes.
+
+## Notes
+
+- **Reloading after template edits:** `sprinkle refresh` only re-scans the VFS —
+  it does not reload an open panel. To pick up template changes, close then
+  reopen from the scoop: `sprinkle close loose-ends && sprinkle refresh && sprinkle open loose-ends`,
+  then `loose-ends reseed`.
+- **No emojis in the UI** — the panel uses Lucide icons (`list-checks`, `check`,
+  `arrow-right`), per the SLICC style guide.
+- **Template:** `templates/loose-ends.shtml` (full-document mode). It persists
+  its own view via `slicc.setState`/`getState`, but the store is authoritative —
+  always reseed from `/shared/loose-ends.json` on bootstrap.

--- a/skills/loose-ends/SKILL.md
+++ b/skills/loose-ends/SKILL.md
@@ -148,6 +148,7 @@ The panel fires these licks back to the cone as `[Sprinkle Event: loose-ends]`:
 | `do`   | `{ id, title, summary, detail }` | User clicks **Do** | Start working the task now, using `detail` as the agent brief (`summary` gives the human framing). The row stays in the list (a "Do" is not a completion). |
 | `done` | `{ id, title }` | User clicks **Done** | The panel already removed the row optimistically. Remove that `id` from `/shared/loose-ends.json` and bump `updated`. No panel round-trip needed. |
 | `open-session` | `{ id, file, at }` | User clicks the **"from &lt;date&gt;"** provenance link | Open the originating transcript at `/sessions/<file>` (e.g. `read_file`) and surface it to the user — the conversation this loose end came from. |
+| `request-load` | `{}` | Panel `init` when it could **not** reach the store itself (neither `slicc.readFile` nor `slicc.exec` worked in the sandbox) | Reseed the panel from the store: `sprinkle send loose-ends '{"action":"load-items","tasks":[ ...store tasks... ]}'` (delegate to the scoop). This is the safety net behind self-hydration. |
 
 > **`done` is optimistic in the panel.** The row disappears the instant the user
 > clicks, then the lick fires. The cone's only job is to make the store match by
@@ -183,9 +184,13 @@ store writes.
 - **No emojis in the UI** — the panel uses Lucide icons (`list-checks`, `check`,
   `arrow-right`), per the SLICC style guide.
 - **Template:** `templates/loose-ends.shtml` (full-document mode). On open it
-  **self-hydrates from the store** — its `init` reads `STORE_PATH`
-  (default `/shared/loose-ends.json`) via `slicc.readFile()` and renders from
-  that, so closing and reopening the sprinkle never empties the list. `slicc.setState`/`getState`
-  is only a same-session fast-path cache. If your store lives elsewhere, change
-  the `STORE_PATH` constant near the top of the script. The store is
-  authoritative — `bootstrap` also reseeds explicitly for good measure.
+  **self-hydrates from the store** so closing + reopening never loses the list.
+  Its `init` reads `STORE_PATH` (default `/shared/loose-ends.json`) — trying
+  `slicc.readFile()` first, then `slicc.exec('cat …')` — and renders from that.
+  If **neither** works in the sandbox, it fires a `request-load` lick and the
+  cone reseeds (see the lick table). `slicc.setState`/`getState` is only a
+  same-session cache and does **not** survive a full close+reopen — that was the
+  original "empty after reopen" bug. **Test hydration with `sprinkle close` +
+  `sprinkle open`, not `sprinkle reload`** (reload keeps the state cache and
+  masks the problem). If your store lives elsewhere, change the `STORE_PATH`
+  constant near the top of the script.

--- a/skills/loose-ends/SKILL.md
+++ b/skills/loose-ends/SKILL.md
@@ -46,6 +46,7 @@ and reseed from the store (see [Resurrecting](#resurrecting-in-a-new-session)).
       "summary": "Human-facing: what this is and why it's still open, in a sentence or two. Always visible on the card.",
       "detail": "Agent-facing: the full working brief — exact next actions, addresses, file paths, links, GUIDs. Collapsed behind an \"Agent brief\" toggle.",
       "created": "2026-07-30T17:15:00Z",
+      "skills": ["sessionize", "gmail"],
       "session": {
         "id": "c20ed555-454d-4bc1-925c-2d11f7e2074d",
         "file": "2026-07-30T17-23-30-891Z-slicc-speaking-talks-and-loose-ends.md",
@@ -61,6 +62,7 @@ and reseed from the store (see [Resurrecting](#resurrecting-in-a-new-session)).
 - **`summary` — human-facing.** The at-a-glance "what & why", always visible. Keep it short and readable.
 - **`detail` — agent-facing.** The full brief the cone acts on: concrete steps, contacts, paths, links. Shown collapsed under an "Agent brief" toggle; can be long.
 - `created` — ISO timestamp (informational; rendered on the card).
+- `skills` — optional `string[]` of the SLICC skills involved (e.g. `["sessionize","gmail"]`). Rendered as tag chips on the card and passed through to the monday item.
 - `session` — provenance into `/sessions/`: `{ id, file, at }` linking the task back to the conversation that spawned it (see [Session provenance](#session-provenance)). Optional.
 - Bump the top-level `updated` on every store write.
 
@@ -174,6 +176,29 @@ persists. To bring the panel back exactly as it was:
 `bootstrap` re-copies the template, reopens the panel, and reseeds every task
 from `/shared/loose-ends.json`. The cone resumes handling `do`/`done` licks and
 store writes.
+
+## Monday integration (source protocol)
+
+Loose ends are open follow-ups, so they belong in the daily `monday` triage. The
+helper exposes a monday-compatible source command:
+
+```bash
+loose-ends monday --limit N --depth N --date Nd   # prints a JSON array to stdout
+```
+
+It reads the store and emits one monday item per task. Notes:
+
+- Each item = `{ id, ts, source:"loose-ends", title, body:<summary>, detail, skills, session, rating_hint }`.
+  `id` is the task id (already stable/unique), `ts` is `created`, `body` is the
+  human summary, and `rating_hint` tells the rater these are user-curated
+  follow-ups carrying real intent (actionable unless the summary says they're
+  waiting on someone else).
+- **`--date` is intentionally ignored** — a loose end from weeks ago is still
+  open, so the whole backlog surfaces (bounded by `--limit`). `--depth` is
+  accepted and ignored.
+- Include it in a run positionally — `monday loose-ends gh gmail` — or add
+  `loose-ends` to `KNOWN_COMMANDS` in `monday/scripts/monday.jsh` for
+  auto-discovery. See `monday/references/SOURCE_PROTOCOL.md`.
 
 ## Notes
 

--- a/skills/loose-ends/SKILL.md
+++ b/skills/loose-ends/SKILL.md
@@ -182,6 +182,10 @@ store writes.
   then `loose-ends reseed`.
 - **No emojis in the UI** — the panel uses Lucide icons (`list-checks`, `check`,
   `arrow-right`), per the SLICC style guide.
-- **Template:** `templates/loose-ends.shtml` (full-document mode). It persists
-  its own view via `slicc.setState`/`getState`, but the store is authoritative —
-  always reseed from `/shared/loose-ends.json` on bootstrap.
+- **Template:** `templates/loose-ends.shtml` (full-document mode). On open it
+  **self-hydrates from the store** — its `init` reads `STORE_PATH`
+  (default `/shared/loose-ends.json`) via `slicc.readFile()` and renders from
+  that, so closing and reopening the sprinkle never empties the list. `slicc.setState`/`getState`
+  is only a same-session fast-path cache. If your store lives elsewhere, change
+  the `STORE_PATH` constant near the top of the script. The store is
+  authoritative — `bootstrap` also reseeds explicitly for good measure.

--- a/skills/loose-ends/SKILL.md
+++ b/skills/loose-ends/SKILL.md
@@ -11,10 +11,13 @@ A durable, cross-session to-do list rendered as a sprinkle panel. Unlike the
 publish/annotate state), loose-ends is a hand-curated backlog of open threads
 the user wants kept in view until they're truly done.
 
-Each task carries a **title** and a free-form **context** blob — the "why it's
-open / what to do next / links" — so a future session (or a future you) can pick
-it up cold. The panel shows the title, an expandable context preview, and two
-buttons: **Do** and **Done**.
+Each task carries a **title**, a human-facing **summary** (the at-a-glance what &
+why), and an agent-facing **detail** brief (the full "what to do next / links"),
+plus a **created** timestamp and optional **session** provenance linking it back
+to the `/sessions/` transcript it came from — so a future session (or a future
+you) can pick it up cold. The panel shows the title and summary, a collapsible
+"Agent brief", a created date, a "from &lt;date&gt;" link to the origin session,
+and two buttons: **Do** and **Done**.
 
 ## Architecture — who owns what
 
@@ -35,13 +38,19 @@ and reseed from the store (see [Resurrecting](#resurrecting-in-a-new-session)).
 
 ```json
 {
-  "updated": "2026-07-30T17:22:24.862Z",
+  "updated": "2026-07-30T18:08:00.000Z",
   "tasks": [
     {
       "id": "le-example",
       "title": "Short imperative title",
-      "context": "The full why/what/links blob. Can be long — the panel truncates a preview and expands on click.",
-      "created": "2026-07-30T17:15:00Z"
+      "summary": "Human-facing: what this is and why it's still open, in a sentence or two. Always visible on the card.",
+      "detail": "Agent-facing: the full working brief — exact next actions, addresses, file paths, links, GUIDs. Collapsed behind an \"Agent brief\" toggle.",
+      "created": "2026-07-30T17:15:00Z",
+      "session": {
+        "id": "c20ed555-454d-4bc1-925c-2d11f7e2074d",
+        "file": "2026-07-30T17-23-30-891Z-slicc-speaking-talks-and-loose-ends.md",
+        "at": "2026-07-30T17:23:30.891Z"
+      }
     }
   ]
 }
@@ -49,10 +58,33 @@ and reseed from the store (see [Resurrecting](#resurrecting-in-a-new-session)).
 
 - `id` — stable, unique, kebab-case (e.g. `le-<slug>`). Upserts key on it.
 - `title` — one-line imperative summary shown in bold.
-- `context` — optional rich text; the panel shows a ~140-char preview with a
-  "more" toggle.
-- `created` — ISO timestamp (informational).
+- **`summary` — human-facing.** The at-a-glance "what & why", always visible. Keep it short and readable.
+- **`detail` — agent-facing.** The full brief the cone acts on: concrete steps, contacts, paths, links. Shown collapsed under an "Agent brief" toggle; can be long.
+- `created` — ISO timestamp (informational; rendered on the card).
+- `session` — provenance into `/sessions/`: `{ id, file, at }` linking the task back to the conversation that spawned it (see [Session provenance](#session-provenance)). Optional.
 - Bump the top-level `updated` on every store write.
+
+> **Back-compat.** Older tasks used a single `context` field (== the agent
+> `detail`) with no `summary`/`session`. The template still reads `context` as a
+> fallback for `detail`, and if there's no `summary` it shows the detail (when
+> short) or hides it behind the brief toggle. Prefer `summary` + `detail` for new
+> tasks.
+
+### Session provenance
+
+Every task can point back to the `/sessions/` transcript it came from. Each
+session file is named `<ISO-ts>-<slug>.md` and indexed in `/sessions/index.json`
+as `{ filename, title, frozenAt, sessionId, ... }`.
+
+- **Resolve a task's origin session by time:** a task `created` at time *T*
+  belongs to the session whose `frozenAt` is the smallest value `>= T` (sessions
+  are sequential; the one frozen just after the task was created was the active
+  one). Populate `session` = `{ id: sessionId, file: filename, at: frozenAt }`.
+- The **live** (unfrozen) session isn't in `index.json` yet, so a task created
+  mid-session may not resolve until that session is frozen — set what you know
+  (`at` = now) and reconcile later with the same rule.
+- On the card, the provenance renders as a **"from &lt;date&gt;"** link; clicking
+  it fires an `open-session` lick (see below).
 
 ## Quick-start / bootstrap
 
@@ -94,7 +126,7 @@ The cone owns the store, so it does two things per change: **write the JSON**
 1. Cone appends/replaces the task in `/shared/loose-ends.json` and bumps `updated`.
 2. Cone → scoop:
    ```
-   feed_scoop("loose-ends", "sprinkle send loose-ends '{\"action\":\"add-item\",\"task\":{\"id\":\"le-foo\",\"title\":\"...\",\"context\":\"...\",\"created\":\"2026-07-30T00:00:00Z\"}}'")
+   feed_scoop("loose-ends", "sprinkle send loose-ends '{\"action\":\"add-item\",\"task\":{\"id\":\"le-foo\",\"title\":\"...\",\"summary\":\"human what & why\",\"detail\":\"agent brief: steps, contacts, paths, links\",\"created\":\"2026-07-30T00:00:00Z\",\"session\":{\"id\":\"...\",\"file\":\"...md\",\"at\":\"...\"}}}'")
    ```
    `add-item` upserts: an existing `id` is replaced in place; a new `id` is
    appended.
@@ -113,8 +145,9 @@ The panel fires these licks back to the cone as `[Sprinkle Event: loose-ends]`:
 
 | Action | Data | When | Cone handler |
 |--------|------|------|--------------|
-| `do`   | `{ id, title, context }` | User clicks **Do** | Start working the task now, using `context` as the brief. The row stays in the list (a "Do" is not a completion). |
+| `do`   | `{ id, title, summary, detail }` | User clicks **Do** | Start working the task now, using `detail` as the agent brief (`summary` gives the human framing). The row stays in the list (a "Do" is not a completion). |
 | `done` | `{ id, title }` | User clicks **Done** | The panel already removed the row optimistically. Remove that `id` from `/shared/loose-ends.json` and bump `updated`. No panel round-trip needed. |
+| `open-session` | `{ id, file, at }` | User clicks the **"from &lt;date&gt;"** provenance link | Open the originating transcript at `/sessions/<file>` (e.g. `read_file`) and surface it to the user — the conversation this loose end came from. |
 
 > **`done` is optimistic in the panel.** The row disappears the instant the user
 > clicks, then the lick fires. The cone's only job is to make the store match by

--- a/skills/loose-ends/scripts/loose-ends.jsh
+++ b/skills/loose-ends/scripts/loose-ends.jsh
@@ -20,6 +20,8 @@
 const exec = require('sliccy:exec');
 const fs = require('fs');
 
+const DEFAULT_STORE = '/shared/loose-ends.json';
+
 // Hand-parse argv: jsh's parseFlags treats single-dash flags as booleans and
 // drops their value, so we only honour explicit --long / --long=value forms.
 function parseArgs(argv) {
@@ -79,7 +81,7 @@ async function main() {
   const cmd = args._[0] || 'bootstrap';
 
   const name = typeof args.name === 'string' ? args.name : 'loose-ends';
-  const storePath = typeof args.store === 'string' ? args.store : '/shared/loose-ends.json';
+  const storePath = typeof args.store === 'string' ? args.store : DEFAULT_STORE;
   const template = typeof args.template === 'string'
     ? args.template
     : '/workspace/skills/loose-ends/templates/loose-ends.shtml';
@@ -95,8 +97,23 @@ async function main() {
       throw new Error(`template not found: ${template} (pass --template <path>)`);
     }
     const dir = `/shared/sprinkles/${name}`;
+    const dest = `${dir}/${name}.shtml`;
     await sh(`mkdir -p ${shellQuote(dir)}`);
-    await sh(`cp ${shellQuote(template)} ${shellQuote(`${dir}/${name}.shtml`)}`);
+    await sh(`cp ${shellQuote(template)} ${shellQuote(dest)}`);
+    // Bake the selected --store into the installed template so the panel's own
+    // self-hydration (STORE_PATH) reads the SAME store as `reseed`. Without this,
+    // a custom --store only affects reseed and the panel reloads the default
+    // store on every close/reopen.
+    if (storePath !== DEFAULT_STORE) {
+      const shtml = fs.readFileSync(dest, 'utf8');
+      const safe = storePath.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+      const patched = shtml.replace(/const STORE_PATH = '[^']*';/, `const STORE_PATH = '${safe}';`);
+      if (patched !== shtml) {
+        fs.writeFileSync(dest, patched);
+      } else {
+        process.stderr.write('loose-ends: warning — could not find STORE_PATH in template to inject --store; panel will hydrate from the template default\n');
+      }
+    }
     await sh(`sprinkle refresh`);
     await sh(`sprinkle open ${shellQuote(name)}`);
     const n = await reseed(name, storePath);

--- a/skills/loose-ends/scripts/loose-ends.jsh
+++ b/skills/loose-ends/scripts/loose-ends.jsh
@@ -1,0 +1,120 @@
+// ─────────────────────────────────────────────────────────────────────────
+//  loose-ends — sprinkle-side bootstrap / reseed helper
+//
+//  Run this from the OWNING SCOOP (the scoop named after the sprinkle). It is
+//  the one process allowed to touch `sprinkle`. The store JSON is authoritative
+//  and cone-owned; this helper only READS it — it never writes tasks.
+//
+//  Commands:
+//    loose-ends bootstrap   Copy the template into the sprinkle dir, refresh the
+//                           VFS, open the panel, then reseed it from the store.
+//    loose-ends reseed      Re-send `load-items` from the store to an
+//                           already-open panel (no template copy / open).
+//
+//  Options (all optional, --long form only — single-dash flags are ignored):
+//    --name <n>       sprinkle + scoop name           (default: loose-ends)
+//    --store <path>   store JSON path                 (default: /shared/loose-ends.json)
+//    --template <p>   template .shtml to install      (default: the skill's templates/loose-ends.shtml)
+// ─────────────────────────────────────────────────────────────────────────
+
+const exec = require('sliccy:exec');
+const fs = require('fs');
+
+// Hand-parse argv: jsh's parseFlags treats single-dash flags as booleans and
+// drops their value, so we only honour explicit --long / --long=value forms.
+function parseArgs(argv) {
+  const out = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith('--')) {
+      const eq = a.indexOf('=');
+      if (eq !== -1) {
+        out[a.slice(2, eq)] = a.slice(eq + 1);
+      } else {
+        const next = argv[i + 1];
+        if (next !== undefined && !next.startsWith('--')) { out[a.slice(2)] = next; i++; }
+        else out[a.slice(2)] = true;
+      }
+    } else {
+      out._.push(a);
+    }
+  }
+  return out;
+}
+
+function shellQuote(s) {
+  return `'${String(s).replace(/'/g, `'\\''`)}'`;
+}
+
+async function sh(cmd) {
+  const r = await exec(cmd);
+  if (r.exitCode !== 0) {
+    throw new Error((r.stderr || r.stdout || `command failed: ${cmd}`).trim());
+  }
+  return (r.stdout || '').trim();
+}
+
+function readStore(storePath) {
+  if (!fs.existsSync(storePath)) return { updated: null, tasks: [] };
+  let data;
+  try {
+    data = JSON.parse(fs.readFileSync(storePath, 'utf8'));
+  } catch (e) {
+    throw new Error(`store at ${storePath} is not valid JSON: ${e.message}`);
+  }
+  if (!data || !Array.isArray(data.tasks)) return { updated: data && data.updated || null, tasks: [] };
+  return data;
+}
+
+async function reseed(name, storePath) {
+  const store = readStore(storePath);
+  const payload = JSON.stringify({ action: 'load-items', tasks: store.tasks });
+  await sh(`sprinkle send ${shellQuote(name)} ${shellQuote(payload)}`);
+  return store.tasks.length;
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const args = parseArgs(argv);
+  const cmd = args._[0] || 'bootstrap';
+
+  const name = typeof args.name === 'string' ? args.name : 'loose-ends';
+  const storePath = typeof args.store === 'string' ? args.store : '/shared/loose-ends.json';
+  const template = typeof args.template === 'string'
+    ? args.template
+    : '/workspace/skills/loose-ends/templates/loose-ends.shtml';
+
+  if (cmd === 'reseed') {
+    const n = await reseed(name, storePath);
+    process.stdout.write(`loose-ends: reseeded '${name}' with ${n} task(s) from ${storePath}\n`);
+    return;
+  }
+
+  if (cmd === 'bootstrap') {
+    if (!fs.existsSync(template)) {
+      throw new Error(`template not found: ${template} (pass --template <path>)`);
+    }
+    const dir = `/shared/sprinkles/${name}`;
+    await sh(`mkdir -p ${shellQuote(dir)}`);
+    await sh(`cp ${shellQuote(template)} ${shellQuote(`${dir}/${name}.shtml`)}`);
+    await sh(`sprinkle refresh`);
+    await sh(`sprinkle open ${shellQuote(name)}`);
+    const n = await reseed(name, storePath);
+    process.stdout.write(
+      `loose-ends: opened '${name}' and loaded ${n} task(s) from ${storePath}\n` +
+      `Stay alive for lick events — do NOT finish.\n`
+    );
+    return;
+  }
+
+  process.stderr.write(
+    `loose-ends: unknown command '${cmd}'\n` +
+    `usage: loose-ends [bootstrap|reseed] [--name <n>] [--store <path>] [--template <path>]\n`
+  );
+  process.exit(1);
+}
+
+await main().catch((e) => {
+  process.stderr.write(`loose-ends: ${e.message}\n`);
+  process.exit(1);
+});

--- a/skills/loose-ends/scripts/loose-ends.jsh
+++ b/skills/loose-ends/scripts/loose-ends.jsh
@@ -107,9 +107,36 @@ async function main() {
     return;
   }
 
+  if (cmd === 'monday') {
+    // monday source protocol: print a JSON array of items to stdout, logs to stderr.
+    // Loose ends are standing follow-ups, so --date is intentionally NOT applied
+    // (an old open loose end is still open); --limit is honoured.
+    const limit = Number(args.limit != null ? args.limit : 50) || 50;
+    const store = readStore(storePath);
+    const RATING_HINT =
+      'This is a user-curated loose end — a follow-up the user explicitly saved to act on later, ' +
+      'so it carries real intent; treat it as actionable unless its summary says it is waiting on ' +
+      'someone else. `body` is the human summary; `detail` is the full agent brief. `skills` lists ' +
+      'the SLICC skills involved. There is no external state, so do not down-rank it as resolved.';
+    const items = store.tasks.slice(0, limit).map((t) => ({
+      id: t.id,
+      ts: t.created || (t.session && t.session.at) || null,
+      source: 'loose-ends',
+      title: t.title || t.id,
+      body: t.summary || t.detail || '',
+      detail: t.detail || t.context || '',
+      skills: Array.isArray(t.skills) ? t.skills : [],
+      session: t.session || null,
+      rating_hint: RATING_HINT,
+    }));
+    process.stderr.write(`[loose-ends] monday: ${items.length} item(s)\n`);
+    process.stdout.write(JSON.stringify(items) + '\n');
+    return;
+  }
+
   process.stderr.write(
     `loose-ends: unknown command '${cmd}'\n` +
-    `usage: loose-ends [bootstrap|reseed] [--name <n>] [--store <path>] [--template <path>]\n`
+    `usage: loose-ends [bootstrap|reseed|monday] [--name <n>] [--store <path>] [--template <path>] [--limit N]\n`
   );
   process.exit(1);
 }

--- a/skills/loose-ends/templates/loose-ends.shtml
+++ b/skills/loose-ends/templates/loose-ends.shtml
@@ -294,7 +294,24 @@ function fmtDate(iso) {
 // ═══════════════════════════════════════════════════
 let tasks = [];
 
-function loadState() {
+// The authoritative store. The panel self-hydrates from this file on open so
+// closing + reopening the sprinkle never loses the list (view state via
+// slicc.setState is only a fast-path cache and does not survive a full reopen).
+// If your store lives elsewhere, change this one constant.
+const STORE_PATH = '/shared/loose-ends.json';
+
+async function loadState() {
+  // 1) Authoritative: read the store file directly.
+  try {
+    if (slicc.readFile) {
+      const txt = await slicc.readFile(STORE_PATH);
+      if (txt) {
+        const data = JSON.parse(txt);
+        if (data && Array.isArray(data.tasks)) { tasks = data.tasks; return; }
+      }
+    }
+  } catch (e) { /* fall through to cached view state */ }
+  // 2) Fallback: last persisted view state (same-session snappiness).
   const saved = slicc.getState && slicc.getState();
   if (saved && Array.isArray(saved.tasks)) tasks = saved.tasks;
 }
@@ -476,8 +493,8 @@ function renderIcons() {
 // ═══════════════════════════════════════════════════
 //  INIT
 // ═══════════════════════════════════════════════════
-(function init() {
-  loadState();
+(async function init() {
+  await loadState();
   renderAll();
 })();
 </script>

--- a/skills/loose-ends/templates/loose-ends.shtml
+++ b/skills/loose-ends/templates/loose-ends.shtml
@@ -160,35 +160,39 @@
       font-size: 12.5px;
       color: var(--s2-fg);
       line-height: 1.35;
-      margin-bottom: 6px;
+      margin-bottom: 5px;
     }
 
-    /* ── Context details/expand ── */
-    .task-context {
+    /* ── Human-facing summary (always visible) ── */
+    .task-summary {
       font-size: 11.5px;
       color: var(--s2-fg-secondary, var(--s2-fg));
+      line-height: 1.5;
+      white-space: pre-wrap;
+    }
+
+    /* ── Agent-facing detail (collapsible) ── */
+    .task-context {
+      font-size: 11.5px;
+      margin-top: 6px;
     }
     .task-context > summary {
       list-style: none;
       cursor: pointer;
-      color: var(--s2-color-detail, rgba(128,128,128,0.8));
-      line-height: 1.45;
       outline: none;
-      display: block;
-    }
-    .task-context > summary::-webkit-details-marker { display: none; }
-    .task-context > summary .preview { display: inline; }
-    .task-context > summary .more,
-    .task-context > summary .less {
+      display: inline-flex;
+      align-items: center;
+      gap: 3px;
       color: var(--s2-accent);
       font-weight: 600;
-      margin-left: 4px;
-      white-space: nowrap;
+      font-size: 10.5px;
     }
-    .task-context > summary .less { display: none; }
-    .task-context[open] > summary .preview { display: none; }
-    .task-context[open] > summary .more { display: none; }
-    .task-context[open] > summary .less { display: inline; }
+    .task-context > summary::-webkit-details-marker { display: none; }
+    .task-context > summary .chev { transition: transform 0.15s ease; }
+    .task-context[open] > summary .chev { transform: rotate(90deg); }
+    .task-context > summary .lbl-close { display: none; }
+    .task-context[open] > summary .lbl-open { display: none; }
+    .task-context[open] > summary .lbl-close { display: inline; }
     /* .full is a sibling of <summary>, so native <details> hides it while
        collapsed and reveals it on open — no duplicated text. */
     .task-context .full {
@@ -196,7 +200,36 @@
       line-height: 1.55;
       white-space: pre-wrap;
       margin-top: 6px;
+      font-size: 11.5px;
     }
+
+    /* ── Meta row: created date + session provenance ── */
+    .task-meta {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-top: 8px;
+      flex-wrap: wrap;
+    }
+    .task-date,
+    .task-session {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      font-size: 10px;
+      color: var(--s2-color-detail, rgba(128,128,128,0.8));
+      line-height: 1;
+    }
+    .task-session {
+      background: none;
+      border: none;
+      padding: 0;
+      cursor: pointer;
+      font-family: inherit;
+    }
+    .task-session:hover { color: var(--s2-accent); }
+    .task-date .sprinkle-icon,
+    .task-session .sprinkle-icon { width: 11px; height: 11px; }
 
     /* ── Actions row ── */
     .task-actions {
@@ -246,6 +279,16 @@ function escHtml(str) {
 
 const PREVIEW_LEN = 140;
 
+// Format an ISO timestamp as e.g. "Jul 30, 2026" (empty string if unparseable).
+function fmtDate(iso) {
+  if (!iso) return '';
+  try {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return '';
+    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  } catch (e) { return ''; }
+}
+
 // ═══════════════════════════════════════════════════
 //  STATE
 // ═══════════════════════════════════════════════════
@@ -288,33 +331,60 @@ function createTaskCard(task) {
   div.className = 'task-item';
   div.dataset.id = task.id;
 
-  const context = task.context || '';
-  const needsTruncate = context.length > PREVIEW_LEN;
-  const preview = needsTruncate ? context.slice(0, PREVIEW_LEN).trimEnd() + '…' : context;
+  // v2 schema: human-facing `summary`, agent-facing `detail`.
+  // Back-compat: older tasks carry `context` (== the agent detail) and no summary.
+  const summary = task.summary || '';
+  const detail  = task.detail || task.context || '';
+  const created = fmtDate(task.created);
+  const session = task.session || null;
 
-  // Lick payloads — encoded with esc(JSON.stringify(obj)).
-  const doData   = esc(JSON.stringify({ action: 'do',   data: { id: task.id, title: task.title, context: task.context } }));
+  // Lick payload — the cone acts on `detail`; `summary` gives it the human framing.
+  const doData = esc(JSON.stringify({ action: 'do', data: {
+    id: task.id, title: task.title, summary, detail
+  } }));
 
-  let contextBlock = '';
-  if (context) {
-    if (needsTruncate) {
-      contextBlock =
-        '<details class="task-context">' +
-          '<summary>' +
-            '<span class="preview">' + escHtml(preview) + '</span>' +
-            '<span class="more">more</span>' +
-            '<span class="less">less</span>' +
-          '</summary>' +
-          '<div class="full">' + escHtml(context) + '</div>' +
-        '</details>';
-    } else {
-      contextBlock = '<div class="task-context"><div class="full" style="margin-top:0;color:var(--s2-fg-secondary,var(--s2-fg))">' + escHtml(context) + '</div></div>';
-    }
+  // If there's no explicit summary, fall back to showing the detail as the
+  // visible line (so nothing is hidden behind the collapsed brief).
+  const visibleText = summary || (detail && detail.length <= 220 ? detail : '');
+  const summaryBlock = visibleText
+    ? '<div class="task-summary">' + escHtml(visibleText) + '</div>'
+    : '';
+
+  // Show the collapsible agent brief only when there's detail AND it isn't
+  // already fully shown as the visible summary line.
+  let detailBlock = '';
+  if (detail && detail !== visibleText) {
+    detailBlock =
+      '<details class="task-context">' +
+        '<summary>' +
+          '<i data-lucide="chevron-right" class="sprinkle-icon sm chev"></i>' +
+          '<span class="lbl-open">Agent brief</span>' +
+          '<span class="lbl-close">Hide brief</span>' +
+        '</summary>' +
+        '<div class="full">' + escHtml(detail) + '</div>' +
+      '</details>';
   }
+
+  // Meta row: created date + session provenance link.
+  let metaInner = '';
+  if (created) {
+    metaInner += '<span class="task-date"><i data-lucide="clock" class="sprinkle-icon sm"></i>' + escHtml(created) + '</span>';
+  }
+  if (session && (session.file || session.id)) {
+    const sessData = esc(JSON.stringify({ action: 'open-session', data: {
+      id: session.id || '', file: session.file || '', at: session.at || ''
+    } }));
+    const sessLabel = session.at ? fmtDate(session.at) : (session.file ? session.file.slice(0, 10) : 'session');
+    metaInner += '<button class="task-session" onclick="slicc.lick(' + sessData + ')" title="Open the session this came from">' +
+      '<i data-lucide="history" class="sprinkle-icon sm"></i>from ' + escHtml(sessLabel) + '</button>';
+  }
+  const metaBlock = metaInner ? '<div class="task-meta">' + metaInner + '</div>' : '';
 
   div.innerHTML =
     '<div class="task-title">' + escHtml(task.title || task.id || '') + '</div>' +
-    contextBlock +
+    summaryBlock +
+    detailBlock +
+    metaBlock +
     '<div class="task-actions">' +
       '<button class="sprinkle-btn sprinkle-btn--primary" onclick="slicc.lick(' + doData + ')">' +
         '<i data-lucide="arrow-right" class="sprinkle-icon sm"></i> Do' +

--- a/skills/loose-ends/templates/loose-ends.shtml
+++ b/skills/loose-ends/templates/loose-ends.shtml
@@ -178,27 +178,24 @@
     }
     .task-context > summary::-webkit-details-marker { display: none; }
     .task-context > summary .preview { display: inline; }
-    .task-context > summary .more {
+    .task-context > summary .more,
+    .task-context > summary .less {
       color: var(--s2-accent);
       font-weight: 600;
       margin-left: 4px;
       white-space: nowrap;
     }
+    .task-context > summary .less { display: none; }
     .task-context[open] > summary .preview { display: none; }
     .task-context[open] > summary .more { display: none; }
+    .task-context[open] > summary .less { display: inline; }
+    /* .full is a sibling of <summary>, so native <details> hides it while
+       collapsed and reveals it on open — no duplicated text. */
     .task-context .full {
       color: var(--s2-fg);
       line-height: 1.55;
       white-space: pre-wrap;
-      margin-top: 2px;
-    }
-    .task-context .collapse {
-      display: inline-block;
       margin-top: 6px;
-      color: var(--s2-accent);
-      font-weight: 600;
-      font-size: 11px;
-      cursor: pointer;
     }
 
     /* ── Actions row ── */
@@ -306,11 +303,12 @@ function createTaskCard(task) {
           '<summary>' +
             '<span class="preview">' + escHtml(preview) + '</span>' +
             '<span class="more">more</span>' +
-            '<span class="full">' + escHtml(context) + '</span>' +
+            '<span class="less">less</span>' +
           '</summary>' +
+          '<div class="full">' + escHtml(context) + '</div>' +
         '</details>';
     } else {
-      contextBlock = '<div class="task-context"><span class="full" style="color:var(--s2-fg-secondary,var(--s2-fg))">' + escHtml(context) + '</span></div>';
+      contextBlock = '<div class="task-context"><div class="full" style="margin-top:0;color:var(--s2-fg-secondary,var(--s2-fg))">' + escHtml(context) + '</div></div>';
     }
   }
 

--- a/skills/loose-ends/templates/loose-ends.shtml
+++ b/skills/loose-ends/templates/loose-ends.shtml
@@ -1,0 +1,418 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Loose ends</title>
+  <link rel="icon" href="list-checks" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--s2-font-family, system-ui, sans-serif);
+      background: var(--s2-bg-base);
+      color: var(--s2-fg);
+      font-size: 13px;
+      line-height: 1.5;
+      overflow-x: hidden;
+    }
+
+    #app {
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+      overflow: hidden;
+    }
+
+    /* ── Top bar ── */
+    .top-bar {
+      display: flex;
+      align-items: center;
+      gap: var(--s2-spacing-100, 8px);
+      padding: 10px var(--s2-spacing-200, 12px);
+      background: var(--s2-bg-elevated);
+      border-bottom: 1px solid color-mix(in srgb, var(--s2-fg) 8%, transparent);
+      flex-shrink: 0;
+      min-height: 44px;
+    }
+    .top-bar-title {
+      font-weight: 600;
+      font-size: 13px;
+      flex: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      color: var(--s2-fg);
+    }
+
+    /* ── Pill count badge ── */
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 18px;
+      height: 18px;
+      padding: 0 6px;
+      border-radius: 999px;
+      font-size: 10px;
+      font-weight: 700;
+      background: color-mix(in srgb, var(--s2-accent) 15%, transparent);
+      color: var(--s2-accent);
+      line-height: 1;
+      flex-shrink: 0;
+    }
+    .badge.zero { display: none; }
+
+    /* ── Buttons ── */
+    .sprinkle-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 5px;
+      border-radius: var(--s2-radius-pill, 999px);
+      border: none;
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 12px;
+      font-weight: 500;
+      padding: 5px 11px;
+      transition: opacity 0.15s, background 0.15s, box-shadow 0.15s;
+      white-space: nowrap;
+      line-height: 1.3;
+    }
+    .sprinkle-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+    .sprinkle-btn--primary {
+      background: var(--s2-accent);
+      color: var(--s2-bg-base);
+    }
+    .sprinkle-btn--primary:not(:disabled):hover { opacity: 0.88; }
+    .sprinkle-btn--positive {
+      background: color-mix(in srgb, var(--s2-positive) 12%, transparent);
+      color: var(--s2-positive);
+    }
+    .sprinkle-btn--positive:not(:disabled):hover {
+      background: color-mix(in srgb, var(--s2-positive) 22%, transparent);
+    }
+
+    /* ── Icons ── */
+    .sprinkle-icon {
+      width: 14px;
+      height: 14px;
+      stroke-width: 2;
+      flex-shrink: 0;
+    }
+    .sprinkle-icon.sm { width: 12px; height: 12px; }
+    .sprinkle-icon.lg { width: 16px; height: 16px; }
+
+    /* ── Typography ── */
+    .sprinkle-detail {
+      font-size: 11px;
+      color: var(--s2-color-detail, rgba(128,128,128,0.8));
+    }
+
+    /* ── List scroll ── */
+    #list-scroll {
+      flex: 1;
+      overflow-y: auto;
+      padding: 8px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    #list-scroll::-webkit-scrollbar { width: 4px; }
+    #list-scroll::-webkit-scrollbar-track { background: transparent; }
+    #list-scroll::-webkit-scrollbar-thumb {
+      background: color-mix(in srgb, var(--s2-fg) 15%, transparent);
+      border-radius: 2px;
+    }
+
+    /* ── Empty state ── */
+    .empty-state {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      padding: 48px 20px;
+      color: var(--s2-fg-secondary, var(--s2-fg));
+      opacity: 0.55;
+      text-align: center;
+    }
+    .empty-state .sprinkle-icon { width: 32px; height: 32px; opacity: 0.5; }
+
+    /* ── Task card ── */
+    .task-item {
+      background: var(--s2-bg-elevated);
+      border-radius: var(--s2-radius-l, 10px);
+      box-shadow: var(--s2-shadow-container);
+      overflow: hidden;
+      transition: box-shadow 0.15s, opacity 0.25s ease, transform 0.25s ease;
+      padding: 10px 12px 8px;
+    }
+    .task-item:hover { box-shadow: var(--s2-shadow-elevated); }
+    .task-item.leaving {
+      opacity: 0;
+      transform: translateX(16px);
+    }
+
+    .task-title {
+      font-weight: 600;
+      font-size: 12.5px;
+      color: var(--s2-fg);
+      line-height: 1.35;
+      margin-bottom: 6px;
+    }
+
+    /* ── Context details/expand ── */
+    .task-context {
+      font-size: 11.5px;
+      color: var(--s2-fg-secondary, var(--s2-fg));
+    }
+    .task-context > summary {
+      list-style: none;
+      cursor: pointer;
+      color: var(--s2-color-detail, rgba(128,128,128,0.8));
+      line-height: 1.45;
+      outline: none;
+      display: block;
+    }
+    .task-context > summary::-webkit-details-marker { display: none; }
+    .task-context > summary .preview { display: inline; }
+    .task-context > summary .more {
+      color: var(--s2-accent);
+      font-weight: 600;
+      margin-left: 4px;
+      white-space: nowrap;
+    }
+    .task-context[open] > summary .preview { display: none; }
+    .task-context[open] > summary .more { display: none; }
+    .task-context .full {
+      color: var(--s2-fg);
+      line-height: 1.55;
+      white-space: pre-wrap;
+      margin-top: 2px;
+    }
+    .task-context .collapse {
+      display: inline-block;
+      margin-top: 6px;
+      color: var(--s2-accent);
+      font-weight: 600;
+      font-size: 11px;
+      cursor: pointer;
+    }
+
+    /* ── Actions row ── */
+    .task-actions {
+      display: flex;
+      gap: 6px;
+      align-items: center;
+      margin-top: 10px;
+    }
+  </style>
+</head>
+<body>
+<div id="app">
+  <div class="top-bar">
+    <i data-lucide="list-checks" class="sprinkle-icon lg"></i>
+    <span class="top-bar-title">Loose ends</span>
+    <span id="count-badge" class="badge zero">0</span>
+  </div>
+  <div id="list-scroll">
+    <div class="empty-state" id="empty-state">
+      <i data-lucide="check-check" class="sprinkle-icon"></i>
+      <span class="sprinkle-detail">No loose ends — all clear.</span>
+    </div>
+  </div>
+</div>
+
+<script>
+// ═══════════════════════════════════════════════════
+//  ESCAPING HELPERS
+//  esc()  — attribute-safe encoding. We build lick-data
+//  objects with esc(JSON.stringify(obj)); the JSON is valid
+//  JS and &quot; decodes in-attribute. Do NOT double-stringify.
+// ═══════════════════════════════════════════════════
+function esc(str) {
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+function escHtml(str) {
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+const PREVIEW_LEN = 140;
+
+// ═══════════════════════════════════════════════════
+//  STATE
+// ═══════════════════════════════════════════════════
+let tasks = [];
+
+function loadState() {
+  const saved = slicc.getState && slicc.getState();
+  if (saved && Array.isArray(saved.tasks)) tasks = saved.tasks;
+}
+function saveState() {
+  if (slicc.setState) slicc.setState({ tasks });
+}
+
+// ═══════════════════════════════════════════════════
+//  RENDER
+// ═══════════════════════════════════════════════════
+function updateCount() {
+  const badge = document.getElementById('count-badge');
+  const n = tasks.length;
+  badge.textContent = n;
+  badge.className = 'badge' + (n === 0 ? ' zero' : '');
+}
+
+function updateEmptyState() {
+  const empty = document.getElementById('empty-state');
+  empty.style.display = tasks.length === 0 ? 'flex' : 'none';
+}
+
+function renderAll() {
+  const scroll = document.getElementById('list-scroll');
+  [...scroll.querySelectorAll('.task-item')].forEach(el => el.remove());
+  tasks.forEach(t => scroll.appendChild(createTaskCard(t)));
+  updateCount();
+  updateEmptyState();
+  renderIcons();
+}
+
+function createTaskCard(task) {
+  const div = document.createElement('div');
+  div.className = 'task-item';
+  div.dataset.id = task.id;
+
+  const context = task.context || '';
+  const needsTruncate = context.length > PREVIEW_LEN;
+  const preview = needsTruncate ? context.slice(0, PREVIEW_LEN).trimEnd() + '…' : context;
+
+  // Lick payloads — encoded with esc(JSON.stringify(obj)).
+  const doData   = esc(JSON.stringify({ action: 'do',   data: { id: task.id, title: task.title, context: task.context } }));
+
+  let contextBlock = '';
+  if (context) {
+    if (needsTruncate) {
+      contextBlock =
+        '<details class="task-context">' +
+          '<summary>' +
+            '<span class="preview">' + escHtml(preview) + '</span>' +
+            '<span class="more">more</span>' +
+            '<span class="full">' + escHtml(context) + '</span>' +
+          '</summary>' +
+        '</details>';
+    } else {
+      contextBlock = '<div class="task-context"><span class="full" style="color:var(--s2-fg-secondary,var(--s2-fg))">' + escHtml(context) + '</span></div>';
+    }
+  }
+
+  div.innerHTML =
+    '<div class="task-title">' + escHtml(task.title || task.id || '') + '</div>' +
+    contextBlock +
+    '<div class="task-actions">' +
+      '<button class="sprinkle-btn sprinkle-btn--primary" onclick="slicc.lick(' + doData + ')">' +
+        '<i data-lucide="arrow-right" class="sprinkle-icon sm"></i> Do' +
+      '</button>' +
+      '<button class="sprinkle-btn sprinkle-btn--positive done-btn">' +
+        '<i data-lucide="check" class="sprinkle-icon sm"></i> Done' +
+      '</button>' +
+    '</div>';
+
+  // Done: OPTIMISTIC removal first, then emit the lick.
+  const doneBtn = div.querySelector('.done-btn');
+  doneBtn.addEventListener('click', () => {
+    doneBtn.disabled = true;
+    // 1) Optimistically remove the row + update model/count/empty-state.
+    removeTaskById(task.id, true);
+    // 2) THEN notify the cone.
+    slicc.lick({ action: 'done', data: { id: task.id, title: task.title } });
+  });
+
+  return div;
+}
+
+// Remove a task from the model + DOM (with a small leave animation).
+function removeTaskById(id, animate) {
+  const idx = tasks.findIndex(t => t.id === id);
+  if (idx !== -1) tasks.splice(idx, 1);
+  saveState();
+
+  const scroll = document.getElementById('list-scroll');
+  const el = [...scroll.querySelectorAll('.task-item')].find(n => n.dataset.id === id);
+  const finalize = () => { updateCount(); updateEmptyState(); };
+  if (el) {
+    if (animate) {
+      el.classList.add('leaving');
+      setTimeout(() => { el.remove(); finalize(); }, 250);
+    } else {
+      el.remove();
+      finalize();
+    }
+  } else {
+    finalize();
+  }
+}
+
+// ═══════════════════════════════════════════════════
+//  SLICC EVENTS (inbound from the cone via `sprinkle send`)
+// ═══════════════════════════════════════════════════
+slicc.on('update', (msg) => {
+  if (!msg || !msg.action) return;
+
+  if (msg.action === 'load-items') {
+    tasks = Array.isArray(msg.tasks) ? msg.tasks.slice() : [];
+    saveState();
+    renderAll();
+  }
+
+  else if (msg.action === 'add-item') {
+    if (msg.task && msg.task.id) {
+      const existing = tasks.findIndex(t => t.id === msg.task.id);
+      if (existing !== -1) tasks[existing] = msg.task;
+      else tasks.push(msg.task);
+      saveState();
+      const scroll = document.getElementById('list-scroll');
+      // If it already had a card (upsert), re-render fully; else append.
+      if (existing !== -1) {
+        renderAll();
+      } else {
+        scroll.appendChild(createTaskCard(msg.task));
+        updateCount();
+        updateEmptyState();
+        renderIcons();
+      }
+    }
+  }
+
+  else if (msg.action === 'remove-item') {
+    if (msg.id) removeTaskById(msg.id, false);
+  }
+});
+
+// ═══════════════════════════════════════════════════
+//  ICON RENDER HELPER
+// ═══════════════════════════════════════════════════
+function renderIcons() {
+  if (typeof LucideIcons !== 'undefined' && LucideIcons.render) LucideIcons.render();
+  if (window.LucideIcons) window.LucideIcons.render();
+}
+
+// ═══════════════════════════════════════════════════
+//  INIT
+// ═══════════════════════════════════════════════════
+(function init() {
+  loadState();
+  renderAll();
+})();
+</script>
+<script>if (window.LucideIcons) window.LucideIcons.render();</script>
+</body>
+</html>

--- a/skills/loose-ends/templates/loose-ends.shtml
+++ b/skills/loose-ends/templates/loose-ends.shtml
@@ -11,13 +11,19 @@
     body {
       font-family: var(--s2-font-family, system-ui, sans-serif);
       background: var(--s2-bg-base);
-      color: var(--s2-fg);
+      color: var(--fg);
       font-size: 13px;
       line-height: 1.5;
       overflow-x: hidden;
     }
 
     #app {
+      /* Robust theme tokens: prefer the canonical S2 content token, then the
+         legacy alias — so text stays readable in light AND dark mode. */
+      --fg: var(--s2-content-default, var(--s2-fg));
+      --fg-muted: color-mix(in srgb, var(--fg) 60%, transparent);
+      --fg-faint: color-mix(in srgb, var(--fg) 42%, transparent);
+      --line: color-mix(in srgb, var(--fg) 12%, transparent);
       display: flex;
       flex-direction: column;
       height: 100vh;
@@ -29,12 +35,12 @@
       display: flex;
       align-items: center;
       gap: var(--s2-spacing-100, 8px);
-      padding: 10px var(--s2-spacing-200, 12px);
-      background: var(--s2-bg-elevated);
-      border-bottom: 1px solid color-mix(in srgb, var(--s2-fg) 8%, transparent);
+      padding: 11px 14px;
+      border-bottom: 1px solid var(--line);
       flex-shrink: 0;
       min-height: 44px;
     }
+    .top-bar > .sprinkle-icon { color: var(--fg-muted); }
     .top-bar-title {
       font-weight: 600;
       font-size: 13px;
@@ -42,7 +48,7 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      color: var(--s2-fg);
+      color: var(--fg);
     }
 
     /* ── Pill count badge ── */
@@ -53,45 +59,47 @@
       min-width: 18px;
       height: 18px;
       padding: 0 6px;
-      border-radius: 999px;
+      border-radius: var(--s2-radius-pill, 9999px);
       font-size: 10px;
       font-weight: 700;
-      background: color-mix(in srgb, var(--s2-accent) 15%, transparent);
-      color: var(--s2-accent);
+      background: color-mix(in srgb, var(--fg) 10%, transparent);
+      color: var(--fg-muted);
       line-height: 1;
       flex-shrink: 0;
     }
     .badge.zero { display: none; }
 
-    /* ── Buttons ── */
+    /* ── Buttons (the only rounded elements — S2 mandates pill buttons) ── */
     .sprinkle-btn {
       display: inline-flex;
       align-items: center;
       justify-content: center;
       gap: 5px;
-      border-radius: var(--s2-radius-pill, 999px);
-      border: none;
+      border-radius: var(--s2-radius-pill, 9999px);
+      border: 1px solid transparent;
       cursor: pointer;
       font-family: inherit;
       font-size: 12px;
       font-weight: 500;
-      padding: 5px 11px;
-      transition: opacity 0.15s, background 0.15s, box-shadow 0.15s;
+      padding: 5px 12px;
+      transition: background 0.15s, opacity 0.15s, border-color 0.15s;
       white-space: nowrap;
       line-height: 1.3;
     }
     .sprinkle-btn:disabled { opacity: 0.4; cursor: not-allowed; }
     .sprinkle-btn--primary {
       background: var(--s2-accent);
-      color: var(--s2-bg-base);
+      color: var(--s2-gray-25, var(--s2-bg-base));
     }
     .sprinkle-btn--primary:not(:disabled):hover { opacity: 0.88; }
-    .sprinkle-btn--positive {
-      background: color-mix(in srgb, var(--s2-positive) 12%, transparent);
-      color: var(--s2-positive);
+    .sprinkle-btn--ghost {
+      background: transparent;
+      color: var(--fg-muted);
+      border-color: var(--line);
     }
-    .sprinkle-btn--positive:not(:disabled):hover {
-      background: color-mix(in srgb, var(--s2-positive) 22%, transparent);
+    .sprinkle-btn--ghost:not(:disabled):hover {
+      background: color-mix(in srgb, var(--fg) 6%, transparent);
+      color: var(--fg);
     }
 
     /* ── Icons ── */
@@ -107,22 +115,19 @@
     /* ── Typography ── */
     .sprinkle-detail {
       font-size: 11px;
-      color: var(--s2-color-detail, rgba(128,128,128,0.8));
+      color: var(--fg-muted);
     }
 
     /* ── List scroll ── */
     #list-scroll {
       flex: 1;
       overflow-y: auto;
-      padding: 8px;
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
+      padding: 2px 0 24px;
     }
     #list-scroll::-webkit-scrollbar { width: 4px; }
     #list-scroll::-webkit-scrollbar-track { background: transparent; }
     #list-scroll::-webkit-scrollbar-thumb {
-      background: color-mix(in srgb, var(--s2-fg) 15%, transparent);
+      background: color-mix(in srgb, var(--fg) 15%, transparent);
       border-radius: 2px;
     }
 
@@ -134,22 +139,19 @@
       justify-content: center;
       gap: 8px;
       padding: 48px 20px;
-      color: var(--s2-fg-secondary, var(--s2-fg));
-      opacity: 0.55;
+      color: var(--fg-muted);
       text-align: center;
     }
-    .empty-state .sprinkle-icon { width: 32px; height: 32px; opacity: 0.5; }
+    .empty-state .sprinkle-icon { width: 32px; height: 32px; color: var(--fg-faint); }
 
-    /* ── Task card ── */
+    /* ── Task row (flat — separated by hairline dividers, no card/shadow) ── */
     .task-item {
-      background: var(--s2-bg-elevated);
-      border-radius: var(--s2-radius-l, 10px);
-      box-shadow: var(--s2-shadow-container);
-      overflow: hidden;
-      transition: box-shadow 0.15s, opacity 0.25s ease, transform 0.25s ease;
-      padding: 10px 12px 8px;
+      padding: 13px 14px;
+      border-bottom: 1px solid var(--line);
+      transition: opacity 0.25s ease, transform 0.25s ease, background 0.12s;
     }
-    .task-item:hover { box-shadow: var(--s2-shadow-elevated); }
+    .task-item:last-child { border-bottom: none; }
+    .task-item:hover { background: color-mix(in srgb, var(--fg) 3.5%, transparent); }
     .task-item.leaving {
       opacity: 0;
       transform: translateX(16px);
@@ -157,23 +159,44 @@
 
     .task-title {
       font-weight: 600;
-      font-size: 12.5px;
-      color: var(--s2-fg);
+      font-size: 13px;
+      color: var(--fg);
       line-height: 1.35;
-      margin-bottom: 5px;
+      margin-bottom: 3px;
     }
 
     /* ── Human-facing summary (always visible) ── */
     .task-summary {
-      font-size: 11.5px;
-      color: var(--s2-fg-secondary, var(--s2-fg));
+      font-size: 12px;
+      color: var(--fg-muted);
       line-height: 1.5;
       white-space: pre-wrap;
     }
 
-    /* ── Agent-facing detail (collapsible) ── */
+    /* ── Skill tags ── */
+    .task-tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 5px;
+      margin-top: 8px;
+    }
+    .task-tag {
+      display: inline-flex;
+      align-items: center;
+      gap: 3px;
+      font-size: 10px;
+      font-weight: 500;
+      padding: 2px 8px;
+      border-radius: var(--s2-radius-pill, 9999px);
+      background: color-mix(in srgb, var(--s2-accent) 12%, transparent);
+      color: var(--s2-accent);
+      line-height: 1.5;
+    }
+    .task-tag .sprinkle-icon { width: 9px; height: 9px; opacity: 0.8; }
+
+    /* ── Agent-facing detail (collapsible, offset by a rule — not a box) ── */
     .task-context {
-      font-size: 11.5px;
+      font-size: 12px;
       margin-top: 6px;
     }
     .task-context > summary {
@@ -184,8 +207,8 @@
       align-items: center;
       gap: 3px;
       color: var(--s2-accent);
-      font-weight: 600;
-      font-size: 10.5px;
+      font-weight: 500;
+      font-size: 11px;
     }
     .task-context > summary::-webkit-details-marker { display: none; }
     .task-context > summary .chev { transition: transform 0.15s ease; }
@@ -196,19 +219,21 @@
     /* .full is a sibling of <summary>, so native <details> hides it while
        collapsed and reveals it on open — no duplicated text. */
     .task-context .full {
-      color: var(--s2-fg);
+      color: var(--fg);
       line-height: 1.55;
       white-space: pre-wrap;
       margin-top: 6px;
-      font-size: 11.5px;
+      padding-left: 10px;
+      border-left: 2px solid var(--line);
+      font-size: 12px;
     }
 
     /* ── Meta row: created date + session provenance ── */
     .task-meta {
       display: flex;
       align-items: center;
-      gap: 12px;
-      margin-top: 8px;
+      gap: 14px;
+      margin-top: 9px;
       flex-wrap: wrap;
     }
     .task-date,
@@ -216,8 +241,8 @@
       display: inline-flex;
       align-items: center;
       gap: 4px;
-      font-size: 10px;
-      color: var(--s2-color-detail, rgba(128,128,128,0.8));
+      font-size: 10.5px;
+      color: var(--fg-faint);
       line-height: 1;
     }
     .task-session {
@@ -236,7 +261,7 @@
       display: flex;
       gap: 6px;
       align-items: center;
-      margin-top: 10px;
+      margin-top: 11px;
     }
   </style>
 </head>
@@ -300,19 +325,37 @@ let tasks = [];
 // If your store lives elsewhere, change this one constant.
 const STORE_PATH = '/shared/loose-ends.json';
 
+// A hanging bridge call must never stall init. Some SLICC builds have had
+// slicc.readFile() hang (never settle) inside a sprinkle sandbox, so every
+// async read is guarded by a timeout race; a timed-out read falls through to
+// the next mechanism.
+const READ_TIMEOUT = Symbol('read-timeout');
+function withTimeout(promise, ms) {
+  return Promise.race([
+    promise,
+    new Promise(function (resolve) { setTimeout(function () { resolve(READ_TIMEOUT); }, ms); })
+  ]);
+}
+function delay(ms) { return new Promise(function (r) { setTimeout(r, ms); }); }
 async function readStoreText() {
-  // Try the direct VFS read first; fall back to the worker-shell `cat`
-  // (same jsh runtime that can always reach /shared/). Whichever works.
+  // On some SLICC builds (6.0.2) the FIRST worker-shell bridge call made right
+  // after a sprinkle opens hangs (never settles) while the bridge warms up;
+  // subsequent calls succeed. So retry a few times — a hung attempt is
+  // abandoned by the timeout, and the next one lands once the bridge is warm.
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      if (slicc.exec) {
+        const r = await withTimeout(slicc.exec('cat ' + STORE_PATH), 1200);
+        if (r !== READ_TIMEOUT && r && r.exitCode === 0 && typeof r.stdout === 'string' && r.stdout) return r.stdout;
+      }
+    } catch (e) { /* retry */ }
+    await delay(150);
+  }
+  // Last resort: direct VFS read, timeout-guarded (slicc.readFile can hang too).
   try {
     if (slicc.readFile) {
-      const t = await slicc.readFile(STORE_PATH);
-      if (t) return t;
-    }
-  } catch (e) { /* try next mechanism */ }
-  try {
-    if (slicc.exec) {
-      const r = await slicc.exec('cat ' + STORE_PATH);
-      if (r && r.exitCode === 0 && r.stdout) return r.stdout;
+      const t = await withTimeout(slicc.readFile(STORE_PATH), 1200);
+      if (t !== READ_TIMEOUT && typeof t === 'string' && t) return t;
     }
   } catch (e) { /* fall through */ }
   return null;
@@ -373,7 +416,7 @@ function createTaskCard(task) {
 
   // Lick payload — the cone acts on `detail`; `summary` gives it the human framing.
   const doData = esc(JSON.stringify({ action: 'do', data: {
-    id: task.id, title: task.title, summary, detail
+    id: task.id, title: task.title, summary, detail, skills: task.skills || []
   } }));
 
   // If there's no explicit summary, fall back to showing the detail as the
@@ -382,6 +425,16 @@ function createTaskCard(task) {
   const summaryBlock = visibleText
     ? '<div class="task-summary">' + escHtml(visibleText) + '</div>'
     : '';
+
+  // Skill tags — the SLICC skills involved in the task.
+  let tagsBlock = '';
+  if (Array.isArray(task.skills) && task.skills.length) {
+    tagsBlock = '<div class="task-tags">' +
+      task.skills.map(function (s) {
+        return '<span class="task-tag"><i data-lucide="tag" class="sprinkle-icon"></i>' + escHtml(s) + '</span>';
+      }).join('') +
+      '</div>';
+  }
 
   // Show the collapsible agent brief only when there's detail AND it isn't
   // already fully shown as the visible summary line.
@@ -416,13 +469,14 @@ function createTaskCard(task) {
   div.innerHTML =
     '<div class="task-title">' + escHtml(task.title || task.id || '') + '</div>' +
     summaryBlock +
+    tagsBlock +
     detailBlock +
     metaBlock +
     '<div class="task-actions">' +
       '<button class="sprinkle-btn sprinkle-btn--primary" onclick="slicc.lick(' + doData + ')">' +
         '<i data-lucide="arrow-right" class="sprinkle-icon sm"></i> Do' +
       '</button>' +
-      '<button class="sprinkle-btn sprinkle-btn--positive done-btn">' +
+      '<button class="sprinkle-btn sprinkle-btn--ghost done-btn">' +
         '<i data-lucide="check" class="sprinkle-icon sm"></i> Done' +
       '</button>' +
     '</div>';

--- a/skills/loose-ends/templates/loose-ends.shtml
+++ b/skills/loose-ends/templates/loose-ends.shtml
@@ -300,20 +300,36 @@ let tasks = [];
 // If your store lives elsewhere, change this one constant.
 const STORE_PATH = '/shared/loose-ends.json';
 
-async function loadState() {
-  // 1) Authoritative: read the store file directly.
+async function readStoreText() {
+  // Try the direct VFS read first; fall back to the worker-shell `cat`
+  // (same jsh runtime that can always reach /shared/). Whichever works.
   try {
     if (slicc.readFile) {
-      const txt = await slicc.readFile(STORE_PATH);
-      if (txt) {
-        const data = JSON.parse(txt);
-        if (data && Array.isArray(data.tasks)) { tasks = data.tasks; return; }
-      }
+      const t = await slicc.readFile(STORE_PATH);
+      if (t) return t;
     }
-  } catch (e) { /* fall through to cached view state */ }
-  // 2) Fallback: last persisted view state (same-session snappiness).
+  } catch (e) { /* try next mechanism */ }
+  try {
+    if (slicc.exec) {
+      const r = await slicc.exec('cat ' + STORE_PATH);
+      if (r && r.exitCode === 0 && r.stdout) return r.stdout;
+    }
+  } catch (e) { /* fall through */ }
+  return null;
+}
+
+// Returns 'store' if hydrated from the authoritative store, else 'fallback'.
+async function loadState() {
+  const txt = await readStoreText();
+  if (txt) {
+    try {
+      const data = JSON.parse(txt);
+      if (data && Array.isArray(data.tasks)) { tasks = data.tasks; return 'store'; }
+    } catch (e) { /* corrupt/partial — fall through */ }
+  }
   const saved = slicc.getState && slicc.getState();
   if (saved && Array.isArray(saved.tasks)) tasks = saved.tasks;
+  return 'fallback';
 }
 function saveState() {
   if (slicc.setState) slicc.setState({ tasks });
@@ -494,8 +510,14 @@ function renderIcons() {
 //  INIT
 // ═══════════════════════════════════════════════════
 (async function init() {
-  await loadState();
+  const src = await loadState();
   renderAll();
+  // Safety net: if we could NOT reach the authoritative store (neither
+  // slicc.readFile nor slicc.exec worked in this sandbox), ask the cone to
+  // push the list. The cone answers `request-load` with a load-items message.
+  if (src !== 'store') {
+    try { if (slicc.lick) slicc.lick({ action: 'request-load' }); } catch (e) {}
+  }
 })();
 </script>
 <script>if (window.LucideIcons) window.LucideIcons.render();</script>


### PR DESCRIPTION
Packages the ad-hoc **loose-ends** to-do sprinkle into a proper installable skill, modeled on the `review` skill.

### What's included
- **`SKILL.md`** — purpose; store schema `{updated, tasks:[{id,title,context,created}]}`; the two-owner architecture (cone owns `/shared/loose-ends.json`, scoop owns the sprinkle); the scoop-owns-sprinkle rule; resurrect-in-a-new-session steps; the two lick payloads `do{id,title,context}` and `done{id,title}`; the inbound messages `load-items` / `add-item` (upsert by id) / `remove-item`.
- **`templates/loose-ends.shtml`** — the generic, full-document panel (Lucide icons, no personal paths or data). Two actions per row: **Do** (hand to the cone) and **Done** (optimistic remove).
- **`scripts/loose-ends.jsh`** — a small scoop-side helper: `loose-ends bootstrap` copies the template, refreshes the VFS, opens the panel, and reseeds from the store in one step; `loose-ends reseed` re-sends `load-items`. Read-only on the store (store writes stay the cone's job). `--name` / `--store` / `--template` overrides.

### Bootstrap in one step
```
scoop_scoop("loose-ends")
feed_scoop("loose-ends", "Run: loose-ends bootstrap — then stay alive for lick events, do NOT finish.")
```

Draft while it's dogfooded against the live loose-ends panel.

> Please do **not** squash on merge (merge commit or rebase preferred).

— Sliccy 🍦
