### PR TITLE
feat(loose-ends): add snooze (panel + CLI)

### DIFF
--- a/skills/loose-ends/SKILL.md
+++ b/skills/loose-ends/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: loose-ends
-description: "A persistent to-do / follow-up list that lives in a sprinkle panel alongside the chat. Use when the user wants to track loose ends, open follow-ups, waiting-on-others items, or 'things I still need to do' across sessions — a durable backlog the cone maintains and resurfaces. Each item has a title and a rich context blob (why it's open, what to do, links). The panel offers two actions per row: 'Do' (hand the item to the cone to work on now) and 'Done' (remove it). Triggers on 'loose ends', 'my to-do list', 'open follow-ups', 'things I still need to do', 'track this for later', 'add a loose end', 'what's still open'."
+description: "A persistent to-do / follow-up list that lives in a sprinkle panel alongside the chat. Use when the user wants to track loose ends, open follow-ups, waiting-on-others items, or 'things I still need to do' across sessions — a durable backlog the cone maintains and resurfaces. Each item has a title and a rich context blob (why it's open, what to do, links). The panel offers three actions per row: 'Do' (hand the item to the cone to work on now), 'Snooze' (hide it until Tomorrow / Next Monday / Next week / a picked date, then auto-resurface), and 'Done' (remove it). Triggers on 'loose ends', 'my to-do list', 'open follow-ups', 'things I still need to do', 'track this for later', 'add a loose end', 'snooze this until', 'mute until Monday', 'what's still open'."
 allowed-tools: bash
 ---
 
@@ -21,18 +21,44 @@ and two buttons: **Do** and **Done**.
 
 ## Architecture — who owns what
 
-Two owners, one authoritative file. Keep them separate:
+Two concerns, one authoritative file. Keep the *lifecycle* concerns separate,
+but mutate through one API:
 
-- **Store — cone-owned.** `/shared/loose-ends.json` is the single source of
-  truth. **Only the cone writes it.** It survives scoop restarts and session
-  reloads, so task truth never depends on the (disposable) UI scoop being alive.
-- **Sprinkle — scoop-owned.** One scoop named `loose-ends` owns the panel at
-  `/shared/sprinkles/loose-ends/loose-ends.shtml`. Per the SLICC sprinkle rule,
-  **the cone MUST NOT write the `.shtml` or run `sprinkle`** — it delegates every
-  panel operation (open, reload, `sprinkle send`) to that scoop via `feed_scoop`.
+- **Store — the source of truth.** `/shared/loose-ends.json` survives scoop
+  restarts and session reloads, so task truth never depends on the (disposable)
+  UI scoop being alive. **Mutate it through the `loose-ends` CLI**
+  (`create` / `done` / `snooze` / `unsnooze`), which does an atomic full rewrite
+  *and* best-effort syncs an open panel in one step. Prefer the CLI over
+  hand-editing the JSON (fewer footguns, keeps the panel in step).
+- **Sprinkle lifecycle — scoop-owned.** One scoop named `loose-ends` owns the
+  panel at `/shared/sprinkles/loose-ends/loose-ends.shtml`. Per the SLICC sprinkle
+  rule, **the cone MUST NOT author the `.shtml` or run the panel-lifecycle
+  commands** (`sprinkle refresh` / `open` / `reload` / `close`) — it delegates
+  those to that scoop via `feed_scoop`. (Lightweight `sprinkle send` messaging is
+  what the mutation CLI does internally and is fine from either process.)
 
 The scoop is a puppet: the store is what matters. If the scoop dies, recreate it
 and reseed from the store (see [Resurrecting](#resurrecting-in-a-new-session)).
+
+### CLI — the mutation & reporting API
+
+```bash
+loose-ends list                     # active + snoozed, human-readable
+loose-ends list --snoozed --json    # filter/format
+loose-ends create --title "Ping Marta re: Code Europe slot" \
+  --summary "Waiting on her reply to the abstract" \
+  --detail "Full brief: contacts, links, next steps…" \
+  --skills gmail,outlook [--id le-custom] [--snooze monday]
+loose-ends done   <id>              # remove
+loose-ends snooze <id> <tomorrow|monday|week|YYYY-MM-DD>   # hide until (09:00 local)
+loose-ends unsnooze <id>            # wake now
+```
+
+`create` upserts when `--id` matches an existing task. Every mutating command
+writes the store atomically (bumps `updated`) then best-effort `sprinkle send`s
+the matching panel message; a failed/absent send prints a note and is non-fatal
+(the panel self-hydrates on next open, or `loose-ends reseed` catches up).
+
 
 ### Store schema
 
@@ -47,6 +73,7 @@ and reseed from the store (see [Resurrecting](#resurrecting-in-a-new-session)).
       "detail": "Agent-facing: the full working brief — exact next actions, addresses, file paths, links, GUIDs. Collapsed behind an \"Agent brief\" toggle.",
       "created": "2026-07-30T17:15:00Z",
       "skills": ["sessionize", "gmail"],
+      "snoozedUntil": null,
       "session": {
         "id": "c20ed555-454d-4bc1-925c-2d11f7e2074d",
         "file": "2026-07-30T17-23-30-891Z-slicc-speaking-talks-and-loose-ends.md",
@@ -63,6 +90,7 @@ and reseed from the store (see [Resurrecting](#resurrecting-in-a-new-session)).
 - **`detail` — agent-facing.** The full brief the cone acts on: concrete steps, contacts, paths, links. Shown collapsed under an "Agent brief" toggle; can be long.
 - `created` — ISO timestamp (informational; rendered on the card).
 - `skills` — optional `string[]` of the SLICC skills involved (e.g. `["sessionize","gmail"]`). Rendered as tag chips on the card and passed through to the monday item.
+- `snoozedUntil` — optional ISO timestamp. When set to a **future** time the task is *snoozed*: the panel renders it, greyed and compact, in a collapsed "Snoozed (N)" section at the **bottom** of the list, and it is **excluded** from `loose-ends monday` output (it isn't "open now"). Absent, `null`, or a **past** timestamp = active (a passed snooze auto-resurfaces to the active list). See [Snooze](#snooze).
 - `session` — provenance into `/sessions/`: `{ id, file, at }` linking the task back to the conversation that spawned it (see [Session provenance](#session-provenance)). Optional.
 - Bump the top-level `updated` on every store write.
 
@@ -116,26 +144,35 @@ Options (all `--long` form): `--name <n>` (default `loose-ends`),
 `--store <path>` (default `/shared/loose-ends.json`),
 `--template <path>` (default the skill's `templates/loose-ends.shtml`).
 
-The helper only **reads** the store — it never writes tasks (that stays the
-cone's job). Run it from the owning scoop; it drives `sprinkle`.
+`bootstrap`/`reseed` drive `sprinkle` lifecycle — run them from the owning scoop.
+The mutation commands (`create`/`done`/`snooze`/`unsnooze`) and `list`/`monday`
+can run from either process (they write the store atomically and only *message*
+the panel).
 
 ## Adding, updating, and removing tasks
 
-The cone owns the store, so it does two things per change: **write the JSON**
-(direct file edit) **and** tell the scoop to update the panel.
+**Prefer the CLI** — one atomic command writes the store *and* syncs the panel:
 
-**Add / update a task (upsert by `id`):**
-1. Cone appends/replaces the task in `/shared/loose-ends.json` and bumps `updated`.
-2. Cone → scoop:
-   ```
-   feed_scoop("loose-ends", "sprinkle send loose-ends '{\"action\":\"add-item\",\"task\":{\"id\":\"le-foo\",\"title\":\"...\",\"summary\":\"human what & why\",\"detail\":\"agent brief: steps, contacts, paths, links\",\"created\":\"2026-07-30T00:00:00Z\",\"session\":{\"id\":\"...\",\"file\":\"...md\",\"at\":\"...\"}}}'")
-   ```
-   `add-item` upserts: an existing `id` is replaced in place; a new `id` is
-   appended.
+```bash
+loose-ends create --title "…" --summary "human what & why" \
+  --detail "agent brief: steps, contacts, paths, links" --skills gmail,outlook
+loose-ends done   le-foo          # remove
+loose-ends snooze le-foo monday   # hide until (tomorrow|monday|week|YYYY-MM-DD)
+loose-ends unsnooze le-foo        # wake now
+```
 
-**Remove a task:**
-1. Cone deletes it from the store and bumps `updated`.
-2. Cone → scoop: `sprinkle send loose-ends '{"action":"remove-item","id":"le-foo"}'`.
+`create` upserts by `--id` (auto-generated `le-<slug>` when omitted) and accepts
+`--snooze <when>`, `--session-file`/`--session-id`/`--session-at`.
+
+<details><summary>Manual flow (fallback / advanced)</summary>
+
+If you must edit the JSON by hand, do both halves yourself: write
+`/shared/loose-ends.json` (bump `updated`) **and** message the panel via the scoop:
+
+- Add/update (upsert by `id`):
+  `feed_scoop("loose-ends", "sprinkle send loose-ends '{\"action\":\"add-item\",\"task\":{\"id\":\"le-foo\", … }}'")`
+- Remove: `sprinkle send loose-ends '{"action":"remove-item","id":"le-foo"}'`
+</details>
 
 > ### ⚠️ Always confirm before tying up a loose end
 > **The cone must NOT unilaterally remove or "mark done" a loose end** — even
@@ -166,7 +203,15 @@ The panel fires these licks back to the cone as `[Sprinkle Event: loose-ends]`:
 | `do`   | `{ id, title, summary, detail }` | User clicks **Do** | Start working the task now, using `detail` as the agent brief (`summary` gives the human framing). The row stays in the list (a "Do" is not a completion). **When the work is finished, do NOT auto-remove it — report the result and ask the user whether to tie it up** (they may have more to add). See "Always confirm before tying up a loose end". |
 | `done` | `{ id, title }` | User clicks **Done** | The panel already removed the row optimistically. Remove that `id` from `/shared/loose-ends.json` and bump `updated`. No panel round-trip needed. |
 | `open-session` | `{ id, file, at }` | User clicks the **"from &lt;date&gt;"** provenance link | Open the originating transcript at `/sessions/<file>` (e.g. `read_file`) and surface it to the user — the conversation this loose end came from. |
+| `snooze` | `{ id, title, until }` | User picks a snooze preset (Tomorrow / Next Monday / Next week / Pick a date) | The panel already moved the row to the snoozed section optimistically. Set that task's `snoozedUntil = until` (ISO) in `/shared/loose-ends.json` and bump `updated`. No panel round-trip needed. |
+| `unsnooze` | `{ id, title }` | User clicks **Wake now** on a snoozed row | The panel already moved the row back to active optimistically. Clear (delete or `null`) that task's `snoozedUntil` in the store and bump `updated`. |
 | `request-load` | `{}` | Panel `init` when it could **not** reach the store itself (neither `slicc.readFile` nor `slicc.exec` worked in the sandbox) | Reseed the panel from the store: `sprinkle send loose-ends '{"action":"load-items","tasks":[ ...store tasks... ]}'` (delegate to the scoop). This is the safety net behind self-hydration. |
+
+> **`snooze`/`unsnooze` are optimistic in the panel** (like `done`): the row moves
+> the instant the user acts, then the lick fires. The cone's only job is to make
+> the store match (`snoozedUntil` set/cleared + bump `updated`). No `add-item`
+> round-trip needed. A snooze whose time has passed auto-resurfaces in the panel,
+> so a stale future `snoozedUntil` is harmless.
 
 > **`done` is optimistic in the panel.** The row disappears the instant the user
 > clicks, then the lick fires. The cone's only job is to make the store match by
@@ -180,6 +225,26 @@ The panel fires these licks back to the cone as `[Sprinkle Event: loose-ends]`:
 | `load-items` | `{ tasks:[...] }` | Replace the entire list (full reseed). |
 | `add-item` | `{ task:{id,title,context,created} }` | Upsert one task by `id` (replace if present, else append). |
 | `remove-item` | `{ id }` | Remove one task by `id`. |
+
+`load-items` / `add-item` task objects may carry `snoozedUntil` — the panel honors
+it in rendering (no separate inbound action needed).
+
+## Snooze
+
+Each active row has a **Snooze** control (next to Do/Done) offering presets —
+**Tomorrow**, **Next Monday**, **Next week**, and **Pick a date…** — each resolving
+to 09:00 local on the target day. Picking one optimistically moves the row into a
+collapsed **"Snoozed (N)"** section at the bottom (greyed, compact, with a **Wake
+now** button) and fires a `snooze` lick; the cone persists `snoozedUntil` to the
+store. **Wake now** fires `unsnooze` and returns the row to the active list.
+
+- The top-bar count badge counts **active** rows only; snoozed rows are not counted.
+- A snoozed task auto-resurfaces (moves back to active) once `snoozedUntil` passes —
+  the panel re-checks on a timer, so no reopen is needed.
+- Snoozed tasks are **excluded** from `loose-ends monday` (they aren't open *now*).
+- The cone can also snooze a task directly (e.g. "mute this until Monday") by
+  writing a future `snoozedUntil` into the store and re-sending it via `add-item`
+  (upsert) or a full `load-items`.
 
 ## Resurrecting in a new session
 

--- a/skills/loose-ends/scripts/loose-ends.jsh
+++ b/skills/loose-ends/scripts/loose-ends.jsh
@@ -76,11 +76,15 @@ function readStore(storePath) {
   return data;
 }
 
-// Persist the store. fs.writeFileSync fully replaces the file content (unlike a
-// shell `>` redirect, which can leave a stale tail), so this is a clean rewrite.
+// Persist the store atomically: write a sibling temp file, then rename it over
+// the target. rename(2) is atomic on the same filesystem, so a crash mid-write
+// can never leave the authoritative store truncated or half-written — readers
+// always see either the old or the complete new content.
 function writeStore(storePath, store) {
   store.updated = new Date().toISOString();
-  fs.writeFileSync(storePath, JSON.stringify(store, null, 2) + '\n');
+  const tmp = storePath + '.tmp-' + process.pid + '-' + Date.now();
+  fs.writeFileSync(tmp, JSON.stringify(store, null, 2) + '\n');
+  fs.renameSync(tmp, storePath);
   return store;
 }
 
@@ -133,8 +137,11 @@ function parseWhen(when) {
 // open panel in step is a nicety, so a failed/absent `sprinkle send` is not fatal.
 async function trySend(name, payload) {
   try {
-    await exec(`sprinkle send ${shellQuote(name)} ${shellQuote(JSON.stringify(payload))}`);
-    return true;
+    // `exec` resolves with a nonzero exitCode (it does not throw) when the panel
+    // is absent/unavailable, so inspect the code — otherwise we'd always report
+    // "synced" and suppress the documented "panel not synced" warning.
+    const r = await exec(`sprinkle send ${shellQuote(name)} ${shellQuote(JSON.stringify(payload))}`);
+    return !!r && r.exitCode === 0;
   } catch (e) { return false; }
 }
 
@@ -197,7 +204,11 @@ async function main() {
     if (existing !== -1) store.tasks[existing] = { ...store.tasks[existing], ...task };
     else store.tasks.push(task);
     writeStore(storePath, store);
-    const synced = await trySend(name, { action: 'add-item', task });
+    // Send the STORED object (post-merge) so an upsert that omits optional
+    // fields doesn't push an unmerged task to the panel — otherwise add-item
+    // would replace the panel's copy and drop retained session/snoozedUntil.
+    const sent = existing !== -1 ? store.tasks[existing] : task;
+    const synced = await trySend(name, { action: 'add-item', task: sent });
     process.stdout.write(`loose-ends: ${existing !== -1 ? 'updated' : 'created'} '${id}'${synced ? '' : ' (panel not synced — reseed or reopen)'}\n`);
     return;
   }

--- a/skills/loose-ends/scripts/loose-ends.jsh
+++ b/skills/loose-ends/scripts/loose-ends.jsh
@@ -1,15 +1,23 @@
 // ─────────────────────────────────────────────────────────────────────────
-//  loose-ends — sprinkle-side bootstrap / reseed helper
+//  loose-ends — store + sprinkle management for the loose-ends panel
 //
-//  Run this from the OWNING SCOOP (the scoop named after the sprinkle). It is
-//  the one process allowed to touch `sprinkle`. The store JSON is authoritative
-//  and cone-owned; this helper only READS it — it never writes tasks.
+//  The store JSON (default /shared/loose-ends.json) is authoritative. This
+//  command is the single mutation API for it: create/done/snooze/unsnooze do an
+//  atomic full rewrite (fs.writeFileSync, no stale-tail risk) AND best-effort
+//  sync an open panel via `sprinkle send` (a failed/absent send is non-fatal —
+//  the panel self-hydrates from the store on next open, or `reseed` catches up).
+//  Prefer these commands over hand-editing the JSON.
 //
 //  Commands:
 //    loose-ends bootstrap   Copy the template into the sprinkle dir, refresh the
 //                           VFS, open the panel, then reseed it from the store.
-//    loose-ends reseed      Re-send `load-items` from the store to an
-//                           already-open panel (no template copy / open).
+//    loose-ends reseed      Re-send `load-items` from the store to an open panel.
+//    loose-ends list        List loose ends (active + snoozed); --snoozed / --json.
+//    loose-ends create      Add (or upsert by --id) a loose end. --title required.
+//    loose-ends done <id>   Remove a loose end by id.
+//    loose-ends snooze <id> <when>   Hide until: tomorrow|monday|week|YYYY-MM-DD (09:00 local).
+//    loose-ends unsnooze <id>        Wake a snoozed loose end now.
+//    loose-ends monday      Emit the monday-source JSON (snoozed items excluded).
 //
 //  Options (all optional, --long form only — single-dash flags are ignored):
 //    --name <n>       sprinkle + scoop name           (default: loose-ends)
@@ -68,6 +76,75 @@ function readStore(storePath) {
   return data;
 }
 
+// Persist the store. fs.writeFileSync fully replaces the file content (unlike a
+// shell `>` redirect, which can leave a stale tail), so this is a clean rewrite.
+function writeStore(storePath, store) {
+  store.updated = new Date().toISOString();
+  fs.writeFileSync(storePath, JSON.stringify(store, null, 2) + '\n');
+  return store;
+}
+
+function slugify(s) {
+  return String(s || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40) || 'item';
+}
+
+// Generate a unique `le-<slug>` id not already present in the store.
+function genId(title, tasks) {
+  const base = 'le-' + slugify(title);
+  let id = base, n = 2;
+  const has = (x) => tasks.some((t) => t.id === x);
+  while (has(id)) { id = base + '-' + n; n++; }
+  return id;
+}
+
+// Resolve a snooze "when" token to an ISO timestamp at 09:00 LOCAL.
+//   tomorrow | monday (next Monday, strictly future) | week/1w (+7d) | YYYY-MM-DD
+//   or any string Date can parse (used verbatim).
+function parseWhen(when) {
+  const w = String(when || '').trim().toLowerCase();
+  const at9 = (d) => { d.setHours(9, 0, 0, 0); return d.toISOString(); };
+  const now = new Date();
+  if (w === 'tomorrow' || w === 'tom') {
+    const d = new Date(now); d.setDate(d.getDate() + 1); return at9(d);
+  }
+  if (w === 'monday' || w === 'mon') {
+    const d = new Date(now);
+    let diff = (1 - d.getDay() + 7) % 7; // 0=Sun..6=Sat; Monday=1
+    if (diff === 0) diff = 7;            // strictly future
+    d.setDate(d.getDate() + diff); return at9(d);
+  }
+  if (w === 'week' || w === '1w' || w === 'nextweek' || w === 'next-week') {
+    const d = new Date(now); d.setDate(d.getDate() + 7); return at9(d);
+  }
+  if (/^\d{4}-\d{2}-\d{2}$/.test(w)) {
+    const [y, m, dd] = w.split('-').map(Number);
+    return at9(new Date(y, m - 1, dd));
+  }
+  const parsed = new Date(when);
+  if (!isNaN(parsed.getTime())) return parsed.toISOString();
+  throw new Error(`unrecognized snooze time: "${when}" (use: tomorrow | monday | week | YYYY-MM-DD)`);
+}
+
+// Best-effort panel sync — the store write is the source of truth; keeping an
+// open panel in step is a nicety, so a failed/absent `sprinkle send` is not fatal.
+async function trySend(name, payload) {
+  try {
+    await exec(`sprinkle send ${shellQuote(name)} ${shellQuote(JSON.stringify(payload))}`);
+    return true;
+  } catch (e) { return false; }
+}
+
+function isSnoozed(t, now) {
+  if (!t || !t.snoozedUntil) return false;
+  const ts = new Date(t.snoozedUntil).getTime();
+  return !isNaN(ts) && ts > (now == null ? Date.now() : now);
+}
+
+
 async function reseed(name, storePath) {
   const store = readStore(storePath);
   const payload = JSON.stringify({ action: 'load-items', tasks: store.tasks });
@@ -91,6 +168,109 @@ async function main() {
     process.stdout.write(`loose-ends: reseeded '${name}' with ${n} task(s) from ${storePath}\n`);
     return;
   }
+
+  if (cmd === 'create' || cmd === 'add') {
+    const title = typeof args.title === 'string' ? args.title
+      : (args._[1] && !String(args._[1]).startsWith('-') ? args._.slice(1).join(' ') : null);
+    if (!title) throw new Error('create: --title <text> is required (or pass the title as positional args)');
+    const store = readStore(storePath);
+    const id = typeof args.id === 'string' ? args.id : genId(title, store.tasks);
+    const skills = typeof args.skills === 'string'
+      ? args.skills.split(',').map((s) => s.trim()).filter(Boolean) : [];
+    const task = {
+      id,
+      title,
+      summary: typeof args.summary === 'string' ? args.summary : '',
+      detail: typeof args.detail === 'string' ? args.detail : '',
+      created: new Date().toISOString(),
+      skills,
+    };
+    if (typeof args.snooze === 'string') task.snoozedUntil = parseWhen(args.snooze);
+    if (typeof args['session-file'] === 'string' || typeof args['session-id'] === 'string') {
+      task.session = {
+        id: typeof args['session-id'] === 'string' ? args['session-id'] : '',
+        file: typeof args['session-file'] === 'string' ? args['session-file'] : '',
+        at: typeof args['session-at'] === 'string' ? args['session-at'] : new Date().toISOString(),
+      };
+    }
+    const existing = store.tasks.findIndex((t) => t.id === id);
+    if (existing !== -1) store.tasks[existing] = { ...store.tasks[existing], ...task };
+    else store.tasks.push(task);
+    writeStore(storePath, store);
+    const synced = await trySend(name, { action: 'add-item', task });
+    process.stdout.write(`loose-ends: ${existing !== -1 ? 'updated' : 'created'} '${id}'${synced ? '' : ' (panel not synced — reseed or reopen)'}\n`);
+    return;
+  }
+
+  if (cmd === 'done' || cmd === 'remove' || cmd === 'rm') {
+    const id = args._[1];
+    if (!id) throw new Error(`${cmd}: an id is required (e.g. loose-ends done le-foo) — see 'loose-ends list'`);
+    const store = readStore(storePath);
+    const before = store.tasks.length;
+    store.tasks = store.tasks.filter((t) => t.id !== id);
+    if (store.tasks.length === before) throw new Error(`no loose end with id '${id}' (see 'loose-ends list')`);
+    writeStore(storePath, store);
+    const synced = await trySend(name, { action: 'remove-item', id });
+    process.stdout.write(`loose-ends: removed '${id}'${synced ? '' : ' (panel not synced — reseed or reopen)'}\n`);
+    return;
+  }
+
+  if (cmd === 'snooze') {
+    const id = args._[1];
+    const when = typeof args.until === 'string' ? args.until : args._[2];
+    if (!id || !when) throw new Error('snooze: usage: loose-ends snooze <id> <tomorrow|monday|week|YYYY-MM-DD>');
+    const until = parseWhen(when);
+    const store = readStore(storePath);
+    const task = store.tasks.find((t) => t.id === id);
+    if (!task) throw new Error(`no loose end with id '${id}' (see 'loose-ends list')`);
+    task.snoozedUntil = until;
+    writeStore(storePath, store);
+    const synced = await trySend(name, { action: 'add-item', task });
+    process.stdout.write(`loose-ends: snoozed '${id}' until ${until}${synced ? '' : ' (panel not synced — reseed or reopen)'}\n`);
+    return;
+  }
+
+  if (cmd === 'unsnooze' || cmd === 'wake') {
+    const id = args._[1];
+    if (!id) throw new Error(`${cmd}: an id is required (e.g. loose-ends unsnooze le-foo)`);
+    const store = readStore(storePath);
+    const task = store.tasks.find((t) => t.id === id);
+    if (!task) throw new Error(`no loose end with id '${id}' (see 'loose-ends list')`);
+    delete task.snoozedUntil;
+    writeStore(storePath, store);
+    const synced = await trySend(name, { action: 'add-item', task });
+    process.stdout.write(`loose-ends: woke '${id}'${synced ? '' : ' (panel not synced — reseed or reopen)'}\n`);
+    return;
+  }
+
+  if (cmd === 'list' || cmd === 'ls') {
+    const store = readStore(storePath);
+    const now = Date.now();
+    const showSnoozed = args.snoozed === true || args.all === true;
+    let rows = store.tasks;
+    if (args.snoozed === true) rows = rows.filter((t) => isSnoozed(t, now));
+    if (args.json === true) {
+      process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
+      return;
+    }
+    if (!rows.length) { process.stdout.write('loose-ends: no loose ends.\n'); return; }
+    const active = rows.filter((t) => !isSnoozed(t, now));
+    const snoozed = rows.filter((t) => isSnoozed(t, now));
+    const line = (t) => {
+      const skills = (t.skills && t.skills.length) ? `  [${t.skills.join(', ')}]` : '';
+      const snz = isSnoozed(t, now) ? `  (snoozed until ${new Date(t.snoozedUntil).toLocaleString()})` : '';
+      return `  ${t.id}\n    ${t.title || ''}${skills}${snz}\n`;
+    };
+    let out = '';
+    active.forEach((t) => { out += line(t); });
+    if (snoozed.length) {
+      out += `  — snoozed (${snoozed.length}) —\n`;
+      snoozed.forEach((t) => { out += line(t); });
+    }
+    process.stdout.write(`loose-ends (${active.length} active${snoozed.length ? `, ${snoozed.length} snoozed` : ''}):\n` + out);
+    return;
+  }
+
 
   if (cmd === 'bootstrap') {
     if (!fs.existsSync(template)) {
@@ -130,12 +310,17 @@ async function main() {
     // (an old open loose end is still open); --limit is honoured.
     const limit = Number(args.limit != null ? args.limit : 50) || 50;
     const store = readStore(storePath);
+    // A snoozed loose end (snoozedUntil in the future) is intentionally out of
+    // view until it wakes, so it is NOT surfaced to the monday dispatcher.
+    // A snooze whose time has already passed auto-resurfaces (treated as active).
+    const now = Date.now();
+    const openTasks = store.tasks.filter((t) => !isSnoozed(t, now));
     const RATING_HINT =
       'This is a user-curated loose end — a follow-up the user explicitly saved to act on later, ' +
       'so it carries real intent; treat it as actionable unless its summary says it is waiting on ' +
       'someone else. `body` is the human summary; `detail` is the full agent brief. `skills` lists ' +
       'the SLICC skills involved. There is no external state, so do not down-rank it as resolved.';
-    const items = store.tasks.slice(0, limit).map((t) => ({
+    const items = openTasks.slice(0, limit).map((t) => ({
       id: t.id,
       ts: t.created || (t.session && t.session.at) || null,
       source: 'loose-ends',
@@ -153,7 +338,15 @@ async function main() {
 
   process.stderr.write(
     `loose-ends: unknown command '${cmd}'\n` +
-    `usage: loose-ends [bootstrap|reseed|monday] [--name <n>] [--store <path>] [--template <path>] [--limit N]\n`
+    `usage:\n` +
+    `  loose-ends bootstrap [--name <n>] [--store <path>] [--template <path>]\n` +
+    `  loose-ends reseed    [--name <n>] [--store <path>]\n` +
+    `  loose-ends list      [--snoozed] [--json]\n` +
+    `  loose-ends create --title <t> [--summary <s>] [--detail <d>] [--skills a,b] [--id <id>] [--snooze <when>]\n` +
+    `  loose-ends done <id>\n` +
+    `  loose-ends snooze <id> <tomorrow|monday|week|YYYY-MM-DD>\n` +
+    `  loose-ends unsnooze <id>\n` +
+    `  loose-ends monday    [--limit N]\n`
   );
   process.exit(1);
 }

--- a/skills/loose-ends/templates/loose-ends.shtml
+++ b/skills/loose-ends/templates/loose-ends.shtml
@@ -592,8 +592,10 @@ function createSnoozeSubheader(count, collapsed) {
     '<span>Snoozed (' + count + ')</span>' +
     '<i data-lucide="chevron-down" class="sprinkle-icon sm chev"></i>';
   btn.addEventListener('click', () => {
-    const nowCollapsed = snoozeCollapsed !== null ? snoozeCollapsed : true;
-    snoozeCollapsed = !nowCollapsed;
+    // Toggle from the state ACTUALLY rendered (the `collapsed` arg), not from a
+    // null-defaults-to-collapsed guess — otherwise, when everything is snoozed
+    // (auto-expanded), the first click wrongly re-expands and appears to no-op.
+    snoozeCollapsed = !collapsed;
     renderAll();
   });
   return btn;
@@ -850,21 +852,20 @@ slicc.on('update', (msg) => {
       if (existing !== -1) tasks[existing] = msg.task;
       else tasks.push(msg.task);
       saveState();
-      const scroll = document.getElementById('list-scroll');
-      // If it already had a card (upsert), re-render fully; else append.
-      if (existing !== -1) {
-        renderAll();
-      } else {
-        scroll.appendChild(createTaskCard(msg.task));
-        updateCount();
-        updateEmptyState();
-        renderIcons();
-      }
+      // Full partition-aware render so a new/updated task lands in the correct
+      // section (active vs snoozed) with the right controls, and the snoozed
+      // subheader count stays accurate — an incremental append can't do that.
+      renderAll();
     }
   }
 
   else if (msg.action === 'remove-item') {
-    if (msg.id) removeTaskById(msg.id, false);
+    if (msg.id) {
+      removeTaskById(msg.id, false);
+      // Rebuild so the snoozed subheader count/visibility reflects the removal
+      // (removeTaskById only touches the active badge + empty state).
+      renderAll();
+    }
   }
 });
 
@@ -880,12 +881,22 @@ function renderIcons() {
 document.addEventListener('click', () => closeAllSnoozeMenus());
 document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeAllSnoozeMenus(); });
 
-// ── Auto-resurface: every 60s, if any snoozed task's snoozedUntil has passed,
-//    re-render so it returns to the active list without needing a reopen.
+// ── Auto-resurface: every 60s, wake any snooze whose time has passed so it
+//    returns to the active list without needing a reopen. We CLEAR the expired
+//    `snoozedUntil` (rather than just re-rendering) so the task doesn't keep
+//    matching "due" on every subsequent tick — otherwise the panel would rebuild
+//    every minute forever, closing any open brief/menu and disrupting the user.
 setInterval(function () {
   try {
-    const anyDue = tasks.some(t => t.snoozedUntil && new Date(t.snoozedUntil).getTime() <= Date.now());
-    if (anyDue) renderAll();
+    const now = Date.now();
+    let changed = false;
+    tasks.forEach(t => {
+      if (t.snoozedUntil && new Date(t.snoozedUntil).getTime() <= now) {
+        delete t.snoozedUntil;
+        changed = true;
+      }
+    });
+    if (changed) { saveState(); renderAll(); }
   } catch (e) { /* keep the timer cheap + resilient */ }
 }, 60000);
 

--- a/skills/loose-ends/templates/loose-ends.shtml
+++ b/skills/loose-ends/templates/loose-ends.shtml
@@ -263,6 +263,106 @@
       align-items: center;
       margin-top: 11px;
     }
+
+    /* ── Snooze section subheader (flat disclosure — hairline, no box) ── */
+    .snooze-subhead {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 10px 14px;
+      border-bottom: 1px solid var(--line);
+      border-top: 1px solid var(--line);
+      cursor: pointer;
+      user-select: none;
+      color: var(--fg-muted);
+      font-size: 11px;
+      font-weight: 600;
+      background: none;
+      width: 100%;
+      text-align: left;
+      font-family: inherit;
+    }
+    .snooze-subhead:hover { background: color-mix(in srgb, var(--fg) 3.5%, transparent); }
+    .snooze-subhead > .sprinkle-icon { color: var(--fg-faint); }
+    .snooze-subhead .chev { transition: transform 0.15s ease; margin-left: auto; }
+    .snooze-subhead.collapsed .chev { transform: rotate(-90deg); }
+
+    /* ── Compact greyed snoozed row ── */
+    .task-item.snoozed { opacity: 0.65; }
+    .task-item.snoozed .task-title { font-size: 12.5px; margin-bottom: 2px; }
+    .snoozed-until {
+      font-size: 11px;
+      color: var(--fg-faint);
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      line-height: 1;
+    }
+    .snoozed-meta {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      margin-top: 6px;
+    }
+    .snoozed-meta .sprinkle-icon { width: 11px; height: 11px; }
+
+    /* ── Snooze menu (popover — flat, dark-mode safe) ── */
+    .snooze-menu-wrap { position: relative; display: inline-flex; }
+    .snooze-menu {
+      position: absolute;
+      z-index: 50;
+      bottom: calc(100% + 6px);
+      left: 0;
+      min-width: 176px;
+      background: var(--s2-bg-elevated, var(--s2-bg-base));
+      border: 1px solid var(--line);
+      border-radius: var(--s2-radius-l, 10px);
+      box-shadow: var(--s2-shadow-elevated, 0 6px 20px rgba(0,0,0,0.28));
+      padding: 4px;
+      display: none;
+      flex-direction: column;
+      gap: 1px;
+    }
+    .snooze-menu.open { display: flex; }
+    .snooze-menu-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 7px 10px;
+      border-radius: var(--s2-radius-default, 8px);
+      background: none;
+      border: none;
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 12px;
+      color: var(--fg);
+      text-align: left;
+      width: 100%;
+      line-height: 1.3;
+    }
+    .snooze-menu-item:hover { background: color-mix(in srgb, var(--fg) 8%, transparent); }
+    .snooze-menu-item .sprinkle-icon { color: var(--fg-muted); }
+    .snooze-menu-item .sub { color: var(--fg-faint); font-size: 10.5px; margin-left: auto; }
+    .snooze-menu-date {
+      display: none;
+      padding: 6px 8px 4px;
+      border-top: 1px solid var(--line);
+      margin-top: 2px;
+    }
+    .snooze-menu-date.open { display: block; }
+    .snooze-menu-date input[type="date"] {
+      width: 100%;
+      background: var(--s2-bg-base);
+      border: 1px solid var(--line);
+      border-radius: var(--s2-radius-default, 8px);
+      color: var(--fg);
+      font-family: inherit;
+      font-size: 12px;
+      padding: 5px 8px;
+      outline: none;
+    }
+    .snooze-menu-date input[type="date"]:focus { border-color: var(--s2-accent); }
   </style>
 </head>
 <body>
@@ -312,6 +412,64 @@ function fmtDate(iso) {
     if (isNaN(d.getTime())) return '';
     return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
   } catch (e) { return ''; }
+}
+
+// Format a snooze target: "Jul 30, 2026" or "Jul 30, 2026, 2:30 PM" when the
+// time isn't the canonical 09:00 wake hour (so custom times stay visible).
+function fmtSnoozeUntil(iso) {
+  if (!iso) return '';
+  try {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return '';
+    const dateStr = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    if (d.getHours() === 9 && d.getMinutes() === 0) return dateStr;
+    const timeStr = d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+    return dateStr + ', ' + timeStr;
+  } catch (e) { return ''; }
+}
+
+// ── Snooze predicates + time math ──────────────────────────────────
+// A task is snoozed iff snoozedUntil is set AND still in the future.
+// A passed snoozedUntil auto-resurfaces (treated as active).
+function isSnoozed(task) {
+  if (!task || !task.snoozedUntil) return false;
+  const t = new Date(task.snoozedUntil).getTime();
+  return !isNaN(t) && t > Date.now();
+}
+
+// Build an ISO timestamp for a date offset by `days`, at 09:00 local.
+function atNineAM(date) {
+  const d = new Date(date);
+  d.setHours(9, 0, 0, 0);
+  return d.toISOString();
+}
+function snoozeTomorrow() {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  return atNineAM(d);
+}
+function snoozeNextWeek() {
+  const d = new Date();
+  d.setDate(d.getDate() + 7);
+  return atNineAM(d);
+}
+// Next Monday strictly in the future (if today is Monday → +7 days).
+function snoozeNextMonday() {
+  const d = new Date();
+  const day = d.getDay(); // 0=Sun … 1=Mon
+  let add = (1 - day + 7) % 7; // days until next Monday (0 if today is Monday)
+  if (add === 0) add = 7;      // strictly in the future
+  d.setDate(d.getDate() + add);
+  return atNineAM(d);
+}
+// A local YYYY-MM-DD (from <input type=date>) at 09:00 local.
+function snoozeFromDateInput(value) {
+  if (!value) return null;
+  const parts = value.split('-');
+  if (parts.length !== 3) return null;
+  const d = new Date(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2]), 9, 0, 0, 0);
+  if (isNaN(d.getTime())) return null;
+  return d.toISOString();
 }
 
 // ═══════════════════════════════════════════════════
@@ -381,25 +539,90 @@ function saveState() {
 // ═══════════════════════════════════════════════════
 //  RENDER
 // ═══════════════════════════════════════════════════
+// Disclosure state for the snoozed section. Default: collapsed when there are
+// active items (keep the active list front-and-center), expanded when the only
+// items are snoozed. Recomputed lazily in renderAll unless the user toggled it.
+let snoozeCollapsed = null; // null = auto; true/false = user-pinned
+
 function updateCount() {
+  // Badge counts ACTIVE tasks only (snoozed items are parked).
   const badge = document.getElementById('count-badge');
-  const n = tasks.length;
+  const n = tasks.filter(t => !isSnoozed(t)).length;
   badge.textContent = n;
   badge.className = 'badge' + (n === 0 ? ' zero' : '');
 }
 
 function updateEmptyState() {
+  // Empty only when there are zero tasks total (active AND snoozed).
   const empty = document.getElementById('empty-state');
   empty.style.display = tasks.length === 0 ? 'flex' : 'none';
 }
 
 function renderAll() {
   const scroll = document.getElementById('list-scroll');
-  [...scroll.querySelectorAll('.task-item')].forEach(el => el.remove());
-  tasks.forEach(t => scroll.appendChild(createTaskCard(t)));
+  [...scroll.querySelectorAll('.task-item, .snooze-subhead')].forEach(el => el.remove());
+  closeAllSnoozeMenus();
+
+  const active = tasks.filter(t => !isSnoozed(t));
+  const snoozed = tasks.filter(t => isSnoozed(t));
+
+  // Active rows first, in existing order.
+  active.forEach(t => scroll.appendChild(createTaskCard(t)));
+
+  // Snoozed section: subheader disclosure + compact greyed rows, last.
+  if (snoozed.length) {
+    const collapsed = snoozeCollapsed !== null ? snoozeCollapsed : (active.length > 0);
+    scroll.appendChild(createSnoozeSubheader(snoozed.length, collapsed));
+    if (!collapsed) {
+      snoozed.forEach(t => scroll.appendChild(createSnoozedRow(t)));
+    }
+  }
+
   updateCount();
   updateEmptyState();
   renderIcons();
+}
+
+// The muted disclosure row between active and snoozed sections.
+function createSnoozeSubheader(count, collapsed) {
+  const btn = document.createElement('button');
+  btn.className = 'snooze-subhead' + (collapsed ? ' collapsed' : '');
+  btn.innerHTML =
+    '<i data-lucide="alarm-clock-off" class="sprinkle-icon sm"></i>' +
+    '<span>Snoozed (' + count + ')</span>' +
+    '<i data-lucide="chevron-down" class="sprinkle-icon sm chev"></i>';
+  btn.addEventListener('click', () => {
+    const nowCollapsed = snoozeCollapsed !== null ? snoozeCollapsed : true;
+    snoozeCollapsed = !nowCollapsed;
+    renderAll();
+  });
+  return btn;
+}
+
+// Compact, greyed, minimal snoozed row: title + "Snoozed until …" + Wake now.
+function createSnoozedRow(task) {
+  const div = document.createElement('div');
+  div.className = 'task-item snoozed';
+  div.dataset.id = task.id;
+
+  const until = fmtSnoozeUntil(task.snoozedUntil);
+  div.innerHTML =
+    '<div class="task-title">' + escHtml(task.title || task.id || '') + '</div>' +
+    '<div class="snoozed-meta">' +
+      '<span class="snoozed-until">' +
+        '<i data-lucide="clock" class="sprinkle-icon sm"></i>Snoozed until ' + escHtml(until) +
+      '</span>' +
+      '<button class="sprinkle-btn sprinkle-btn--ghost wake-btn">' +
+        '<i data-lucide="alarm-clock" class="sprinkle-icon sm"></i> Wake now' +
+      '</button>' +
+    '</div>';
+
+  const wakeBtn = div.querySelector('.wake-btn');
+  wakeBtn.addEventListener('click', () => {
+    wakeBtn.disabled = true;
+    unsnoozeTask(task.id);
+  });
+  return div;
 }
 
 function createTaskCard(task) {
@@ -479,6 +702,26 @@ function createTaskCard(task) {
       '<button class="sprinkle-btn sprinkle-btn--ghost done-btn">' +
         '<i data-lucide="check" class="sprinkle-icon sm"></i> Done' +
       '</button>' +
+      '<div class="snooze-menu-wrap">' +
+        '<button class="sprinkle-btn sprinkle-btn--ghost snooze-btn" title="Snooze this loose end">' +
+          '<i data-lucide="alarm-clock" class="sprinkle-icon sm"></i> Snooze' +
+        '</button>' +
+        '<div class="snooze-menu">' +
+          '<button class="snooze-menu-item" data-preset="tomorrow">' +
+            '<i data-lucide="sun" class="sprinkle-icon sm"></i>Tomorrow' +
+          '</button>' +
+          '<button class="snooze-menu-item" data-preset="monday">' +
+            '<i data-lucide="calendar" class="sprinkle-icon sm"></i>Next Monday' +
+          '</button>' +
+          '<button class="snooze-menu-item" data-preset="week">' +
+            '<i data-lucide="calendar-days" class="sprinkle-icon sm"></i>Next week' +
+          '</button>' +
+          '<button class="snooze-menu-item" data-preset="pick">' +
+            '<i data-lucide="calendar-clock" class="sprinkle-icon sm"></i>Pick a date…' +
+          '</button>' +
+          '<div class="snooze-menu-date"><input type="date" /></div>' +
+        '</div>' +
+      '</div>' +
     '</div>';
 
   // Done: OPTIMISTIC removal first, then emit the lick.
@@ -491,7 +734,80 @@ function createTaskCard(task) {
     slicc.lick({ action: 'done', data: { id: task.id, title: task.title } });
   });
 
+  // Snooze: open a preset menu; picking a preset snoozes optimistically + emits.
+  wireSnoozeMenu(div, task);
+
   return div;
+}
+
+// ── Snooze menu wiring ─────────────────────────────────────────────
+function closeAllSnoozeMenus() {
+  document.querySelectorAll('.snooze-menu.open').forEach(m => {
+    m.classList.remove('open');
+    const dateWrap = m.querySelector('.snooze-menu-date');
+    if (dateWrap) dateWrap.classList.remove('open');
+  });
+}
+
+function wireSnoozeMenu(row, task) {
+  const btn = row.querySelector('.snooze-btn');
+  const menu = row.querySelector('.snooze-menu');
+  const dateWrap = row.querySelector('.snooze-menu-date');
+  const dateInput = dateWrap ? dateWrap.querySelector('input[type="date"]') : null;
+  if (!btn || !menu) return;
+
+  btn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    const isOpen = menu.classList.contains('open');
+    closeAllSnoozeMenus();
+    if (!isOpen) menu.classList.add('open');
+  });
+
+  // Keep clicks inside the menu from bubbling to the document (outside-click close).
+  menu.addEventListener('click', (e) => e.stopPropagation());
+
+  menu.querySelectorAll('.snooze-menu-item').forEach(item => {
+    item.addEventListener('click', () => {
+      const preset = item.dataset.preset;
+      if (preset === 'pick') {
+        if (dateWrap) dateWrap.classList.add('open');
+        if (dateInput) setTimeout(() => dateInput.focus(), 30);
+        return;
+      }
+      let until = null;
+      if (preset === 'tomorrow') until = snoozeTomorrow();
+      else if (preset === 'monday') until = snoozeNextMonday();
+      else if (preset === 'week') until = snoozeNextWeek();
+      if (until) applySnooze(task.id, task.title, until);
+    });
+  });
+
+  if (dateInput) {
+    dateInput.addEventListener('change', () => {
+      const until = snoozeFromDateInput(dateInput.value);
+      if (until) applySnooze(task.id, task.title, until);
+    });
+  }
+}
+
+// Optimistically snooze a task locally, re-render, then notify the cone.
+function applySnooze(id, title, untilIso) {
+  closeAllSnoozeMenus();
+  const t = tasks.find(x => x.id === id);
+  if (t) t.snoozedUntil = untilIso;
+  saveState();
+  renderAll();
+  slicc.lick({ action: 'snooze', data: { id, title, until: untilIso } });
+}
+
+// Optimistically wake a snoozed task locally, re-render, then notify the cone.
+function unsnoozeTask(id) {
+  const t = tasks.find(x => x.id === id);
+  const title = t ? t.title : '';
+  if (t) delete t.snoozedUntil;
+  saveState();
+  renderAll();
+  slicc.lick({ action: 'unsnooze', data: { id, title } });
 }
 
 // Remove a task from the model + DOM (with a small leave animation).
@@ -559,6 +875,19 @@ function renderIcons() {
   if (typeof LucideIcons !== 'undefined' && LucideIcons.render) LucideIcons.render();
   if (window.LucideIcons) window.LucideIcons.render();
 }
+
+// ── Close snooze menus on outside-click / Escape ──
+document.addEventListener('click', () => closeAllSnoozeMenus());
+document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeAllSnoozeMenus(); });
+
+// ── Auto-resurface: every 60s, if any snoozed task's snoozedUntil has passed,
+//    re-render so it returns to the active list without needing a reopen.
+setInterval(function () {
+  try {
+    const anyDue = tasks.some(t => t.snoozedUntil && new Date(t.snoozedUntil).getTime() <= Date.now());
+    if (anyDue) renderAll();
+  } catch (e) { /* keep the timer cheap + resilient */ }
+}, 60000);
 
 // ═══════════════════════════════════════════════════
 //  INIT


### PR DESCRIPTION
## Add **snooze** to the loose-ends panel + CLI

A to-do list without snooze is half a to-do list. This adds the ability to hide a loose end until a wake time, so items you can't act on yet (waiting on someone, blocked until a date) stop nagging and auto-resurface when they're relevant again.

### Panel (`templates/loose-ends.shtml`)
- New per-row **Snooze** button with a preset menu: **Tomorrow**, **Next Monday**, **Next week**, **Pick a date…** — all resolving to **09:00 local**.
- Snoozed rows render **greyed and compact** in a collapsible **"Snoozed (N)"** section at the **bottom** of the list, with a **Wake now** button (no Do/Done/tags/brief).
- Top-bar count badge now counts **active** rows only.
- **60s auto-resurface** timer: a snooze whose time has passed moves back to the active list without a reopen.
- Optimistic UX: the row moves instantly, then a lick fires. Init/hydration and existing `do`/`done`/`open-session`/`load-items`/`add-item`/`remove-item` behavior are untouched.

### CLI (`scripts/loose-ends.jsh`)
The helper is now the store **mutation API** (was read-only). Each mutator does an atomic full rewrite (`fs.writeFileSync`, bumps `updated`) plus a **best-effort `sprinkle send`** (non-fatal; the panel self-hydrates on next open):
- `loose-ends create --title … [--summary --detail --skills a,b --id --snooze <when>]` (upsert by id, auto `le-<slug>`)
- `loose-ends done <id>`
- `loose-ends list [--snoozed] [--json]`
- `loose-ends snooze <id> <tomorrow|monday|week|YYYY-MM-DD>` / `loose-ends unsnooze <id>`
- `monday` now **excludes** currently-snoozed items (they aren't open *now*).

### Schema / licks (`SKILL.md`)
- New optional task field **`snoozedUntil`** (ISO). Future = snoozed; absent/null/past = active (auto-resurfaces).
- New panel→cone licks (optimistic): `{action:"snooze",data:{id,title,until}}` and `{action:"unsnooze",data:{id,title}}` — the cone persists `snoozedUntil` and bumps `updated`.
- Docs updated: schema, lick tables, a Snooze section, CLI reference, and the architecture section (mutation-API model; `sprinkle` *lifecycle* stays scoop-owned).

### Testing
- CLI verified end-to-end (create/list/snooze/unsnooze/done + monday snooze-exclusion; "next Monday" math; atomic writes).
- Sprinkle verified standalone in **dark and light** themes (menu, ordering, active-only badge) and **live** (`refresh`/`close`/`open`/`send`/`reseed`, no CLI hang); lick shapes confirmed to match the cone-side handlers.

Sliccy 🍦
