### PR TITLE
feat(tiktok): transcript, filmstrip, and see for agent video understanding

### DIFF
--- a/skills/tiktok/SKILL.md
+++ b/skills/tiktok/SKILL.md
@@ -3,13 +3,17 @@ name: tiktok
 description: Interact with TikTok via its web API and messages page — search TikTok
   (videos, users, mixed feed), read video stats (plays, likes, comments, shares,
   saves), list a creator's videos, read comments, check notifications and the
-  activity feed, and read/send direct messages. Use when the user wants to
-  automate TikTok, look up a TikTok video's stats or view count, search TikTok,
-  check TikTok notifications or DMs, read or send a TikTok message, or pull
-  TikTok data without clicking through www.tiktok.com. Activate on mentions of
-  "TikTok", "TikTok stats", "TikTok video", "TikTok search", "TikTok
-  notifications", "TikTok messages", "TikTok DM", "views/likes on a TikTok", or
-  related TikTok workflows.
+  activity feed, read/send direct messages, and see a video (extract auto-caption
+  transcripts + filmstrip contact sheets so an agent can see/hear what a TikTok
+  is about without a human). Use when the user wants to automate TikTok, look up
+  a TikTok video's stats or view count, search TikTok, check TikTok notifications
+  or DMs, read or send a TikTok message, pull a TikTok transcript/captions,
+  generate a filmstrip of frames, "watch" a TikTok, or pull TikTok data without
+  clicking through www.tiktok.com. Activate on mentions of "TikTok", "TikTok
+  stats", "TikTok video", "TikTok search", "TikTok notifications", "TikTok
+  messages", "TikTok DM", "views/likes on a TikTok", "TikTok transcript",
+  "TikTok captions", "TikTok filmstrip", "watch this TikTok", or related TikTok
+  workflows.
 allowed-tools: bash
 ---
 
@@ -84,6 +88,12 @@ tiktok studio user                                 # Studio creator profile info
 
 # Aggregation
 tiktok monday [--limit=N] [--date=Nd]            # unified inbox JSON (notifications + unread DMs)
+
+# See a video (transcript + filmstrip — for agents)
+tiktok transcript <videoId|url> [--lang=eng-US] [--out=path] [--json] [--raw]
+tiktok filmstrip  <videoId|url> [--frames=8] [--width=160] [--out=path] [--json]
+tiktok see      <videoId|url> [--frames=8] [--lang=eng-US] [--dir=path] [--json]
+
 
 # Escape hatch — call ANY TikTok endpoint (like `gh api`)
 tiktok api <path> [--method=GET] [--query k=v ...] [--data '<json>'] [--bare] [--raw] [--include]
@@ -166,6 +176,62 @@ tiktok read-messages "Olanski"
 tiktok send-message "Olanski" "thanks for the video!"
 ```
 
+
+## Seeing a video (transcript + filmstrip)
+
+The combo command is `tiktok see` — **not** `watch`. In SLICC, `watch` means a
+long-lived webhook/lick monitor (`gh pr watch`, `slack watch`). This is a one-shot
+content capture.
+
+An agent can't literally play a TikTok. `see` / `transcript` / `filmstrip`
+give it the next-best thing: the auto-caption track (what was said / narrated)
+plus a contact sheet of frames (what it looked like).
+
+```bash
+# One-shot: open the video, dump captions + filmstrip into a dir
+tiktok see 7667617105923083542 --json
+tiktok see 'https://www.tiktok.com/@uci_cycling/video/7667617105923083542' --frames=12
+
+# Just the timed transcript (WebVTT → plain text)
+tiktok transcript 7667617105923083542
+tiktok transcript 7667617105923083542 --json            # {cues:[{start,end,text},...]}
+tiktok transcript 7667617105923083542 --raw             # original WebVTT
+tiktok transcript 7667617105923083542 --out=/tmp/t.txt
+
+# Just a filmstrip JPEG of N frames across the duration
+tiktok filmstrip 7667617105923083542 --frames=8 --out=/tmp/strip.jpg
+tiktok filmstrip 7667617105923083542 --frames=12 --width=200 --json
+```
+
+### How it works
+
+- **Transcript** reads `video.subtitleInfos` / `claInfo.captionInfos` from the
+  item (via `/api/item/detail/` or the open video page's rehydration data),
+  then downloads the WebVTT from the CDN **inside the logged-in tab** so cookies
+  and referer are correct. Not every video has captions — exit code 2 means none.
+- **Filmstrip** navigates to the video page, finds the `<video>` element, seeks
+  to N evenly-spaced timestamps, and `canvas.drawImage`s each frame into a
+  horizontal JPEG contact sheet with timestamps. Seeks are synchronous
+  (`video.currentTime = t` + shell sleep) — top-level `await` on `seeked`
+  hangs on TikTok tabs, so don't "improve" it that way.
+- **see** does both, writes `captions.vtt`, `transcript.txt`,
+  `filmstrip.jpg`, and `summary.json` under `--dir` (default
+  `/workspace/skills/tiktok/.tmp/see-<id>/`), and with `--json` prints one
+  agent-friendly payload including full `cues`.
+
+### Flags
+
+| flag | commands | default | notes |
+|------|----------|---------|-------|
+| `--lang` | transcript, see | eng-US preference | substring match on language code |
+| `--out` | transcript, filmstrip | stdout / `.tmp/filmstrip-<id>.jpg` | path; `transcript` infers format from extension (`.vtt`/`.json`/`.txt`) |
+| `--dir` | see | `.tmp/see-<id>/` | output directory |
+| `--frames` / `--n` | filmstrip, see | 8 | 1–24 |
+| `--width` / `--w` | filmstrip, see | 160 | thumb width px (64–480) |
+| `--seek-wait` | filmstrip | 700 | ms to wait after each seek for the frame to decode |
+| `--json` | all three | off | machine-readable |
+| `--raw` | transcript | off | original WebVTT on stdout |
+
 ## Notes for the assistant
 
 - **Pagination:** most list commands print a `cursor` / `max_time`; pass it back
@@ -179,3 +245,13 @@ tiktok send-message "Olanski" "thanks for the video!"
   the foreground (it issues real keyboard events). Reading only captures what's
   currently rendered (roughly the last ~40 bubbles).
 - Do not read `appId` from the page — the web API id is hard-coded to `1988`.
+- **Filmstrip seeks must be sync.** `video.currentTime = t` + shell sleep +
+  canvas capture. Top-level `await` on the `seeked` event hangs on TikTok
+  tabs; `eval-file` of an async canvas export can return `{}`. Don't "fix".
+- **Not every video has captions.** `transcript`/`see` exit 2 when
+  `subtitleInfos`/`captionInfos` are empty. Sports/music/text-on-screen
+  clips often still have ASR commentary captions; pure-music clips often don't.
+- `see`/`filmstrip` need a real navigable video page (they call
+  `playwright-cli goto`). Prefer passing a full `@user/video/<id>` URL when
+  you have one so the first navigation hits.
+

--- a/skills/tiktok/references/endpoints.md
+++ b/skills/tiktok/references/endpoints.md
@@ -129,3 +129,23 @@ REST endpoint for conversation history or sending. The skill uses the rendered
 - **Composer**: `[contenteditable="true"]` / `textarea`; type + Enter to send.
 - `/api/im/item_detail/?itemId=<id>` is only used by the UI to hydrate previews
   of *shared videos* inside a conversation — not the messages themselves.
+
+## Captions / seeing a video
+
+No dedicated caption API — captions hang off the item payload:
+
+| Source | Path to captions |
+|--------|------------------|
+| `GET /api/item/detail/?itemId=` | `itemInfo.itemStruct.video.subtitleInfos[]` and `.claInfo.captionInfos[]` |
+| Open video page rehydration | `__UNIVERSAL_DATA_FOR_REHYDRATION__` → `webapp.video-detail.itemInfo.itemStruct.video.*` (same shape) |
+
+Each caption entry (field names vary camel/snake):
+
+- `Url` / `url` / `urlList[]` — CDN WebVTT (signed, expiring)
+- `LanguageCodeName` / `language` — e.g. `eng-US`
+- `Format` / `captionFormat` — `webvtt`
+- `Source` — `ASR` for auto-generated
+- `Version` / `variant` — e.g. `1:big_caption`
+
+Filmstrip does not use an API; it seeks the in-page `<video>` element and
+captures frames via canvas (see `references/notes.md`).

--- a/skills/tiktok/references/notes.md
+++ b/skills/tiktok/references/notes.md
@@ -73,3 +73,69 @@ events need it).
 `language`, and `wid` (used as `device_id`). `httpOnly` session cookies aren't in
 `document.cookie` — but same-origin `fetch(..., {credentials:'include'})` from the
 page sends them automatically.
+
+## Seeing videos (transcript + filmstrip)
+
+The combo command is `tiktok see` (not `watch`). In SLICC, `watch` means a
+long-lived webhook/lick monitor (`gh pr watch`, `slack watch`); this is a
+one-shot content capture.
+
+Added Aug 2026 after live-validating against a 104s UCI track-cycling clip
+(`7667617105923083542`).
+
+### Captions live on the item, not a separate API
+
+`itemStruct.video.subtitleInfos[]` (and the richer
+`itemStruct.video.claInfo.captionInfos[]`) list available caption tracks.
+Each entry has a CDN `Url` / `urlList[]` pointing at a WebVTT file, plus
+`LanguageCodeName` (e.g. `eng-US`), `Format: webvtt`, `Source: ASR` for
+auto-generated. Fetch the VTT **from inside the logged-in tab**
+(`fetch(url, {credentials:'include'})`) — bare Node fetch sometimes works for
+caption CDNs but fails for video CDNs; keep one path.
+
+`/api/item/detail/?itemId=` returns the same subtitleInfos. When the API is
+soft-throttled (empty 200), fall back to reading
+`__UNIVERSAL_DATA_FOR_REHYDRATION__` → `webapp.video-detail.itemInfo.itemStruct`
+from an open video page. Return a **slim** item (drop playAddr url_lists etc.)
+— the full blob is multi-MB and can break the eval bridge.
+
+### Filmstrip: sync seek only
+
+This does NOT work on TikTok tabs (hangs until timeout):
+
+```js
+v.currentTime = t;
+await new Promise(r => v.addEventListener('seeked', r, { once: true }));
+```
+
+This does (proven ~50ms per eval):
+
+```js
+// eval 1 (sync)
+v.muted = true; v.pause(); v.currentTime = t;
+// shell: sleep ~700ms for the frame to decode
+// eval 2 (sync)
+ctx.drawImage(v, ...);
+```
+
+Build the strip on `window.__ttStrip` (a page-global canvas) across N seek/draw
+cycles, then `canvas.toDataURL('image/jpeg', 0.85)` once at the end. A single
+async eval-file that does all N seeks and returns the data URL came back as
+`{}` — keep steps small and sync.
+
+Canvas is not tainted when the `<video>` uses `crossOrigin="use-credentials"`
+on the same TikTok origin session — `toDataURL` succeeds.
+
+### Video page navigation
+
+`playwright-cli goto https://www.tiktok.com/@<user>/video/<id> --tab=<id>` is
+reliable. Without the author handle, `/@/video/<id>` usually redirects. Prefer
+resolving `author.uniqueId` from item/detail first. After goto, invalidate the
+cached tab (URL changed) and poll until `video.readyState >= 1`.
+
+### SLICC convert/ffmpeg limits
+
+The in-browser SLICC `convert` is NOT full ImageMagick (`+append` / `-gravity`
+unsupported). `ffmpeg` needs `ipk add @ffmpeg/core@0.12.10` before it can
+hstack. The skill therefore stitches the filmstrip with page-context canvas —
+zero native deps.

--- a/skills/tiktok/scripts/tiktok.jsh
+++ b/skills/tiktok/scripts/tiktok.jsh
@@ -772,6 +772,697 @@ async function cmdMonday(positional, flags) {
 }
 
 // ---------------------------------------------------------------------------
+// Video seeing: transcript (captions) + filmstrip (frame contact sheet)
+// (verb is `see`, not `watch` — `watch` is reserved for webhook/lick monitors
+// like `gh pr watch` / `slack watch`.)
+// ---------------------------------------------------------------------------
+//
+// An agent "sees" a TikTok by combining:
+//   1. Auto-captions (WebVTT from video.subtitleInfos / claInfo.captionInfos)
+//   2. A filmstrip of N frames grabbed from the in-page <video> via canvas
+//
+// Gotchas (learned the hard way, Aug 2026):
+//   - playwright-cli `eval` top-level await (and eval-file async returning large
+//     canvas payloads) can hang or come back as `{}` on TikTok tabs. Filmstrip
+//     capture uses ONLY sync evals: set video.currentTime, sleep in the shell,
+//     then canvas.drawImage + toDataURL.
+//   - Caption VTT URLs are CDN-signed; fetch them from page context with
+//     credentials so cookies/referer stay correct.
+//   - Filmstrip needs the video open in a tab; transcript can use item/detail
+//     when subtitleInfos are present, else falls back to the video page.
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** Accept a bare numeric id, a @user/video/<id> URL, or a /video/<id> URL. */
+function parseVideoRef(raw) {
+  const s = String(raw || '').trim();
+  if (!s) return null;
+  let m = s.match(/\/video\/(\d{5,})/);
+  if (m) {
+    const author = (s.match(/@([A-Za-z0-9._]+)/) || [])[1] || null;
+    return { id: m[1], author };
+  }
+  m = s.match(/(\d{5,})/);
+  if (m) return { id: m[1], author: null };
+  return null;
+}
+
+function fmtTs(sec) {
+  sec = Math.max(0, Number(sec) || 0);
+  const h = Math.floor(sec / 3600);
+  const m = Math.floor((sec % 3600) / 60);
+  const s = Math.floor(sec % 60);
+  const ms = Math.round((sec - Math.floor(sec)) * 1000);
+  const pad = (n, w) => String(n).padStart(w || 2, '0');
+  if (h > 0) return pad(h) + ':' + pad(m) + ':' + pad(s) + '.' + pad(ms, 3);
+  return pad(m) + ':' + pad(s) + '.' + pad(ms, 3);
+}
+
+function parseWebVtt(vtt) {
+  const lines = String(vtt || '').replace(/^\uFEFF/, '').split(/\r?\n/);
+  const cues = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.includes('-->')) continue;
+    const parts = line.split('-->');
+    if (parts.length < 2) continue;
+    const startRaw = parts[0].trim().split(/\s+/)[0];
+    const endRaw = parts[1].trim().split(/\s+/)[0];
+    const toSec = (t) => {
+      t = String(t).replace(',', '.');
+      const p = t.split(':').map(Number);
+      if (p.length === 3) return p[0] * 3600 + p[1] * 60 + p[2];
+      if (p.length === 2) return p[0] * 60 + p[1];
+      return Number(t) || 0;
+    };
+    const text = [];
+    i++;
+    while (i < lines.length && lines[i].trim() !== '') {
+      if (!/^\d+$/.test(lines[i].trim())) text.push(lines[i].trim());
+      i++;
+    }
+    const joined = text.join(' ').replace(/<[^>]+>/g, '').trim();
+    if (!joined) continue;
+    cues.push({ start: toSec(startRaw), end: toSec(endRaw), text: joined });
+  }
+  return cues;
+}
+
+/**
+ * Run a JS expression in the TikTok tab via playwright-cli eval-file.
+ * Expression should be a sync IIFE that returns a string or JSON-serializable
+ * value. Avoid top-level await — it hangs on some TikTok tabs (Aug 2026).
+ */
+async function pwEval(tab, expression) {
+  if (typeof fs.mkdirSync === 'function') {
+    try { fs.mkdirSync(TMP_DIR, { recursive: true }); } catch (e) {}
+  }
+  const exprFile = TMP_DIR + '/eval-expr.js';
+  const outFile = TMP_DIR + '/eval-out.txt';
+  fs.writeFileSync(exprFile, expression);
+  const { stderr } = await exec(
+    'playwright-cli eval-file ' + exprFile + ' --tab=' + tab.targetId + ' --output=' + outFile
+  );
+  let out = '';
+  try { out = fs.readFileSync(outFile, 'utf8'); } catch (e) {}
+  if (!out) {
+    const err = (stderr || '').trim();
+    throw new Error('empty eval result' + (err ? ': ' + err : ''));
+  }
+  if (out.endsWith('\n')) out = out.slice(0, -1);
+  // Unwrap a single JSON-encoded string layer when present.
+  if (out.charAt(0) === '"' && out.charAt(out.length - 1) === '"') {
+    try { out = JSON.parse(out); } catch (e) {}
+  }
+  return out;
+}
+
+/** Like pwEval but for async page expressions (e.g. fetch). Returns parsed JSON if possible. */
+async function pwEvalAsync(tab, asyncIifeSource) {
+  if (typeof fs.mkdirSync === 'function') {
+    try { fs.mkdirSync(TMP_DIR, { recursive: true }); } catch (e) {}
+  }
+  const exprFile = TMP_DIR + '/eval-async.js';
+  const outFile = TMP_DIR + '/eval-async-out.txt';
+  fs.writeFileSync(exprFile, asyncIifeSource);
+  const { stderr } = await exec(
+    'playwright-cli eval-file ' + exprFile + ' --tab=' + tab.targetId + ' --output=' + outFile
+  );
+  let out = '';
+  try { out = fs.readFileSync(outFile, 'utf8'); } catch (e) {}
+  if (!out) {
+    const err = (stderr || '').trim();
+    throw new Error('empty async eval result' + (err ? ': ' + err : ''));
+  }
+  if (out.endsWith('\n')) out = out.slice(0, -1);
+  if (out.charAt(0) === '"' && out.charAt(out.length - 1) === '"') {
+    try { out = JSON.parse(out); } catch (e) {}
+  }
+  try { return JSON.parse(out); } catch (e) { return out; }
+}
+
+function extractCaptionsFromItem(item) {
+  const video = (item && item.video) || {};
+  const list = [];
+  const seen = new Set();
+  const push = (c) => {
+    if (!c) return;
+    const url = c.Url || c.url
+      || (c.urlList && c.urlList[0])
+      || (c.url_list && c.url_list[0]);
+    if (!url || seen.has(url)) return;
+    seen.add(url);
+    list.push({
+      url: url,
+      language: c.LanguageCodeName || c.language || c.languageCode || '',
+      format: c.Format || c.captionFormat || c.format || 'webvtt',
+      source: c.Source || (c.isAutoGen ? 'ASR' : '') || '',
+      isAuto: !!(c.isAutoGen || c.Source === 'ASR' || c.source === 'ASR'),
+      variant: c.Version || c.variant || '',
+      urlList: c.urlList || c.url_list || [url],
+    });
+  };
+  const subs = video.subtitleInfos || video.subtitle_infos || [];
+  for (let i = 0; i < subs.length; i++) push(subs[i]);
+  const cla = video.claInfo || video.cla_info || (item && item.claInfo) || null;
+  if (cla && cla.captionInfos) {
+    for (let i = 0; i < cla.captionInfos.length; i++) push(cla.captionInfos[i]);
+  }
+  return list;
+}
+
+async function fetchItemStruct(id) {
+  // Soft-fail variant of apiGet: on throttle / error return null so callers can
+  // fall back to the open video page instead of killing the process.
+  try {
+    const { status, bodyText, data } = await signedRequest({
+      url: '/api/item/detail/',
+      query: { itemId: id },
+    });
+    if (!bodyText || !data) return null;
+    if (data.status_code && data.status_code !== 0 && !data.itemInfo) return null;
+    return (data.itemInfo && data.itemInfo.itemStruct) || null;
+  } catch (e) {
+    return null;
+  }
+}
+
+async function ensureVideoTab(id, author) {
+  let tab = await findTab();
+  const cur = tab.url || '';
+  if (cur.indexOf('/video/' + id) !== -1) return tab;
+
+  let uniqueId = author || null;
+  if (!uniqueId) {
+    try {
+      const it = await fetchItemStruct(id);
+      if (it && it.author) {
+        uniqueId = it.author.uniqueId || it.author.unique_id || null;
+      }
+      ensureVideoTab._lastItem = it || null;
+    } catch (e) {
+      // throttle / API failure — continue with /@/video/id
+    }
+  }
+  const url = uniqueId
+    ? 'https://www.tiktok.com/@' + uniqueId + '/video/' + id
+    : 'https://www.tiktok.com/@/video/' + id;
+
+  try {
+    await exec('playwright-cli goto ' + url + ' --tab=' + tab.targetId);
+  } catch (e) {
+    await exec('playwright-cli open ' + url);
+  }
+  // URL changed — drop cache and re-find.
+  _tab = null;
+  tab = await findTab();
+
+  for (let i = 0; i < 15; i++) {
+    try {
+      const raw = await pwEval(tab, "(() => {\n"
+        + "  const v = [...document.querySelectorAll('video')].find(x => x.duration > 1 && x.videoWidth > 0);\n"
+        + "  return JSON.stringify({\n"
+        + "    ready: !!(v && v.readyState >= 1),\n"
+        + "    duration: v ? v.duration : 0,\n"
+        + "    w: v ? v.videoWidth : 0,\n"
+        + "    h: v ? v.videoHeight : 0,\n"
+        + "    href: location.href\n"
+        + "  });\n"
+        + "})()");
+      const st = JSON.parse(raw);
+      if (st.ready) return tab;
+      if (st.href && st.href.indexOf('/video/' + id) !== -1 && i > 5 && st.duration > 0) return tab;
+    } catch (e) {}
+    await sleep(400);
+  }
+  return tab;
+}
+
+async function readItemFromPage(tab) {
+  const raw = await pwEval(tab, "(() => {\n"
+    + "  try {\n"
+    + "    const el = document.getElementById('__UNIVERSAL_DATA_FOR_REHYDRATION__');\n"
+    + "    if (!el) return JSON.stringify({ error: 'no-universal-data' });\n"
+    + "    const scope = JSON.parse(el.textContent).__DEFAULT_SCOPE__ || {};\n"
+    + "    let item = null;\n"
+    + "    const keys = Object.keys(scope);\n"
+    + "    for (let i = 0; i < keys.length; i++) {\n"
+    + "      const v = scope[keys[i]];\n"
+    + "      if (v && v.itemInfo && v.itemInfo.itemStruct) { item = v.itemInfo.itemStruct; break; }\n"
+    + "      if (v && v.itemStruct) { item = v.itemStruct; break; }\n"
+    + "    }\n"
+    + "    if (!item) return JSON.stringify({ error: 'no-item', keys: keys });\n"
+    + "    const video = item.video || {};\n"
+    + "    const slim = {\n"
+    + "      id: item.id || item.aweme_id,\n"
+    + "      desc: item.desc || '',\n"
+    + "      createTime: item.createTime || item.create_time,\n"
+    + "      author: item.author ? {\n"
+    + "        uniqueId: item.author.uniqueId || item.author.unique_id,\n"
+    + "        nickname: item.author.nickname || item.author.nickName,\n"
+    + "        secUid: item.author.secUid || item.author.sec_uid\n"
+    + "      } : null,\n"
+    + "      stats: item.statsV2 || item.stats || {},\n"
+    + "      video: {\n"
+    + "        duration: video.duration,\n"
+    + "        width: video.width,\n"
+    + "        height: video.height,\n"
+    + "        ratio: video.ratio,\n"
+    + "        subtitleInfos: video.subtitleInfos || video.subtitle_infos || [],\n"
+    + "        claInfo: video.claInfo || video.cla_info || null\n"
+    + "      }\n"
+    + "    };\n"
+    + "    return JSON.stringify(slim);\n"
+    + "  } catch (e) {\n"
+    + "    return JSON.stringify({ error: String(e) });\n"
+    + "  }\n"
+    + "})()");
+  const data = JSON.parse(raw);
+  if (data.error) throw new Error('page item: ' + data.error);
+  return data;
+}
+
+async function fetchVttText(tab, urls) {
+  const list = Array.isArray(urls) ? urls : [urls];
+  const src = "(async () => {\n"
+    + "  const urls = " + JSON.stringify(list) + ";\n"
+    + "  let lastErr = '';\n"
+    + "  for (let i = 0; i < urls.length; i++) {\n"
+    + "    try {\n"
+    + "      const r = await fetch(urls[i], { credentials: 'include' });\n"
+    + "      const text = await r.text();\n"
+    + "      if (r.ok && text && /WEBVTT/i.test(text)) {\n"
+    + "        return JSON.stringify({ ok: true, status: r.status, text: text });\n"
+    + "      }\n"
+    + "      lastErr = 'HTTP ' + r.status + ' len=' + (text ? text.length : 0);\n"
+    + "    } catch (e) { lastErr = String(e); }\n"
+    + "  }\n"
+    + "  return JSON.stringify({ ok: false, error: lastErr || 'fetch failed' });\n"
+    + "})()";
+  let parsed = await pwEvalAsync(tab, src);
+  if (typeof parsed === 'string') {
+    try { parsed = JSON.parse(parsed); } catch (e) {}
+  }
+  if (!parsed || !parsed.ok) {
+    throw new Error('caption fetch failed: ' + ((parsed && parsed.error) || 'unknown'));
+  }
+  return parsed.text;
+}
+
+function pickCaption(captions, lang) {
+  if (!captions.length) return null;
+  if (lang) {
+    const want = String(lang).toLowerCase();
+    for (let i = 0; i < captions.length; i++) {
+      if ((captions[i].language || '').toLowerCase().indexOf(want) !== -1) return captions[i];
+    }
+  }
+  for (let i = 0; i < captions.length; i++) {
+    if (/eng/i.test(captions[i].language) && captions[i].isAuto) return captions[i];
+  }
+  for (let i = 0; i < captions.length; i++) {
+    if (/eng/i.test(captions[i].language)) return captions[i];
+  }
+  for (let i = 0; i < captions.length; i++) {
+    if (captions[i].isAuto) return captions[i];
+  }
+  return captions[0];
+}
+
+function authorOf(item) {
+  if (!item || !item.author) return null;
+  return item.author.uniqueId || item.author.unique_id || null;
+}
+
+async function cmdTranscript(args, flags) {
+  const ref = parseVideoRef(args[0]);
+  if (!ref) {
+    console.error('Usage: tiktok transcript <videoId|url> [--lang=eng-US] [--out=path] [--json] [--raw]');
+    process.exit(1);
+  }
+  const wantJson = !!flags.json;
+  const wantRaw = !!(flags.raw || flags.vtt);
+  const lang = flags.lang || flags.language || null;
+
+  let item = null;
+  let tab = null;
+  item = await fetchItemStruct(ref.id);
+  const apiFailed = !item;
+
+  let captions = item ? extractCaptionsFromItem(item) : [];
+
+  if (!captions.length) {
+    tab = await ensureVideoTab(ref.id, ref.author || authorOf(item));
+    const pageItem = await readItemFromPage(tab);
+    if (!item) item = pageItem;
+    captions = extractCaptionsFromItem(pageItem);
+    if (!item.video) item.video = pageItem.video;
+  }
+
+  if (!captions.length) {
+    console.error('No captions/subtitles available for video ' + ref.id
+      + '. (TikTok only ships auto-captions on some videos.)');
+    process.exit(2);
+  }
+
+  const cap = pickCaption(captions, lang);
+  if (!tab) tab = await findTab();
+
+  let vtt;
+  try {
+    const urls = (cap.urlList && cap.urlList.length) ? cap.urlList : [cap.url];
+    vtt = await fetchVttText(tab, urls);
+  } catch (e) {
+    console.error('Failed to download captions: ' + (e.message || e));
+    process.exit(1);
+  }
+
+  const cues = parseWebVtt(vtt);
+  const meta = {
+    id: String((item && item.id) || ref.id),
+    author: authorOf(item) || ref.author || null,
+    desc: ((item && item.desc) || '').replace(/\n/g, ' ').trim(),
+    duration: (item && item.video && item.video.duration) || null,
+    language: cap.language,
+    source: cap.source || (cap.isAuto ? 'ASR' : 'unknown'),
+    cueCount: cues.length,
+  };
+
+  if (flags.out) {
+    const outPath = String(flags.out);
+    if (wantRaw || /\.vtt$/i.test(outPath)) fs.writeFileSync(outPath, vtt);
+    else if (wantJson || /\.json$/i.test(outPath)) {
+      fs.writeFileSync(outPath, JSON.stringify(Object.assign({}, meta, { cues: cues }), null, 2));
+    } else {
+      const body = cues.map((c) => fmtTs(c.start) + '  ' + c.text).join('\n') + '\n';
+      fs.writeFileSync(outPath, body);
+    }
+    console.error('wrote ' + outPath);
+  }
+
+  if (wantRaw) {
+    process.stdout.write(vtt.endsWith('\n') ? vtt : vtt + '\n');
+    return;
+  }
+  if (wantJson) {
+    console.log(JSON.stringify(Object.assign({}, meta, { cues: cues }), null, 2));
+    return;
+  }
+
+  console.log('Transcript for ' + meta.id + (meta.author ? ' @' + meta.author : ''));
+  if (meta.desc) console.log('  ' + meta.desc.slice(0, 100));
+  console.log('  language: ' + (meta.language || '?')
+    + '  source: ' + meta.source
+    + '  cues: ' + meta.cueCount
+    + (meta.duration ? '  duration: ' + meta.duration + 's' : '')
+    + (apiFailed ? '  (via page)' : ''));
+  console.log('');
+  for (let i = 0; i < cues.length; i++) {
+    console.log(fmtTs(cues[i].start) + '  ' + cues[i].text);
+  }
+}
+
+async function cmdFilmstrip(args, flags) {
+  const ref = parseVideoRef(args[0]);
+  if (!ref) {
+    console.error('Usage: tiktok filmstrip <videoId|url> [--frames=8] [--width=160] [--out=path] [--seek-wait=700] [--json]');
+    process.exit(1);
+  }
+  const nFrames = Math.max(1, Math.min(24, parseInt(flags.frames || flags.n || '8', 10) || 8));
+  const thumbW = Math.max(64, Math.min(480, parseInt(flags.width || flags.w || '160', 10) || 160));
+  const seekWait = Math.max(200, Math.min(3000, parseInt(flags['seek-wait'] || '700', 10) || 700));
+  const outPath = String(flags.out || (TMP_DIR + '/filmstrip-' + ref.id + '.jpg'));
+  const wantJson = !!flags.json;
+
+  const tab = await ensureVideoTab(ref.id, ref.author);
+
+  let probe;
+  try {
+    probe = JSON.parse(await pwEval(tab, "(() => {\n"
+      + "  const v = [...document.querySelectorAll('video')].find(x => x.duration > 1 && x.videoWidth > 0)\n"
+      + "    || document.querySelector('video');\n"
+      + "  if (!v) return JSON.stringify({ error: 'no-video-element' });\n"
+      + "  return JSON.stringify({\n"
+      + "    duration: v.duration,\n"
+      + "    w: v.videoWidth,\n"
+      + "    h: v.videoHeight,\n"
+      + "    ready: v.readyState\n"
+      + "  });\n"
+      + "})()"));
+  } catch (e) {
+    console.error('Could not read <video> on the page: ' + (e.message || e));
+    process.exit(1);
+  }
+  if (probe.error) {
+    console.error('No playable <video> element found for ' + ref.id
+      + '. Open the video on www.tiktok.com and retry.');
+    process.exit(1);
+  }
+
+  const duration = Number(probe.duration) || 0;
+  if (!(duration > 0)) {
+    console.error('Video duration is 0/NaN — the player may still be loading. Retry in a moment.');
+    process.exit(1);
+  }
+  const thumbH = Math.round(thumbW * (probe.h || 16) / (probe.w || 9));
+
+  await pwEval(tab, "(() => {\n"
+    + "  const N = " + nFrames + ", tw = " + thumbW + ", th = " + thumbH + ";\n"
+    + "  const c = document.createElement('canvas');\n"
+    + "  c.width = tw * N; c.height = th;\n"
+    + "  window.__ttStrip = { c: c, ctx: c.getContext('2d'), tw: tw, th: th, N: N, times: [] };\n"
+    + "  return 'ok';\n"
+    + "})()");
+
+  const times = [];
+  for (let i = 0; i < nFrames; i++) {
+    const t = (duration * (i + 0.5)) / nFrames;
+    times.push(Math.round(t * 10) / 10);
+    const label = fmtTs(t).replace(/\.\d+$/, '');
+
+    await pwEval(tab, "(() => {\n"
+      + "  const v = [...document.querySelectorAll('video')].find(x => x.duration > 1)\n"
+      + "    || document.querySelector('video');\n"
+      + "  if (!v) return 'no-video';\n"
+      + "  v.muted = true;\n"
+      + "  try { v.pause(); } catch (e) {}\n"
+      + "  v.currentTime = " + t + ";\n"
+      + "  return 'seek:' + v.currentTime;\n"
+      + "})()");
+    await sleep(seekWait);
+
+    await pwEval(tab, "(() => {\n"
+      + "  const s = window.__ttStrip;\n"
+      + "  const v = [...document.querySelectorAll('video')].find(x => x.duration > 1)\n"
+      + "    || document.querySelector('video');\n"
+      + "  if (!s || !v) return 'missing';\n"
+      + "  const i = " + i + ";\n"
+      + "  s.ctx.drawImage(v, 0, 0, v.videoWidth, v.videoHeight, i * s.tw, 0, s.tw, s.th);\n"
+      + "  s.ctx.fillStyle = 'rgba(0,0,0,0.55)';\n"
+      + "  s.ctx.fillRect(i * s.tw, s.th - 22, s.tw, 22);\n"
+      + "  s.ctx.fillStyle = '#fff';\n"
+      + "  s.ctx.font = 'bold 14px sans-serif';\n"
+      + "  s.ctx.fillText(" + JSON.stringify(label) + ", i * s.tw + 8, s.th - 6);\n"
+      + "  s.times[i] = " + t + ";\n"
+      + "  return 'drew:' + i;\n"
+      + "})()");
+  }
+
+  const dataUrl = await pwEval(tab, "(() => {\n"
+    + "  const s = window.__ttStrip;\n"
+    + "  if (!s) return '';\n"
+    + "  return s.c.toDataURL('image/jpeg', 0.85);\n"
+    + "})()");
+
+  if (!dataUrl || String(dataUrl).indexOf('data:image') !== 0) {
+    console.error('Filmstrip export failed (empty or non-image data URL).'
+      + ' The canvas may be tainted or the player not ready.');
+    process.exit(1);
+  }
+  const b64 = String(dataUrl).replace(/^data:image\/\w+;base64,/, '');
+  const buf = Buffer.from(b64, 'base64');
+  try {
+    const slash = outPath.lastIndexOf('/');
+    if (slash > 0 && typeof fs.mkdirSync === 'function') {
+      fs.mkdirSync(outPath.slice(0, slash), { recursive: true });
+    }
+  } catch (e) {}
+  fs.writeFileSync(outPath, buf);
+
+  const result = {
+    id: ref.id,
+    out: outPath,
+    bytes: buf.length,
+    frames: nFrames,
+    width: thumbW * nFrames,
+    height: thumbH,
+    thumbWidth: thumbW,
+    thumbHeight: thumbH,
+    duration: duration,
+    times: times,
+    videoWidth: probe.w,
+    videoHeight: probe.h,
+  };
+
+  if (wantJson) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log('Filmstrip ' + ref.id);
+    console.log('  frames:   ' + nFrames + ' @ ' + thumbW + 'x' + thumbH
+      + '  (sheet ' + result.width + 'x' + result.height + ')');
+    console.log('  duration: ' + duration.toFixed(1) + 's');
+    console.log('  times:    ' + times.join(', '));
+    console.log('  out:      ' + outPath + '  (' + buf.length + ' bytes)');
+  }
+  return result;
+}
+
+async function cmdSee(args, flags) {
+  const ref = parseVideoRef(args[0]);
+  if (!ref) {
+    console.error('Usage: tiktok see <videoId|url> [--frames=8] [--width=160] [--lang=eng-US] [--dir=path] [--json]');
+    console.error('  Opens the video, extracts transcript + filmstrip so an agent can "see" it.');
+    process.exit(1);
+  }
+  const dir = String(flags.dir || (TMP_DIR + '/see-' + ref.id));
+  if (typeof fs.mkdirSync === 'function') {
+    try { fs.mkdirSync(dir, { recursive: true }); } catch (e) {}
+  }
+
+  const tab = await ensureVideoTab(ref.id, ref.author);
+  let item = null;
+  try {
+    item = await readItemFromPage(tab);
+  } catch (e) {
+    try { item = await fetchItemStruct(ref.id); } catch (e2) {}
+  }
+
+  let transcript = null;
+  let transcriptError = null;
+  try {
+    const captions = item ? extractCaptionsFromItem(item) : [];
+    if (!captions.length) throw new Error('no captions on item');
+    const cap = pickCaption(captions, flags.lang || flags.language || null);
+    const urls = (cap.urlList && cap.urlList.length) ? cap.urlList : [cap.url];
+    const vtt = await fetchVttText(tab, urls);
+    const cues = parseWebVtt(vtt);
+    const vttPath = dir + '/captions.vtt';
+    const txtPath = dir + '/transcript.txt';
+    fs.writeFileSync(vttPath, vtt);
+    fs.writeFileSync(txtPath, cues.map((c) => fmtTs(c.start) + '  ' + c.text).join('\n') + '\n');
+    transcript = {
+      language: cap.language,
+      source: cap.source || (cap.isAuto ? 'ASR' : 'unknown'),
+      cueCount: cues.length,
+      vtt: vttPath,
+      text: txtPath,
+      cues: cues,
+    };
+  } catch (e) {
+    transcriptError = e && e.message ? e.message : String(e);
+  }
+
+  let filmstrip = null;
+  let filmstripError = null;
+  try {
+    const fsFlags = Object.assign({}, flags, { out: dir + '/filmstrip.jpg' });
+    const prevLog = console.log;
+    const prevErr = console.error;
+    if (flags.json) {
+      console.log = function () {};
+      console.error = function () {};
+    }
+    try {
+      filmstrip = await cmdFilmstrip([ref.id], fsFlags);
+    } finally {
+      console.log = prevLog;
+      console.error = prevErr;
+    }
+  } catch (e) {
+    filmstripError = e && e.message ? e.message : String(e);
+  }
+
+  const author = authorOf(item);
+  const summary = {
+    id: ref.id,
+    url: author
+      ? 'https://www.tiktok.com/@' + author + '/video/' + ref.id
+      : 'https://www.tiktok.com/@/video/' + ref.id,
+    author: author,
+    nickname: item && item.author ? (item.author.nickname || null) : null,
+    desc: item ? (item.desc || '').replace(/\n/g, ' ').trim() : null,
+    duration: (item && item.video && item.video.duration)
+      || (filmstrip && filmstrip.duration) || null,
+    stats: (item && item.stats) || null,
+    dir: dir,
+    transcript: transcript ? {
+      language: transcript.language,
+      source: transcript.source,
+      cueCount: transcript.cueCount,
+      vtt: transcript.vtt,
+      text: transcript.text,
+    } : null,
+    transcriptError: transcriptError,
+    filmstrip: filmstrip ? {
+      out: filmstrip.out,
+      frames: filmstrip.frames,
+      width: filmstrip.width,
+      height: filmstrip.height,
+      times: filmstrip.times,
+      bytes: filmstrip.bytes,
+    } : null,
+    filmstripError: filmstripError,
+    cues: transcript ? transcript.cues : null,
+  };
+
+  try {
+    fs.writeFileSync(dir + '/summary.json', JSON.stringify(summary, null, 2));
+  } catch (e) {}
+
+  if (flags.json) {
+    console.log(JSON.stringify(summary, null, 2));
+    return summary;
+  }
+
+  console.log('See ' + summary.id + (summary.author ? ' @' + summary.author : ''));
+  if (summary.desc) console.log('  ' + summary.desc.slice(0, 120));
+  if (summary.duration) console.log('  duration: ' + summary.duration + 's');
+  if (summary.stats) {
+    const s = summary.stats;
+    console.log('  ▶ ' + num(s.playCount)
+      + '  ❤ ' + num(s.diggCount)
+      + '  💬 ' + num(s.commentCount)
+      + '  ↪ ' + num(s.shareCount));
+  }
+  console.log('  dir: ' + dir);
+  console.log('');
+  if (transcript) {
+    console.log('Transcript (' + (transcript.language || '?')
+      + ', ' + transcript.source + ', ' + transcript.cueCount + ' cues):');
+    console.log('  ' + transcript.text);
+    console.log('');
+    for (let i = 0; i < transcript.cues.length; i++) {
+      console.log(fmtTs(transcript.cues[i].start) + '  ' + transcript.cues[i].text);
+    }
+    console.log('');
+  } else {
+    console.log('Transcript: unavailable (' + (transcriptError || 'unknown') + ')');
+    console.log('');
+  }
+  if (filmstrip) {
+    console.log('Filmstrip: ' + filmstrip.out);
+    console.log('  ' + filmstrip.frames + ' frames, '
+      + filmstrip.width + 'x' + filmstrip.height
+      + ', times: ' + filmstrip.times.join(', '));
+  } else {
+    console.log('Filmstrip: unavailable (' + (filmstripError || 'unknown') + ')');
+  }
+  return summary;
+}
+
+// ---------------------------------------------------------------------------
 // Dispatch
 // ---------------------------------------------------------------------------
 
@@ -795,6 +1486,11 @@ const commands = {
   api: cmdApi,
   studio: cmdStudio,
   monday: cmdMonday,
+  transcript: cmdTranscript,
+  captions: cmdTranscript,
+  filmstrip: cmdFilmstrip,
+  frames: cmdFilmstrip,
+  see: cmdSee,
 };
 
 function parseArgs(argv) {
@@ -849,7 +1545,19 @@ if (!cmd || cmd === 'help' || cmd === '--help') {
   console.log('Escape hatch (like `gh api`):');
   console.log('  api <path> [--method=GET] [--query k=v ...] [--data \'<json>\'] [--bare] [--raw] [--include]');
   console.log('                                                Call any TikTok endpoint from the signed page context\n');
+
+  console.log('See a video (transcript + filmstrip — one-shot, not a webhook watcher):');
+  console.log('  transcript <videoId|url> [--lang=eng-US] [--out=path] [--json] [--raw]');
+  console.log('                                                Pull auto-captions (WebVTT) as a timed transcript');
+  console.log('                                                Aliases: captions');
+  console.log('  filmstrip  <videoId|url> [--frames=8] [--width=160] [--out=path] [--seek-wait=700] [--json]');
+  console.log('                                                Contact sheet of N frames from the in-page player');
+  console.log('                                                Aliases: frames');
+  console.log('  see        <videoId|url> [--frames=8] [--width=160] [--lang=eng-US] [--dir=path] [--json]');
+  console.log('                                                Open video + transcript + filmstrip in one shot');
+  console.log('                                                (not a webhook watcher — use transcript/filmstrip/see, never "watch")\n');
   console.log('Tip: get a secUid for user-videos via `tiktok search <name> --type=user`.');
+  console.log('Tip: see/transcript/filmstrip accept a bare video id or a full @user/video/<id> URL.');
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary

Agents can't play TikToks. This gives them the next-best thing so they can **see** a video without a human:

- **`tiktok transcript <id|url>`** — auto-caption WebVTT to timed transcript (`--json` / `--raw` / `--out`)
- **`tiktok filmstrip <id|url>`** — N-frame JPEG contact sheet from the in-page `<video>` (`--frames` / `--width` / `--out`)
- **`tiktok see <id|url>`** — one-shot combo writing `captions.vtt` + `transcript.txt` + `filmstrip.jpg` + `summary.json` (full cues inline with `--json`)

**Naming:** the combo verb is `see`, **not** `watch`. In SLICC, `watch` means a long-lived webhook/lick monitor (`gh pr watch`, `slack watch`). This is a one-shot content capture.

## How

| Piece | Source |
|-------|--------|
| Captions | `itemStruct.video.subtitleInfos` / `claInfo.captionInfos` (API or page rehydration), then CDN WebVTT fetched in-page with credentials |
| Filmstrip | Navigate to video, sync `video.currentTime = t` + shell sleep + `canvas.drawImage`, horizontal JPEG with timestamps |
| Soft throttle | `fetchItemStruct` uses `signedRequest` (no hard exit) so page fallback works when `/api/item/detail` returns empty 200 |

### Gotcha baked in

Top-level `await` on the `seeked` event **hangs** on TikTok tabs. `eval-file` of an async canvas export returned `{}`. Filmstrip uses only sync evals. Documented in `references/notes.md` so nobody "fixes" it.

## Live-validated

Against UCI track cycling `7667617105923083542` (104s):

```
$ tiktok transcript 7667617105923083542
# 32 ASR cues, eng-US

$ tiktok filmstrip 7667617105923083542 --frames=4
# 640x284 JPEG contact sheet

$ tiktok see 7667617105923083542 --frames=4 --json
# { id, author, duration, cues[32], filmstrip, transcript, dir }  exit 0, ~5s

$ tiktok watch …
# Unknown command: watch   (intentionally not registered)
```

## Files

- `skills/tiktok/scripts/tiktok.jsh` — commands + helpers
- `skills/tiktok/SKILL.md` — see section, flags table, trigger keywords
- `skills/tiktok/references/notes.md` — seek/canvas/CDN gotchas + naming note
- `skills/tiktok/references/endpoints.md` — caption field map

## Test plan

- [x] `tiktok transcript <id>` prints timed cues, exit 0
- [x] `tiktok filmstrip <id> --frames=4` writes valid JPEG
- [x] `tiktok see <id> --frames=2 --json` returns full payload
- [x] `tiktok watch` is unknown (does not collide with webhook-watch convention)
- [x] API throttle falls back to page without process.exit
- [ ] Video with no captions exits 2 with clear message
- [ ] Full `@user/video/<id>` URL form accepted
